### PR TITLE
3 ritters instead of 1

### DIFF
--- a/Resources/Prototypes/_Crescent/Maps/Stations/kal.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Stations/kal.yml
@@ -23,7 +23,7 @@
             GovernorDSM: [ 1, 1 ]
             AdjutantDSM: [ 1, 1 ]
             KnightDSM: [ 4, 4 ]
-            RitterDSM: [ 1, 1 ]
+            RitterDSM: [ 3, 3 ]
             LevymanDSM: [ 8, 8 ]
             ArchmaesterDSM: [ 1, 1 ]
             ScribeDSM: [ 6, 6 ]


### PR DESCRIPTION
on request of DSMcord
also to make them be able to fly in a V wedge or something for larp
larp
makes ritter pop 3 instead of just 1