### PR TITLE
Update NCWL Docs URL in HullrotRuleset.xml

### DIFF
--- a/Resources/ServerInfo/_Crescent/ServerRules/HullrotRuleset.xml
+++ b/Resources/ServerInfo/_Crescent/ServerRules/HullrotRuleset.xml
@@ -1,5 +1,5 @@
 <Document>
-﻿﻿[color=#ff0000]HULLROT[/color]
+[color=#ff0000]HULLROT[/color]
 
 HULLROT is a roleplaying project and all participants of the game build the environment that creates an interesting and enjoyable story. Members not respecting the setting of the game will not be present again.
 
@@ -9,34 +9,34 @@ Evil exists in this world and is condoned in many cases. For instance, sabotagin
 
 Killing another player is a quick and effective method of resolving a conflict but try your best to keep it interesting. Hostages are often worth a lot more.
 
-[color=#ff0000]Q:[/color] Is there a wiki? 
-    [color=#00ff00]A:[/color] There is no official wiki yet, but this fan made one is good: https://wreakhavoconthemiddleclass.github.io/ncwl-docs/guides/introduction/
+[color=#ff0000]Q:[/color] Is there a wiki?
+    [color=#00ff00]A:[/color] There is no official wiki yet, but this fan made one is good: https://ncwldocs.github.io/guides/introduction/
 
-[color=#ff0000]Q:[/color] Where can I join the discord? 
+[color=#ff0000]Q:[/color] Where can I join the discord?
     [color=#00ff00]A:[/color] https://discord.gg/S5VTFSwPEe (permanent link)
 
-[color=#ff0000]Q:[/color] Where can I find the lore? 
+[color=#ff0000]Q:[/color] Where can I find the lore?
     [color=#00ff00]A:[/color] There is no centralized location for the lore. Find out ingame, ask others, or weave your own when the round requires it.
 
 [color=#ff0000]Q:[/color] When does the server go up?
     [color=#00ff00]A:[/color] The game is tested erratically, and usually on weekends. Not every weekend is a guaranteed testlaunch. Uptimes can be found on the Discord.
 
-[color=#ff0000]Q:[/color] You've been dehubbed. What should I do to access you? 
+[color=#ff0000]Q:[/color] You've been dehubbed. What should I do to access you?
     [color=#00ff00]A:[/color] You can list https://ss14hubs.com/ as an alternative hub to find us during uptime, or direct connect via our IP that we announce for each host.
 
-[color=#ff0000]Q:[/color] What are the rules of this server? 
+[color=#ff0000]Q:[/color] What are the rules of this server?
     [color=#00ff00]A:[/color] There are none. Hullrot is a roleplaying game, and operates on a basis of mutual player trust and collaboration. Play your character realistically. Underperforming players are often tossed out.
 
-[color=#ff0000]Q:[/color] Where can I find the source? Can I contribute? 
+[color=#ff0000]Q:[/color] Where can I find the source? Can I contribute?
     [color=#00ff00]A:[/color] https://github.com/MLGTASTICa/Hullrot. You are encouraged to make pull requests on this github.
 
-[color=#ff0000]Q:[/color] I donated to your Patreon, how can I claim my rewards? 
+[color=#ff0000]Q:[/color] I donated to your Patreon, how can I claim my rewards?
     [color=#00ff00]A:[/color] You may contact @aisha on Discord.
 
-[color=#ff0000]Q:[/color] I donated and I got banned from the game sometime later! Can I have a refund? 
+[color=#ff0000]Q:[/color] I donated and I got banned from the game sometime later! Can I have a refund?
     [color=#00ff00]A:[/color] We recommend you unsubscribe and never come back here again.
 
-[color=#ff0000]Q:[/color] How do I donate to you? 
+[color=#ff0000]Q:[/color] How do I donate to you?
     [color=#00ff00]A:[/color] We have a patreon that can be found at: https://www.patreon.com/sectorcrescent.
 
 </Document>


### PR DESCRIPTION
Old: `https://wreakhavoconthemiddleclass.github.io/ncwl-docs/guides/introduction/`

New: `https://ncwldocs.github.io/guides/introduction/`

# Description

Updating a URL in the server rules.

# TODO

N/A


# Media

N/A


# Changelog

:cl:
- tweak: updated NCWL Docs URL in server rules
