### PR TITLE
fixes pdt gun projectiles phasing thru ships and being useless

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/SpaceArtillery/shells.yml
+++ b/Resources/Prototypes/_Crescent/Entities/SpaceArtillery/shells.yml
@@ -773,6 +773,10 @@
     radius: 3.5
     color: orange
     energy: 0.5
+  - type: ProjectilePhasePrevent #do not remove
+    mask:
+    - BulletImpassable
+    - Impassable
 
 - type: entity
   id: PDTBulletCase


### PR DESCRIPTION
when we removed ProjectilePhasePrevent from stuff we removed it from vulcans and pdt guns

we added it back to vulcans but forgot about PDT guns which made them phase thru stuff entirely

this fixes that by adding it back