### PR TITLE
Remove SSD sign indicator

### DIFF
--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -44,5 +44,5 @@ public sealed partial class CCVars
     ///     Control displaying SSD indicators near players
     /// </summary>
     public static readonly CVarDef<bool> ICShowSSDIndicator =
-        CVarDef.Create("ic.show_ssd_indicator", true, CVar.CLIENTONLY);
+        CVarDef.Create("ic.show_ssd_indicator", false, CVar.CLIENTONLY);
 }


### PR DESCRIPTION
Still shows that someone is SSD if you inspect their description, just not on the character itself.
The sign shows up on people that use the gnosis psionic and reveals people who disconnect in the dark. also kind of makes characters standing around less appealing to look at due to the big glowing green sign indicating they're SSD due to which i believe it should be removed.