### PR TITLE
adds dogtag-based stores for NCWL and DSM. makes IDs be proper currencies for them

### DIFF
--- a/Resources/Prototypes/_Crescent/DogtagStore/catalog_DSM.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/catalog_DSM.yml
@@ -1,12 +1,11 @@
-# example
+# DSM catalog for the id/dogtag console, using communard IDs as currency
 - type: storeCategory
-  id: StoreCategoryGeneric
-  name: Generic Items
+  id: StoreCategoryDSMSnacks
+  name: Snacks
   priority: 12
 
-# example
 - type: listing
-  id: StoreListingGenericMRE
+  id: StoreListingDSMMRE
   name: MRE snack
   description: delicious n tasty
   icon: { sprite: /Textures/Objects/Consumable/Food/snacks.rsi, state: icon }
@@ -14,16 +13,20 @@
   cost:
     DogtagNCWL: 1
   categories:
-  - StoreCategoryGeneric
+  - StoreCategoryDSMSnacks
 
-# example
+- type: storeCategory
+  id: StoreCategoryDSMUtility
+  name: Utility
+  priority: 10
+
 - type: listing
-  id: StoreListingFlashbang
+  id: StoreListingDSMFlashbang
   name: bright grenade
   description: dont look at it
   icon: { sprite: /Textures/Objects/Weapons/Grenades/flashbang.rsi, state: icon }
-  productEntity: GrenadeFlash
+  productEntity: GrenadeFlashBang
   cost:
-    DogtagNCWL: 1
+    DogtagNCWL: 2
   categories:
-  - StoreCategoryGeneric
+  - StoreCategoryDSMUtility

--- a/Resources/Prototypes/_Crescent/DogtagStore/catalog_NCWL.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/catalog_NCWL.yml
@@ -1,29 +1,32 @@
-# example
+# NCWL catalog for the id/dogtag console, using imperial IDs as currency
 - type: storeCategory
-  id: StoreCategoryGeneric
-  name: Generic Items
+  id: StoreCategoryNCWLSnacks
+  name: Snacks
   priority: 12
 
-# example
 - type: listing
-  id: StoreListingGenericMRE
+  id: StoreListingNCWLMRE
   name: MRE snack
   description: delicious n tasty
   icon: { sprite: /Textures/Objects/Consumable/Food/snacks.rsi, state: icon }
   productEntity: FoodSnackMREBrownie
   cost:
-    DogtagNCWL: 1
+    DogtagDSM: 1
   categories:
-  - StoreCategoryGeneric
+  - StoreCategoryNCWLSnacks
 
-# example
+- type: storeCategory
+  id: StoreCategoryNCWLUtility
+  name: Utility
+  priority: 10
+
 - type: listing
-  id: StoreListingFlashbang
+  id: StoreListingNCWLFlashbang
   name: bright grenade
   description: dont look at it
   icon: { sprite: /Textures/Objects/Weapons/Grenades/flashbang.rsi, state: icon }
-  productEntity: GrenadeFlash
+  productEntity: GrenadeFlashBang
   cost:
-    DogtagNCWL: 1
+    DogtagDSM: 2
   categories:
-  - StoreCategoryGeneric
+  - StoreCategoryNCWLUtility

--- a/Resources/Prototypes/_Crescent/DogtagStore/currency.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/currency.yml
@@ -1,0 +1,4 @@
+- type: currency
+  id: DogtagNCWL
+  displayName: Communard Dogtags
+  canWithdraw: false

--- a/Resources/Prototypes/_Crescent/DogtagStore/currency.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/currency.yml
@@ -1,4 +1,9 @@
 - type: currency
   id: DogtagNCWL
-  displayName: Communard Dogtags
+  displayName: Communard IDs #CHANGE TO DOGTAG LATER
+  canWithdraw: false
+
+- type: currency
+  id: DogtagDSM
+  displayName: Imperial IDs #CHANGE TO DOGTAG LATER
   canWithdraw: false

--- a/Resources/Prototypes/_Crescent/DogtagStore/generic_catalog.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/generic_catalog.yml
@@ -1,0 +1,27 @@
+- type: storeCategory
+  id: StoreCategoryGeneric
+  name: Generic Items
+  priority: 12
+
+# generic gear every faction store gets
+- type: listing
+  id: StoreListingGenericMRE
+  name: MRE snack
+  description: delicious n tasty
+  icon: { sprite: /Textures/Objects/Consumable/Food/snacks.rsi, state: icon }
+  productEntity: FoodSnackMREBrownie
+  cost:
+    DogtagNCWL: 1
+  categories:
+  - StoreCategoryGeneric
+
+- type: listing
+  id: StoreListingFlashbang
+  name: bright grenade
+  description: dont look at it
+  icon: { sprite: /Textures/Objects/Weapons/Grenades/flashbang.rsi, state: icon }
+  productEntity: GrenadeFlash
+  cost:
+    DogtagNCWL: 1
+  categories:
+  - StoreCategoryGeneric

--- a/Resources/Prototypes/_Crescent/DogtagStore/machines.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/machines.yml
@@ -1,0 +1,119 @@
+- type: entity
+  id: BaseStore
+  parent: BaseMachinePowered
+  name: standing store
+  description: Just add capitalism!
+  abstract: true
+  components:
+  - type: StationAiWhitelist
+  - type: AmbientOnPowered
+  - type: AmbientSound
+    volume: -9
+    range: 3
+    enabled: false
+    sound:
+      path: /Audio/Ambience/Objects/vending_machine_hum.ogg
+    components:
+  - type: Sprite
+    sprite: _Crescent/Structures/syndicatearmory.rsi
+    layers:
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.Base"]
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+      shader: unshaded
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+    snapCardinals: false
+  - type: Physics
+    bodyType: Static
+  - type: Transform
+    noRot: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.45,0.25,0.45"
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+        density: 1000
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Breakage"]
+      - !type:EjectVendorItems
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+  - type: Repairable
+    doAfterDelay: 8
+  - type: ActivatableUI
+    key: enum.StoreUiKey.Key
+  - type: ActivatableUIRequiresPower
+  - type: UserInterface
+    interfaces:
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+  - type: Anchorable
+  - type: TypingIndicator
+    proto: robot
+  - type: Speech
+    speechVerb: Robotic
+    speechSounds: Vending
+  - type: IntrinsicRadioReceiver
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
+  - type: ActiveRadio
+    channels:
+    - Binary
+    - Common
+  - type: DoAfter
+  - type: Electrified
+    enabled: false
+    usesApcPower: true
+  - type: EtherealLight
+  - type: PointLight
+    enabled: false
+    castShadows: false
+    radius: 2
+    energy: 1.5
+    mask: /Textures/Effects/LightMasks/cone.png
+    autoRot: true
+  - type: LitOnPowered
+  - type: ApcPowerReceiver
+    powerLoad: 200
+  - type: Actions
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-mechanical
+    weight: 0.025 # fuck you in particular (it now needs 40 vending machines to be as likely as 1 interesting animal)
+  - type: StaticPrice
+    price: 100
+  - type: Appearance
+
+
+# The parented StorePresetHullrot<whatever> is what decides the stock for this store.
+
+- type: entity
+  parent: [ BaseStructureUnanchorable, BaseStore, StorePresetHullrotDogtagGenericNCWL ]
+  id: BaseDogtagStore
+  name: Generic Dogtag Store NCWL
+  description: A debug store for using dogtags to buy things. You should not be seeing this.

--- a/Resources/Prototypes/_Crescent/DogtagStore/machines.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/machines.yml
@@ -44,13 +44,6 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Breakage"]
-      - !type:EjectVendorItems
-    - trigger:
-        !type:DamageTrigger
         damage: 200
       behaviors:
       - !type:SpawnEntitiesBehavior
@@ -113,7 +106,13 @@
 # The parented StorePresetHullrot<whatever> is what decides the stock for this store.
 
 - type: entity
-  parent: [ BaseStructureUnanchorable, BaseStore, StorePresetHullrotDogtagGenericNCWL ]
-  id: BaseDogtagStore
-  name: Generic Dogtag Store NCWL
-  description: A debug store for using dogtags to buy things. You should not be seeing this.
+  parent: [ BaseStructureUnanchorable, BaseStore, StorePresetHullrotDogtagNCWL ]
+  id: NCWLDogtagStore
+  name: NCWL Bounty Console
+  description: A machine rewarding your revolutionary might with better gear. Only accepts DSM ID cards.
+
+- type: entity
+  parent: [ BaseStructureUnanchorable, BaseStore, StorePresetHullrotDogtagDSM ]
+  id: DSMDogtagStore
+  name: DSM Bounty Console
+  description: A machine rewarding your righteous fury with better gear. Only accepts NCWL ID cards.

--- a/Resources/Prototypes/_Crescent/DogtagStore/presets.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/presets.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: StorePresetHullrotDogtagGenericNCWL #GENERIC. DON'T USE THIS
+  abstract: true
+  components:
+  - type: Store
+    name: The Generic Store!
+    categories:
+    - StoreCategoryGeneric
+    currencyWhitelist:
+    - DogtagNCWL
+    balance:
+      DogtagNCWL: 0

--- a/Resources/Prototypes/_Crescent/DogtagStore/presets.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/presets.yml
@@ -1,12 +1,29 @@
 - type: entity
-  id: StorePresetHullrotDogtagGenericNCWL #GENERIC. DON'T USE THIS
+  id: StorePresetHullrotDogtagNCWL
   abstract: true
   components:
   - type: Store
-    name: The Generic Store!
+    name: Workers League Bounty Console. Uses imperial IDs as currency.
     categories:
-    - StoreCategoryGeneric
+    - StoreCategoryNCWLSnacks
+    - StoreCategoryNCWLUtility
+    currencyWhitelist:
+    - DogtagDSM
+    balance:
+      DogtagDSM: 0
+
+- type: entity
+  id: StorePresetHullrotDogtagDSM
+  abstract: true
+  components:
+  - type: Store
+    name: Mandate Bounty Console. Uses communard IDs as currency.
+    categories:
+    - StoreCategoryDSMSnacks
+    - StoreCategoryDSMUtility
     currencyWhitelist:
     - DogtagNCWL
     balance:
       DogtagNCWL: 0
+
+

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/identification_cards.yml
@@ -5,6 +5,9 @@
   id: NCWLIDCardKommissar
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: Sprite
     layers:
     - state: default
@@ -17,6 +20,9 @@
   id: NCWLIDCardSanitar
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: PresetIdCard
     job: SanitarNCWL
   - type: Sprite
@@ -29,6 +35,9 @@
   id: NCWLIDCardArtificer
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: Sprite
     layers:
     - state: default
@@ -41,6 +50,9 @@
   id: NCWLIDCardDoktor
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: Sprite
     layers:
     - state: default
@@ -53,6 +65,9 @@
   id: NCWLIDCardAdministrator
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: Sprite
     layers:
     - state: default
@@ -65,6 +80,9 @@
   id: NCWLIDCardKapitan
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: Sprite
     layers:
     - state: default
@@ -77,6 +95,9 @@
   id: NCWLIDCardKadet
   name: NCWL ID card
   components:
+  - type: Currency
+    price:
+      DogtagNCWL: 1
   - type: Sprite
     layers:
     - state: default

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/identification_cards.yml
@@ -246,6 +246,9 @@
   id: DSMIDCardFreeholder
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -258,6 +261,9 @@
   id: DSMIDCardTemplar
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -270,6 +276,9 @@
   id: DSMIDCardAdvocatus
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -282,6 +291,9 @@
   id: DSMIDCardArchmaester
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -294,6 +306,9 @@
   id: DSMIDCardSurgeon
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -306,6 +321,9 @@
   id: DSMIDCardWealth
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -318,6 +336,9 @@
   id: DSMIDCardForeman
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -330,6 +351,9 @@
   id: DSMIDCardScribe
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -342,6 +366,9 @@
   id: DSMIDCardLevyman
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -354,6 +381,9 @@
   id: DSMIDCardKnight
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -366,6 +396,9 @@
   id: DSMIDCardRitter
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -376,7 +409,11 @@
 - type: entity
   parent: IDCardStandard
   id: DSMIDCardLabor
+  name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -389,6 +426,9 @@
   id: DSMIDCardCourtier
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -401,6 +441,9 @@
   id: DSMIDCardAdjutant
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default
@@ -413,6 +456,9 @@
   id: DSMIDCardGovernor
   name: imperial ID card
   components:
+  - type: Currency
+    price:
+      DogtagDSM: 1
   - type: Sprite
     layers:
     - state: default


### PR DESCRIPTION
this adds 2 new vendors that take NCWL and DSM dogtags respectively, and currently vend either an MRE or a flashbang.
all that needs to be done is to add the actual store contents which is balancing n shit. aisha you do this

boring code shit to make it easier to review:
- all yaml
- adds a new folder, DogtagStore in _Crescent for everything
- uses existing Uplink/Telecrystal code
- currency.yml defines the 2 new currencies, DogtagNCWL and DogtagDSM
- catalog_DSM and catalog_NCWL defines the actual catalog. you find categories and then items in those categories there with examples
- presets.yml defines the 2 presets used for each of the 2 store entities. you only touch this when you add more categories, or if you want to add more vendors
- machines.yml contains a castrated vending machine prototype made as the base store machine prototype, and the 2 NCWL and DSM vending machine entities

TODO:
- new sprites for DSM and NCWL id's to look like an imperial paper(?) seal, and a soviet brooch. i think volgin got this
- new sprites for the vendors themselves
- actual fucking catalog for both vending machines