### PR TITLE
revert mech friction and acceleration

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Specific/mechs.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Specific/mechs.yml
@@ -38,8 +38,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
     baseSprintSpeed: 4.5
-    weightlessFriction: 0
-    weightlessAcceleration: 0.3
     weightlessModifier: 4.5 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
@@ -110,8 +108,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 3.5
-    weightlessFriction: 0
-    weightlessAcceleration: 0.1
     weightlessModifier: 4.75 # 15ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
@@ -179,8 +175,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.9
     baseSprintSpeed: 3.5
-    weightlessFriction: 0
-    weightlessAcceleration: 0.2
     weightlessModifier: 6.25 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
@@ -247,8 +241,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.5
     baseSprintSpeed: 5.5
-    weightlessFriction: 0
-    weightlessAcceleration: 0.25
     weightlessModifier: 4 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
@@ -319,8 +311,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
     baseSprintSpeed: 1.85
-    weightlessFriction: 0
-    weightlessAcceleration: 0.1
     weightlessModifier: 5.5 # 10ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
@@ -392,8 +382,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 3.5
-    weightlessFriction: 0
-    weightlessAcceleration: 0.15
     weightlessModifier: 4.75 # 15ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
@@ -474,8 +462,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.9
     baseSprintSpeed: 3.5
-    weightlessFriction: 0
-    weightlessAcceleration: 0.2
     weightlessModifier: 6.25 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching


### PR DESCRIPTION
the friction and acceleration modifier makes mechs considerably slower than originally intended if either modifier is removed and currently makes the mechs drag on in space making it inconvenient to use in space while already being extremely vulnerable.