### PR TITLE
changed all HandheldMassScanner to HandheldMassScannerEE

### DIFF
--- a/Resources/Maps/Dungeon/mineshaft.yml
+++ b/Resources/Maps/Dungeon/mineshaft.yml
@@ -3142,7 +3142,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 37.5,20.5
       parent: 2
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 729
     components:

--- a/Resources/Maps/_Crescent/Shuttles/DSM/countsman.yml
+++ b/Resources/Maps/_Crescent/Shuttles/DSM/countsman.yml
@@ -20555,7 +20555,7 @@ entities:
     - type: Transform
       pos: 6.497226,-28.398174
       parent: 1
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 5080
     components:

--- a/Resources/Maps/_Crescent/Shuttles/DSM/nemesis.yml
+++ b/Resources/Maps/_Crescent/Shuttles/DSM/nemesis.yml
@@ -7503,7 +7503,7 @@ entities:
     - type: Transform
       pos: -4.4798203,-3.4345436
       parent: 1
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 869
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCSP/corvax.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/corvax.yml
@@ -1467,7 +1467,7 @@ entities:
       parent: 1
     - type: Thruster
       originalPowerLoad: 1500
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 163
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCWL/clementine.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCWL/clementine.yml
@@ -9665,7 +9665,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 2144
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCWL/sasha.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCWL/sasha.yml
@@ -4221,7 +4221,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 345
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCWL/zhipov.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCWL/zhipov.yml
@@ -7446,7 +7446,7 @@ entities:
     - type: Transform
       pos: 7.5135927,-33.4
       parent: 2
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 677
     components:

--- a/Resources/Maps/_Crescent/Stations/ardour.yml
+++ b/Resources/Maps/_Crescent/Stations/ardour.yml
@@ -15403,7 +15403,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 1173
     components:

--- a/Resources/Maps/_Crescent/Stations/clementine.yml
+++ b/Resources/Maps/_Crescent/Stations/clementine.yml
@@ -9371,7 +9371,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
-- proto: HandHeldMassScanner
+- proto: 
   entities:
   - uid: 2144
     components:

--- a/Resources/Maps/_Crescent/Stations/dochenskaya.yml
+++ b/Resources/Maps/_Crescent/Stations/dochenskaya.yml
@@ -4087,7 +4087,7 @@ entities:
     - type: Transform
       pos: -11.654456,5.6138062
       parent: 1
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 293
     components:

--- a/Resources/Maps/_Crescent/Stations/freeport.yml
+++ b/Resources/Maps/_Crescent/Stations/freeport.yml
@@ -27977,7 +27977,7 @@ entities:
     - type: Transform
       pos: -4.5182357,56.438828
       parent: 1
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 3672
     components:

--- a/Resources/Maps/_Crescent/Stations/refuge.yml
+++ b/Resources/Maps/_Crescent/Stations/refuge.yml
@@ -8268,7 +8268,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.179423,-7.3466
       parent: 1
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 1903
     components:

--- a/Resources/Maps/_NF/POI/cove.yml
+++ b/Resources/Maps/_NF/POI/cove.yml
@@ -20634,7 +20634,7 @@ entities:
     - type: Transform
       pos: 6.497226,-28.398174
       parent: 1
-- proto: HandHeldMassScanner
+- proto: HandHeldMassScannerEE
   entities:
   - uid: 5080
     components:

--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -12,7 +12,7 @@
       - id: OxygenTankFilled
       - id: FireExtinguisher
       - id: ClothingShoesBootsMag
-      - id: HandHeldMassScanner
+      - id: HandHeldMassScannerEE
       - id: Pickaxe
       - id: Welder
       - id: Wrench

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -2,7 +2,7 @@
   name: handheld mass scanner
   parent: BaseHandheldComputer
   id: HandHeldMassScannerEE
-  description: A hand-held mass scanner.
+  description: A hand-held mass scanner. It only consumes power when scanning.
   suffix : Einstein-Engines
   components:
   - type: Item

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -374,7 +374,7 @@
     - SignalTrigger
     - VoiceTrigger
     - Igniter
-    - HandHeldMassScanner
+    - HandHeldMassScannerEE
     - PowerCellMicrortg
     - PowerCellMicroreactor
     - PowerCellHigh

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -148,8 +148,8 @@
     Plastic: 250
 
 - type: latheRecipe
-  id: HandHeldMassScanner
-  result: HandHeldMassScannerEmpty
+  id: HandHeldMassScannerEE
+  result: HandHeldMassScannerEE
   category: Tools
   completetime: 2
   materials:

--- a/Resources/Prototypes/_Crescent/_Hyperwar/Wardrobes.yml
+++ b/Resources/Prototypes/_Crescent/_Hyperwar/Wardrobes.yml
@@ -30,7 +30,7 @@
     DrinkMREFlask: 100
     WeaponGrapplingGun: 150
     JetpackCaptainFilled: 150
-    HandHeldMassScanner: 150
+    HandHeldMassScannerEE: 150
     Crowbar: 150
     ClothingOuterHardsuitSyndicateBG: 150
     OxygenTankFilled: 150
@@ -64,7 +64,7 @@
     DrinkMREFlask: 100
     WeaponGrapplingGun: 150
     JetpackCaptainFilled: 150
-    HandHeldMassScanner: 150
+    HandHeldMassScannerEE: 150
     Crowbar: 150
     ClothingOuterHardsuitNCWLInfantry: 150
     OxygenTankFilled: 150
@@ -103,7 +103,7 @@
     DrinkMREFlask: 100
     WeaponGrapplingGun: 150
     JetpackCaptainFilled: 150
-    HandHeldMassScanner: 150
+    HandHeldMassScannerEE: 150
     Crowbar: 150
     ClothingOuterHardsuitImperialSoldier: 150
     OxygenTankFilled: 150
@@ -145,7 +145,7 @@
     DrinkMREFlask: 100
     WeaponGrapplingGun: 150
     JetpackCaptainFilled: 150
-    HandHeldMassScanner: 150
+    HandHeldMassScannerEE: 150
     Crowbar: 150
     ClothingOuterHardsuitCMMPatrol: 150
     OxygenTankFilled: 150

--- a/Resources/Prototypes/_NF/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Lockers/security.yml
@@ -6,6 +6,6 @@
   - type: StorageFill
     contents:
       - id: PinpointerUniversal
-      - id: HandHeldMassScanner
+      - id: HandHeldMassScannerEE
       - id: WeaponGrapplingGun
       - id: BoxZiptie

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/astrovend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/astrovend.yml
@@ -12,7 +12,7 @@
     JetpackMiniFilled: 10
     JetpackBlueFilled: 10
     EncryptionKeyTraffic: 30
-    HandHeldMassScanner: 10
+    HandHeldMassScannerEE: 10
 # Pilot drip
     ClothingBackpackPilot: 6
     ClothingBackpackDuffelPilot: 6

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_supply.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_supply.yml
@@ -63,7 +63,7 @@
     offset: 0.0
     rarePrototypes:
     - OreBagOfHolding
-    - HandHeldMassScanner
+    - HandHeldMassScannerEE
     - SpawnDungeonLootHardsuitsSalvage
     rareChance: 0.05
 


### PR DESCRIPTION
after the rebase all non-EE mass scanners kind of broke. they only display where they were spawned in, and they also consume power and run out very fast when not in use. EE mass scanners only consume power when in use, and actually move with you.

this just replaces all instances (except the HandheldMassScanner prototype) of HandheldMassScanner with HandheldMassScannerEE, making it appear in vending machines, static spawns and lathes.

also adds " It only consumes power when scanning." to its description to help with confusion.