### PR TITLE
fix up jackal armory post-overnerf

### DIFF
--- a/Resources/Maps/_Crescent/Stations/jackal.yml
+++ b/Resources/Maps/_Crescent/Stations/jackal.yml
@@ -11365,14 +11365,14 @@ entities:
         - 635
         - 149
         - 485
-        swarmer missile launcher:
-        - 149
-        - 485
         230mm 'Hephaeustus' assault artillery platform:
         - 114
         - 631
         - 632
         - 635
+        swarmer missile launcher:
+        - 149
+        - 485
 - proto: ComputerWallmountBankATM
   entities:
   - uid: 1135
@@ -11591,12 +11591,6 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 103
-          - 102
-          - 101
-          - 100
-          - 99
-          - 98
           - 97
           - 96
           - 95
@@ -11607,15 +11601,11 @@ entities:
           - 90
           - 89
           - 88
-          - 87
-          - 86
           - 85
           - 84
-          - 83
-          - 82
-          - 81
+          - 87
+          - 86
           - 80
-          - 79
           - 78
           - 77
           - 76
@@ -11638,20 +11628,6 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 135
-          - 134
-          - 133
-          - 132
-          - 131
-          - 130
-          - 129
-          - 128
-          - 127
-          - 126
-          - 125
-          - 124
-          - 123
-          - 122
           - 121
           - 120
           - 119
@@ -11660,6 +11636,10 @@ entities:
           - 116
           - 115
           - 113
+          - 125
+          - 124
+          - 123
+          - 122
           - 112
           - 111
           - 110
@@ -11771,18 +11751,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 243
-          - 244
-          - 245
-          - 246
-          - 248
-          - 249
-          - 250
-          - 251
-          - 252
-          - 253
-          - 254
-          - 255
+          - 79
+          - 81
+          - 82
+          - 83
+          - 98
           - 256
           - 259
           - 260
@@ -11797,10 +11770,7 @@ entities:
           - 275
           - 280
           - 282
-          - 283
-          - 284
-          - 285
-          - 286
+          - 254
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11818,26 +11788,26 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 322
-          - 321
-          - 319
-          - 306
-          - 305
-          - 304
-          - 303
-          - 295
-          - 294
-          - 293
-          - 292
-          - 291
-          - 290
-          - 289
-          - 288
-          - 335
-          - 336
-          - 338
-          - 342
           - 343
+          - 342
+          - 338
+          - 336
+          - 335
+          - 288
+          - 289
+          - 290
+          - 291
+          - 292
+          - 293
+          - 294
+          - 295
+          - 303
+          - 304
+          - 305
+          - 306
+          - 319
+          - 321
+          - 322
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -15752,51 +15722,6 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 98
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 99
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 100
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 101
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 103
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: GrenadeBlast
   entities:
   - uid: 74
@@ -15836,51 +15761,6 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
   - uid: 78
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 79
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 81
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 82
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 83
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 102
     components:
     - type: Transform
       parent: 73
@@ -17281,15 +17161,6 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 255
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 256
     components:
     - type: Transform
@@ -17416,45 +17287,9 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 283
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 284
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 285
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 286
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: MagazineLightRifleBoxSlugHE
   entities:
-  - uid: 243
+  - uid: 79
     components:
     - type: Transform
       parent: 242
@@ -17463,7 +17298,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 244
+  - uid: 81
     components:
     - type: Transform
       parent: 242
@@ -17472,7 +17307,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 245
+  - uid: 82
     components:
     - type: Transform
       parent: 242
@@ -17481,7 +17316,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 246
+  - uid: 83
     components:
     - type: Transform
       parent: 242
@@ -17490,52 +17325,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 248
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 249
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 250
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 251
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 252
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 253
+  - uid: 98
     components:
     - type: Transform
       parent: 242
@@ -17900,96 +17690,6 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
   - uid: 125
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 126
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 127
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 128
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 129
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 130
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 131
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 132
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 133
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 134
-    components:
-    - type: Transform
-      parent: 104
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 135
     components:
     - type: Transform
       parent: 104

--- a/Resources/Maps/_Crescent/Stations/jackal.yml
+++ b/Resources/Maps/_Crescent/Stations/jackal.yml
@@ -11486,36 +11486,36 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 38
-          - 37
-          - 36
-          - 35
-          - 34
-          - 33
-          - 32
-          - 31
-          - 30
-          - 29
-          - 28
-          - 27
-          - 26
-          - 25
-          - 24
-          - 23
-          - 22
-          - 21
-          - 18
-          - 17
-          - 16
-          - 15
-          - 14
-          - 13
-          - 12
-          - 11
-          - 10
-          - 9
-          - 8
           - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
+          - 16
+          - 17
+          - 18
+          - 21
+          - 22
+          - 23
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
+          - 29
+          - 30
+          - 31
+          - 32
+          - 33
+          - 34
+          - 35
+          - 36
+          - 37
+          - 38
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11554,26 +11554,22 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 49
           - 50
-          - 53
-          - 54
-          - 55
-          - 56
-          - 57
-          - 58
-          - 59
-          - 60
-          - 61
-          - 62
-          - 63
-          - 64
-          - 65
+          - 49
           - 66
-          - 67
-          - 68
-          - 70
-          - 71
+          - 65
+          - 64
+          - 63
+          - 62
+          - 61
+          - 60
+          - 59
+          - 58
+          - 57
+          - 56
+          - 55
+          - 54
+          - 53
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11591,26 +11587,26 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 97
-          - 96
-          - 95
-          - 94
-          - 93
-          - 92
-          - 91
-          - 90
-          - 89
-          - 88
-          - 85
-          - 84
-          - 87
-          - 86
-          - 80
-          - 78
-          - 77
-          - 76
-          - 75
+          - 67
+          - 68
+          - 70
+          - 71
           - 74
+          - 80
+          - 86
+          - 87
+          - 84
+          - 85
+          - 88
+          - 89
+          - 90
+          - 91
+          - 92
+          - 93
+          - 94
+          - 95
+          - 96
+          - 97
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11628,26 +11624,26 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 121
-          - 120
-          - 119
-          - 118
-          - 117
-          - 116
-          - 115
-          - 113
-          - 125
-          - 124
-          - 123
-          - 122
-          - 112
-          - 111
-          - 110
-          - 109
-          - 108
-          - 107
-          - 106
           - 105
+          - 106
+          - 107
+          - 108
+          - 109
+          - 110
+          - 111
+          - 112
+          - 122
+          - 123
+          - 124
+          - 125
+          - 113
+          - 115
+          - 116
+          - 117
+          - 118
+          - 119
+          - 120
+          - 121
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11665,36 +11661,26 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 138
-          - 139
-          - 140
-          - 141
-          - 142
-          - 143
-          - 144
-          - 146
-          - 150
-          - 151
-          - 152
-          - 153
-          - 154
-          - 155
-          - 156
           - 157
-          - 158
-          - 159
-          - 160
+          - 156
+          - 155
+          - 154
+          - 153
+          - 152
+          - 151
+          - 150
+          - 146
+          - 144
+          - 143
           - 161
-          - 162
-          - 163
-          - 164
-          - 165
-          - 166
-          - 167
-          - 168
-          - 169
-          - 170
-          - 172
+          - 160
+          - 159
+          - 158
+          - 142
+          - 141
+          - 138
+          - 140
+          - 139
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11713,27 +11699,22 @@ entities:
           occludes: True
           ents:
           - 220
-          - 219
-          - 218
-          - 215
-          - 214
-          - 210
-          - 207
-          - 204
-          - 203
-          - 202
-          - 200
-          - 197
-          - 174
-          - 175
-          - 180
           - 182
-          - 183
-          - 184
-          - 187
-          - 188
+          - 175
+          - 174
           - 194
-          - 195
+          - 183
+          - 197
+          - 200
+          - 202
+          - 203
+          - 204
+          - 207
+          - 210
+          - 214
+          - 215
+          - 218
+          - 219
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11751,11 +11732,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 75
+          - 76
+          - 77
+          - 78
           - 79
-          - 81
-          - 82
-          - 83
-          - 98
           - 256
           - 259
           - 260
@@ -11788,13 +11769,6 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 343
-          - 342
-          - 338
-          - 336
-          - 335
-          - 288
-          - 289
           - 290
           - 291
           - 292
@@ -11805,9 +11779,8 @@ entities:
           - 304
           - 305
           - 306
-          - 319
-          - 321
-          - 322
+          - 288
+          - 289
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -15724,43 +15697,43 @@ entities:
     - type: InsideEntityStorage
 - proto: GrenadeBlast
   entities:
+  - uid: 67
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 68
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 70
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 71
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 74
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 75
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 76
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 77
-    components:
-    - type: Transform
-      parent: 73
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 78
     components:
     - type: Transform
       parent: 73
@@ -16348,96 +16321,6 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 162
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 163
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 164
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 165
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 166
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 167
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 168
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 169
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 170
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 172
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 823
     components:
     - type: Transform
@@ -16648,42 +16531,6 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
   - uid: 66
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 67
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 68
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 70
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 71
     components:
     - type: Transform
       parent: 48
@@ -16964,24 +16811,6 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 180
-    components:
-    - type: Transform
-      parent: 173
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 187
-    components:
-    - type: Transform
-      parent: 173
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: MagazineGrenadeBlast
   entities:
   - uid: 182
@@ -17002,36 +16831,9 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 184
-    components:
-    - type: Transform
-      parent: 173
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 188
-    components:
-    - type: Transform
-      parent: 173
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: MagazineGrenadeEMP
   entities:
   - uid: 194
-    components:
-    - type: Transform
-      parent: 173
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 195
     components:
     - type: Transform
       parent: 173
@@ -17289,43 +17091,43 @@ entities:
     - type: InsideEntityStorage
 - proto: MagazineLightRifleBoxSlugHE
   entities:
+  - uid: 75
+    components:
+    - type: Transform
+      parent: 242
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 76
+    components:
+    - type: Transform
+      parent: 242
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 77
+    components:
+    - type: Transform
+      parent: 242
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 78
+    components:
+    - type: Transform
+      parent: 242
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 79
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 81
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 82
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 83
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 98
     components:
     - type: Transform
       parent: 242
@@ -17436,78 +17238,6 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
   - uid: 306
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 319
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 321
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 322
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 335
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 336
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 338
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 342
-    components:
-    - type: Transform
-      parent: 287
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 343
     components:
     - type: Transform
       parent: 287

--- a/Resources/Maps/_Crescent/Stations/jackal.yml
+++ b/Resources/Maps/_Crescent/Stations/jackal.yml
@@ -9857,6 +9857,8 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
+- proto: CartridgeShellHighExplosive
+  entities:
   - uid: 12
     components:
     - type: Transform
@@ -9938,144 +9940,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 32
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 33
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 35
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 36
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 37
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 38
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: CartridgeShellHighExplosive
-  entities:
   - uid: 23
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 24
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 25
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 26
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 27
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 28
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 29
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 30
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 31
-    components:
-    - type: Transform
-      parent: 6
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 34
     components:
     - type: Transform
       parent: 6
@@ -11486,13 +11351,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 7
-          - 8
           - 9
           - 10
           - 11
           - 12
-          - 13
           - 14
           - 15
           - 16
@@ -11501,21 +11363,9 @@ entities:
           - 21
           - 22
           - 23
-          - 24
-          - 25
-          - 26
-          - 27
-          - 28
-          - 29
-          - 30
-          - 31
-          - 32
-          - 33
-          - 34
-          - 35
-          - 36
-          - 37
-          - 38
+          - 7
+          - 8
+          - 13
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11554,22 +11404,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 50
-          - 49
-          - 66
-          - 65
-          - 64
-          - 63
-          - 62
-          - 61
-          - 60
-          - 59
-          - 58
-          - 57
-          - 56
-          - 55
-          - 54
           - 53
+          - 54
+          - 55
+          - 56
+          - 57
+          - 58
+          - 59
+          - 60
+          - 49
+          - 50
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11587,11 +11431,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 67
-          - 68
-          - 70
-          - 71
-          - 74
+          - 24
+          - 25
+          - 26
+          - 27
+          - 28
           - 80
           - 86
           - 87
@@ -11661,26 +11505,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 157
-          - 156
-          - 155
-          - 154
-          - 153
-          - 152
-          - 151
-          - 150
-          - 146
-          - 144
-          - 143
-          - 161
-          - 160
-          - 159
-          - 158
-          - 142
-          - 141
-          - 138
-          - 140
           - 139
+          - 140
+          - 138
+          - 141
+          - 142
+          - 143
+          - 144
+          - 146
+          - 150
+          - 151
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11732,26 +11566,16 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 75
-          - 76
-          - 77
-          - 78
-          - 79
-          - 256
-          - 259
-          - 260
-          - 261
-          - 262
-          - 263
-          - 267
-          - 268
-          - 269
-          - 271
-          - 272
-          - 275
-          - 280
-          - 282
-          - 254
+          - 38
+          - 37
+          - 36
+          - 35
+          - 34
+          - 33
+          - 32
+          - 31
+          - 30
+          - 29
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -11769,18 +11593,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 290
-          - 291
-          - 292
-          - 293
-          - 294
-          - 295
-          - 303
-          - 304
-          - 305
-          - 306
-          - 288
           - 289
+          - 288
+          - 306
+          - 305
+          - 304
+          - 303
+          - 295
+          - 294
+          - 293
+          - 292
+          - 291
+          - 290
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -15697,7 +15521,7 @@ entities:
     - type: InsideEntityStorage
 - proto: GrenadeBlast
   entities:
-  - uid: 67
+  - uid: 24
     components:
     - type: Transform
       parent: 73
@@ -15706,7 +15530,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 68
+  - uid: 25
     components:
     - type: Transform
       parent: 73
@@ -15715,7 +15539,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 70
+  - uid: 26
     components:
     - type: Transform
       parent: 73
@@ -15724,7 +15548,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 71
+  - uid: 27
     components:
     - type: Transform
       parent: 73
@@ -15733,7 +15557,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 74
+  - uid: 28
     components:
     - type: Transform
       parent: 73
@@ -16231,96 +16055,6 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 152
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 153
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 154
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 155
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 156
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 157
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 158
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 159
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 160
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 161
-    components:
-    - type: Transform
-      parent: 137
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 823
     components:
     - type: Transform
@@ -16477,60 +16211,6 @@ entities:
       canCollide: False
     - type: InsideEntityStorage
   - uid: 60
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 61
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 62
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 63
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 64
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 65
-    components:
-    - type: Transform
-      parent: 48
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 66
     components:
     - type: Transform
       parent: 48
@@ -16954,7 +16634,7 @@ entities:
     - type: InsideEntityStorage
 - proto: MagazineLightRifleBoxSlug
   entities:
-  - uid: 254
+  - uid: 35
     components:
     - type: Transform
       parent: 242
@@ -16963,7 +16643,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 256
+  - uid: 36
     components:
     - type: Transform
       parent: 242
@@ -16972,7 +16652,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 259
+  - uid: 37
     components:
     - type: Transform
       parent: 242
@@ -16981,106 +16661,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 260
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 261
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 262
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 263
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 267
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 268
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 269
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 271
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 272
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 275
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 280
-    components:
-    - type: Transform
-      parent: 242
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 282
+  - uid: 38
     components:
     - type: Transform
       parent: 242
@@ -17091,7 +16672,7 @@ entities:
     - type: InsideEntityStorage
 - proto: MagazineLightRifleBoxSlugHE
   entities:
-  - uid: 75
+  - uid: 29
     components:
     - type: Transform
       parent: 242
@@ -17100,7 +16681,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 76
+  - uid: 30
     components:
     - type: Transform
       parent: 242
@@ -17109,7 +16690,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 77
+  - uid: 31
     components:
     - type: Transform
       parent: 242
@@ -17118,7 +16699,7 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 78
+  - uid: 32
     components:
     - type: Transform
       parent: 242
@@ -17127,7 +16708,16 @@ entities:
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 79
+  - uid: 33
+    components:
+    - type: Transform
+      parent: 242
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 34
     components:
     - type: Transform
       parent: 242


### PR DESCRIPTION
reduced from previous values, but not made useless like MLG did

ideally this gets you through the early game before nobody can produce ammo for export and doesnt lock you out of specific ship options as long as you're not spamming them

putting this into perspective, this is less than what you'd get from buying 1-2 ammo crates from a commissary
  
  20 vulcan magazines - high demand due to extensive use of MGs, you'll run out very early and need a resupply
  
  20 missiles, primarily low yield - high demand due to high amounts of kurosawas
  
  5 missile cartridges, primarily low yield, barely any EMP - high demand due to high amounts of sumitomos/kurosawas
  
  10 slugthrower magazines - extremely high demand now that they're 50 bullets each instead of 200, you'll run out of these
  
  12 swarmers - reaver/jackal/sinn use these
  
  10 idnas - tick uses these, it doesnt spawn with ammo and you'll instantly run out if you dont buy more
  
  15 120mm shells - only corvax uses these, you usually need more but you can run a single corvax with just 30, if you want a more artillery-focused doctrine you'll have to source them from somewhere else
  
  10 hephaestus shells - jackal/cerberus run these in piles, you'll need to buy these later into the round if you run a cerberus or get into a fight using the jackal
