### PR TITLE
Adds several salvage recipes for industry, and several scrap items

### DIFF
--- a/Resources/Locale/en-US/_Crescent/materials/materials.ftl
+++ b/Resources/Locale/en-US/_Crescent/materials/materials.ftl
@@ -1,6 +1,9 @@
 ## scrap
-materials-scrap-steel = steel scrap
-materials-scrap-titanium =  titanium scrap
+materials-scrap-lowgrade = low-grade metal scrap
+materials-scrap-highgrade =  high-grade metal scrap
+materials-scrap-circuit = damaged electronics
+materials-scrap-plasma = plasma isotope salvage
+materials-scrap-uranium = discarded fissiles
 materials-scrap-steelrefined = refined steel scrap
 materials-scrap-titaniumrefined = refined titanium scrap
 materials-garbage = industrial garbage
@@ -10,13 +13,13 @@ materials-isotopes = volatile plasma isotopes
 materials-galine = galine-5 gas
 materials-chemphoron = deactivated phoron isotopes
 
-##starship parts
+## starship parts
 
 materials-engine = shuttle engine components
 materials-hull = shuttle hull plating
 materials-electronicship = shuttle electronics
 
-#craftparts
+# craftparts
 
 materials-basicelectronics = basic electronic parts
 materials-advancedelectronics = advanced electronic parts

--- a/Resources/Maps/_Crescent/Event/triumphant.yml
+++ b/Resources/Maps/_Crescent/Event/triumphant.yml
@@ -6979,14 +6979,14 @@ entities:
     - type: Transform
       pos: -11.503976,2.7147357
       parent: 1
-- proto: ScrapCircuit
+- proto: ScrapCircuit1
   entities:
   - uid: 859
     components:
     - type: Transform
       pos: -12.074517,3.0066154
       parent: 1
-- proto: ScrapPlasma
+- proto: ScrapPlasma1
   entities:
   - uid: 860
     components:

--- a/Resources/Maps/_Crescent/Shuttles/Fog/radiant.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Fog/radiant.yml
@@ -3154,7 +3154,7 @@ entities:
     - type: Transform
       pos: 1.8334126,-9.462616
       parent: 1
-- proto: ScrapPlasma
+- proto: ScrapPlasma3
   entities:
   - uid: 675
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCSP/eradicator.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/eradicator.yml
@@ -4898,14 +4898,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 1
-- proto: ScrapCircuit
+- proto: ScrapCircuit1
   entities:
   - uid: 468
     components:
     - type: Transform
       pos: -1.2676353,-7.6164103
       parent: 1
-- proto: ScrapPlasma
+- proto: ScrapPlasma1
   entities:
   - uid: 467
     components:

--- a/Resources/Maps/_Crescent/Stations/jackal.yml
+++ b/Resources/Maps/_Crescent/Stations/jackal.yml
@@ -17982,7 +17982,7 @@ entities:
     - type: Transform
       pos: 17.855978,14.563066
       parent: 1
-- proto: ScrapCircuit
+- proto: ScrapCircuit1
   entities:
   - uid: 1040
     components:
@@ -17994,7 +17994,7 @@ entities:
     - type: Transform
       pos: 1.7305666,23.739513
       parent: 1
-- proto: ScrapPlasma
+- proto: ScrapPlasma1
   entities:
   - uid: 1041
     components:

--- a/Resources/Maps/_Crescent/Stations/surezai.yml
+++ b/Resources/Maps/_Crescent/Stations/surezai.yml
@@ -15531,7 +15531,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 27.320206,11.96379
       parent: 1
-- proto: ScrapCircuit
+- proto: ScrapCircuit1
   entities:
   - uid: 2130
     components:
@@ -15547,7 +15547,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 29.609648,9.611828
       parent: 1
-- proto: ScrapPlasma
+- proto: ScrapPlasma1
   entities:
   - uid: 2128
     components:

--- a/Resources/Maps/_NF/POI/tinnia.yml
+++ b/Resources/Maps/_NF/POI/tinnia.yml
@@ -6825,7 +6825,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: ScrapCircuit
+- proto: ScrapCircuit1
   entities:
   - uid: 117
     components:

--- a/Resources/Prototypes/_Crescent/Entities/Materials/scrap.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Materials/scrap.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: OreBase
   id: SteelScrapOre
-  name: scrapsteel shards
-  description: Scraps of steel blasted off larger structures.
+  name: low-grade metal shards
+  description: Scraps of steel and fused power cables blasted off larger structures.
   suffix: Full
   components:
   - type: Stack
@@ -17,7 +17,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      ScrapSteel: 500
+      ScrapLowGrade: 500
 
 - type: entity
   id: SteelScrap1
@@ -66,8 +66,8 @@
 - type: entity
   parent: OreBase
   id: TitaniumScrapOre
-  name: titanium scrap
-  description: Pile of titanium scrap, blasted off a larger structure.
+  name: high-grade metal shards
+  description: Pile of good quality scrap, blasted off a larger industrial or military structure.
   suffix: Full
   components:
   - type: Tag
@@ -81,7 +81,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      ScrapTitanium: 500
+      ScrapHighGrade: 500
 
 - type: entity
   id: TitaniumScrap1
@@ -94,7 +94,7 @@
 - type: entity
   id: TitaniumScrap6
   parent: TitaniumScrapOre
-  suffix: Single
+  suffix: Six
   components:
     - type: Stack
       count: 6
@@ -102,7 +102,7 @@
 - type: entity
   id: TitaniumScrap17
   parent: TitaniumScrapOre
-  suffix: Single
+  suffix: Seventeen
   components:
     - type: Stack
       count: 17
@@ -110,38 +110,158 @@
 - type: entity
   id: TitaniumScrap25
   parent: TitaniumScrapOre
-  suffix: Single
+  suffix: Twenty Five
   components:
     - type: Stack
       count: 25
 
-#single-use scrap
+#circuit
 
 - type: entity
-  parent: BaseItem
+  parent: OreBase
   id: ScrapCircuit
-  name: destroyed electronics
+  name: damaged electronics
   description: A pile of scrap electronics, ripped out of a larger machine.
+  suffix: Full
   components:
+  - type: Stack
+    stackType: ScrapCircuit
+  - type: Tag
+    tags:
+    - RawMaterial
   - type: Sprite
     sprite: _Crescent/Objects/Misc/scrapcircuit.rsi
-    layers:
-    - state: icon
-  - type: StaticPrice
-    price: 250
+    state: icon
+  - type: Material
+  - type: PhysicalComposition
+    materialComposition:
+      ScrapCircuit: 500
 
 - type: entity
-  parent: BaseItem
-  id: ScrapPlasma
-  name: destroyed plasma pump
-  description: A pile of scrap plasma, ripped out of a larger machine.
+  id: ScrapCircuit1
+  parent: ScrapCircuit
+  suffix: Single
   components:
+    - type: Stack
+      count: 1
+
+- type: entity
+  id: ScrapCircuit5
+  parent: ScrapCircuit
+  suffix: Five
+  components:
+    - type: Stack
+      count: 5
+
+- type: entity
+  id: ScrapCircuit10
+  parent: ScrapCircuit
+  suffix: Ten
+  components:
+    - type: Stack
+      count: 10
+
+- type: entity
+  id: ScrapCircuit20
+  parent: ScrapCircuit
+  suffix: Twenty
+  components:
+    - type: Stack
+      count: 20
+
+#plasma
+
+- type: entity
+  parent: OreBase
+  id: ScrapPlasma
+  name: plasma isotope salvage
+  description: A pile of broken pumps or perhaps canisters, ripped out of an engine and still leaking valuable plasma.
+  suffix: Full
+  components:
+  - type: Stack
+    stackType: ScrapPlasma
+  - type: Tag
+    tags:
+    - RawMaterial
   - type: Sprite
     sprite: _Crescent/Objects/Misc/scraplasma.rsi
-    layers:
-    - state: icon
-  - type: StaticPrice
-    price: 325
+    state: icon
+  - type: Material
+  - type: PhysicalComposition
+    materialComposition:
+      ScrapPlasma: 500
+
+- type: entity
+  id: ScrapPlasma1
+  parent: ScrapPlasma
+  suffix: Single
+  components:
+    - type: Stack
+      count: 1
+
+- type: entity
+  id: ScrapPlasma3
+  parent: ScrapPlasma
+  suffix: Three
+  components:
+    - type: Stack
+      count: 3
+
+- type: entity
+  id: ScrapPlasma5
+  parent: ScrapPlasma
+  suffix: Five
+  components:
+    - type: Stack
+      count: 5
+
+#uranium
+
+- type: entity
+  parent: OreBase
+  id: ScrapUranium
+  name: discarded fissiles
+  description: Spent uranium cells, discarded radio-thermal components, and other radioactive elements that could be reused.
+  suffix: Full
+  components:
+  - type: Stack
+    stackType: ScrapUranium
+  - type: Tag
+    tags:
+    - RawMaterial
+  - type: Sprite
+    sprite: _Crescent/Objects/Misc/scrapuranium.rsi
+    state: icon
+  - type: Material
+  - type: PhysicalComposition
+    materialComposition:
+      ScrapUranium: 500
+
+- type: entity
+  id: ScrapUranium1
+  parent: ScrapUranium
+  suffix: Single
+  components:
+    - type: Stack
+      count: 1
+
+- type: entity
+  id: ScrapUranium3
+  parent: ScrapUranium
+  suffix: Three
+  components:
+    - type: Stack
+      count: 3
+
+- type: entity
+  id: ScrapUranium5
+  parent: ScrapUranium
+  suffix: Five
+  components:
+    - type: Stack
+      count: 5
+
+#single-use scrap
 
 - type: entity
   parent: BaseItem
@@ -155,19 +275,6 @@
     - state: icon
   - type: StaticPrice
     price: 500
-
-- type: entity
-  parent: BaseItem
-  id: ScrapUranium
-  name: spent uranium cell
-  description: A spent uranium cell, discarded. May still be of some use to scrappers.
-  components:
-  - type: Sprite
-    sprite: _Crescent/Objects/Misc/scrapuranium.rsi
-    layers:
-    - state: icon
-  - type: StaticPrice
-    price: 850
 
 - type: entity
   parent: BaseItem
@@ -363,6 +470,7 @@
   components:
   - type: Tag
     tags:
+    - RawMaterial
     - DrugComponent
   - type: Stack
     stackType: RefinedGarbageOre

--- a/Resources/Prototypes/_Crescent/Entities/Reagents/materials.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Reagents/materials.yml
@@ -1,18 +1,42 @@
 - type: material
-  id: ScrapSteel
+  id: ScrapLowGrade
   stackEntity: SteelScrap1
-  name: materials-scrap-steel
+  name: materials-scrap-lowgrade
   unit: materials-unit-chunk
   icon: { sprite: _Crescent/Objects/Materials/ore.rsi, state: icon-scrap }
   price: 0.08
 
 - type: material
-  id: ScrapTitanium
+  id: ScrapHighGrade
   stackEntity: TitaniumScrap1
-  name: materials-scrap-titanium
+  name: materials-scrap-highgrade
   unit: materials-unit-chunk
   icon: { sprite: _Crescent/Objects/Materials/ore.rsi, state: icon-titaniumscrap }
   price: 0.1
+
+- type: material
+  id: ScrapCircuit
+  stackEntity: ScrapCircuit1
+  name: materials-scrap-circuit
+  unit: materials-unit-chunk
+  icon: { sprite: _Crescent/Objects/Misc/scrapcircuit.rsi, state: icon }
+  price: 0.2
+
+- type: material
+  id: ScrapPlasma
+  stackEntity: ScrapPlasma1
+  name: materials-scrap-plasma
+  unit: materials-unit-chunk
+  icon: { sprite: _Crescent/Objects/Misc/scraplasma.rsi, state: icon }
+  price: 0.5
+
+- type: material
+  id: ScrapUranium
+  stackEntity: ScrapUranium1
+  name: materials-scrap-uranium
+  unit: materials-unit-chunk
+  icon: { sprite: _Crescent/Objects/Misc/scrapuranium.rsi, state: icon }
+  price: 0.8
 
 - type: material
   id: RefinedScrapSteel

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/scrap.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/scrap.yml
@@ -4,14 +4,14 @@
   result: RefinedSteelScrap1
   completetime: 0.25
   materials:
-    ScrapSteel: 500
+    ScrapLowGrade: 500
 
 - type: latheRecipe
   id: TitaniumScrap
   result: RefinedTitaniumScrap1
   completetime: 0.25
   materials:
-    ScrapTitanium: 500
+    ScrapHighGrade: 500
 
 - type: latheRecipe
   id: Garbage
@@ -21,29 +21,184 @@
     Garbage: 500
 
 - type: latheRecipe
-  id: SteelScraptoSteel1
+  id: PlasticFromGarbage10
+  result: SheetPlastic10
+  completetime: 0.25
+  materials:
+    RefinedGarbage: 3000
+
+- type: latheRecipe
+  id: PlasticFromGarbage
+  result: SheetPlastic
+  completetime: 0.25
+  materials:
+    RefinedGarbage: 6000
+
+- type: latheRecipe
+  id: SteelFromScrapLowGrade1
   result: SheetSteel1
   completetime: 0.25
   materials:
-    ScrapSteel: 100
+    ScrapLowGrade: 100
 
 - type: latheRecipe
-  id: SteelScraptoSteel
+  id: SteelFromScrapLowGrade
   result: SheetSteel
   completetime: 0.25
   materials:
-    ScrapSteel: 3000
+    ScrapLowGrade: 3000
 
 - type: latheRecipe
-  id: PlasteelFromScrap1
+  id: CopperFromScrapLowGrade1
+  result: IngotCopper1
+  completetime: 0.25
+  materials:
+    ScrapLowGrade: 100
+
+- type: latheRecipe
+  id: CopperFromScrapLowGrade
+  result: IngotCopper
+  completetime: 0.25
+  materials:
+    ScrapLowGrade: 3000
+
+
+- type: latheRecipe
+  id: PlasteelFromScrapHighGrade1
   result: SheetPlasteel1
   completetime: 0.25
   materials:
-    ScrapTitanium: 200
+    ScrapHighGrade: 200
 
 - type: latheRecipe
-  id: PlasteelFromScrap
+  id: PlasteelFromScrapHighGrade
   result: SheetPlasteel
   completetime: 0.25
   materials:
-    ScrapTitanium: 6000
+    ScrapHighGrade: 6000
+
+- type: latheRecipe
+  id: TungstenFromScrapHighGrade1
+  result: IngotTungsten1
+  completetime: 0.25
+  materials:
+    ScrapHighGrade: 250
+
+- type: latheRecipe
+  id: TungstenFromScrapHighGrade
+  result: IngotTungsten
+  completetime: 0.25
+  materials:
+    ScrapHighGrade: 7000
+
+- type: latheRecipe
+  id: GoldFromScrapCircuit1
+  result: IngotGold1
+  completetime: 0.25
+  materials:
+    ScrapCircuit: 250
+
+- type: latheRecipe
+  id: GoldFromScrapCircuit
+  result: IngotGold
+  completetime: 0.25
+  materials:
+    ScrapCircuit: 7000
+
+- type: latheRecipe
+  id: SilverFromScrapCircuit1
+  result: IngotSilver1
+  completetime: 0.25
+  materials:
+    ScrapCircuit: 200
+
+- type: latheRecipe
+  id: SilverFromScrapCircuit
+  result: IngotSilver
+  completetime: 0.25
+  materials:
+    ScrapCircuit: 6000
+
+- type: latheRecipe
+  id: PlasmaFromScrapPlasma1
+  result: SheetPlasma1
+  completetime: 0.25
+  materials:
+    ScrapPlasma: 250
+
+- type: latheRecipe
+  id: PlasmaFromScrapPlasma
+  result: SheetPlasma
+  completetime: 0.25
+  materials:
+    ScrapPlasma: 5000
+
+- type: latheRecipe
+  id: PhoronFromScrapPlasma
+  result: DeactivatedPhoronBottle5
+  completetime: 0.25
+  materials:
+    ScrapPlasma: 2500
+
+- type: latheRecipe
+  id: IsotopesFromScrapPlasma
+  result: PlasmaIsotope5
+  completetime: 0.25
+  materials:
+    ScrapPlasma: 2500
+
+- type: latheRecipe
+  id: UraniumFromScrapUranium1
+  result: SheetUranium1
+  completetime: 0.25
+  materials:
+    ScrapUranium: 500
+
+- type: latheRecipe
+  id: UraniumFromScrapUranium
+  result: SheetUranium
+  completetime: 0.25
+  materials:
+    ScrapUranium: 8000
+
+- type: latheRecipe
+  id: FibreAlloyFromCombinedScrap
+  result: PlastitaniumFibreAlloy1
+  completetime: 0.5
+  materials:
+    ScrapHighGrade: 3000
+    RefinedScrapTitanium: 2000
+    ScrapPlasma: 1000
+
+- type: latheRecipe
+  id: BasicElectronicsFromCombinedScrap
+  result: BasicElectronics1
+  completetime: 0.5
+  materials:
+    RefinedGarbage: 1000
+    ScrapCircuit: 250
+
+- type: latheRecipe
+  id: BasicMechatronicsFromCombinedScrap
+  result: BasicMechatronics1
+  completetime: 0.5
+  materials:
+    RefinedScrapSteel: 1000
+    RefinedScrapTitanium: 250
+
+- type: latheRecipe
+  id: BallisticCyclerFromCombinedScrap
+  result: BallisticCycler1
+  completetime: 0.5
+  materials:
+    RefinedScrapSteel: 5000
+    RefinedScrapTitanium: 3000
+
+- type: latheRecipe
+  id: HardsuitElectronicsFromCombinedScrap
+  result: HardsuitElectronics1
+  completetime: 0.5
+  materials:
+    RefinedScrapSteel: 3000
+    ScrapCircuit: 1000
+    ScrapUranium: 500

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -28,10 +28,31 @@
     - SteelScrap
     - TitaniumScrap
     - Garbage
-    - PlasteelFromScrap1
-    - PlasteelFromScrap
-    - SteelScraptoSteel
-    - SteelScraptoSteel1
+    - PlasticFromGarbage10
+    - PlasticFromGarbage
+    - PlasteelFromScrapHighGrade1
+    - PlasteelFromScrapHighGrade
+    - TungstenFromScrapHighGrade1
+    - TungstenFromScrapHighGrade
+    - SteelFromScrapLowGrade1
+    - SteelFromScrapLowGrade
+    - CopperFromScrapLowGrade1
+    - CopperFromScrapLowGrade
+    - GoldFromScrapCircuit1
+    - GoldFromScrapCircuit
+    - SilverFromScrapCircuit1
+    - SilverFromScrapCircuit
+    - PlasmaFromScrapPlasma1
+    - PlasmaFromScrapPlasma
+    - PhoronFromScrapPlasma
+    - IsotopesFromScrapPlasma
+    - UraniumFromScrapUranium1
+    - UraniumFromScrapUranium
+    - FibreAlloyFromCombinedScrap
+    - BasicElectronicsFromCombinedScrap
+    - BasicMechatronicsFromCombinedScrap
+    - BallisticCyclerFromCombinedScrap
+    - HardsuitElectronicsFromCombinedScrap
 
 - type: entity
   parent: [ BaseMachinePowered, ConstructibleMachine ]
@@ -61,11 +82,31 @@
     - SteelScrap
     - TitaniumScrap
     - Garbage
-    - PlasteelFromScrap1
-    - PlasteelFromScrap
-    - SteelScraptoSteel
-    - SteelScraptoSteel1
-
+    - PlasticFromGarbage10
+    - PlasticFromGarbage
+    - PlasteelFromScrapHighGrade1
+    - PlasteelFromScrapHighGrade
+    - TungstenFromScrapHighGrade1
+    - TungstenFromScrapHighGrade
+    - SteelFromScrapLowGrade1
+    - SteelFromScrapLowGrade
+    - CopperFromScrapLowGrade1
+    - CopperFromScrapLowGrade
+    - GoldFromScrapCircuit1
+    - GoldFromScrapCircuit
+    - SilverFromScrapCircuit1
+    - SilverFromScrapCircuit
+    - PlasmaFromScrapPlasma1
+    - PlasmaFromScrapPlasma
+    - PhoronFromScrapPlasma
+    - IsotopesFromScrapPlasma
+    - UraniumFromScrapUranium1
+    - UraniumFromScrapUranium
+    - FibreAlloyFromCombinedScrap
+    - BasicElectronicsFromCombinedScrap
+    - BasicMechatronicsFromCombinedScrap
+    - BallisticCyclerFromCombinedScrap
+    - HardsuitElectronicsFromCombinedScrap
 
 #drugs
 

--- a/Resources/Prototypes/_Crescent/Stacks/scrap.yml
+++ b/Resources/Prototypes/_Crescent/Stacks/scrap.yml
@@ -2,14 +2,14 @@
 
 - type: stack
   id: SteelScrapOre
-  name: scrapsteel shards
+  name: low-grade metal shards
   icon: { sprite: /Textures/_Crescent/Objects/Materials/ore.rsi, state: icon-scrap }
   spawn: SteelScrap1
   maxCount: 30
 
 - type: stack
   id: TitaniumScrapOre
-  name: titanium scrap
+  name: high-grade metal shards
   icon: { sprite: /Textures/_Crescent/Objects/Materials/ore.rsi, state: icon-titaniumscrap }
   spawn: TitaniumScrap1
   maxCount: 30
@@ -26,6 +26,27 @@
   name: refined titanium scrap
   icon: { sprite: /Textures/_Crescent/Objects/Materials/ore.rsi, state: icon-titta }
   spawn: RefinedTitaniumScrap1
+  maxCount: 30
+
+- type: stack
+  id: ScrapCircuit
+  name: damaged electronics
+  icon: { sprite: /_Crescent/Objects/Misc/scrapcircuit.rsi, state: icon }
+  spawn: ScrapCircuit1
+  maxCount: 30
+
+- type: stack
+  id: ScrapPlasma
+  name: plasma isotope salvage
+  icon: { sprite: /_Crescent/Objects/Misc/scraplasma.rsi, state: icon }
+  spawn: ScrapPlasma1
+  maxCount: 30
+
+- type: stack
+  id: ScrapUranium
+  name: discarded fissiles
+  icon: { sprite: /_Crescent/Objects/Misc/scrapuranium.rsi, state: icon }
+  spawn: ScrapUranium1
   maxCount: 30
 
 #drugmaking


### PR DESCRIPTION
Specifically allows the salvaging of the following materials from scrap: Plastic, steel, copper, plasteel, tungsten, silver, gold, plasma and uranium.

Alongside allowing upcyclers to produce basic mechatronics, electronics, hardsuit electronics, ballistic cyclers, and plastitanium fiber alloy at a higher expense if standard methods of acquisition is unavailable.

Also added in being able to produce Phoron and Plasma-9 Isotope from discarded plasma because I remembered people getting high off gasoline fumes, plus it gives IPM a good case reason to bother trading with SAW or perhaps independent traders for some of their chemicals.

The edited ships by the way is to not have them spawn with 30 stacks of the stuff for balancing reasons.