### PR TITLE
Cargo deeds fixes

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/space_cash.yml
@@ -1,0 +1,43 @@
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash1500
+  suffix: 1500
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi 
+    state: cash_1000 
+  - type: Stack
+    count: 1500
+    
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash3500
+  suffix: 3500
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi 
+    state: cash_1000
+  - type: Stack
+    count: 3500
+    
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash4500
+  suffix: 4500
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi 
+    state: cash_1000
+  - type: Stack
+    count: 4500
+    
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash6000
+  suffix: 6000
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi
+    state: cash_5000 
+  - type: Stack
+    count: 6000

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/trade.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/trade.yml
@@ -532,7 +532,7 @@
   parent: BaseItem
   id: TradeDeedLow
   name: deed of delivery
-  description: A printed deed of delivery. Blocky letting informs that this deed is one thousand Union credits to an official chartered station.
+  description: A printed deed of delivery. Blocky letting informs that this deed is one thousand and five hundred Union credits to an official chartered station.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/TradeGoods/deed.rsi
@@ -543,7 +543,7 @@
   parent: BaseItem
   id: TradeDeedNormal
   name: deed of delivery
-  description: A printed deed of delivery. Blocky letting informs that this deed is worth two thousand Union credits to an official chartered station.
+  description: A printed deed of delivery. Blocky letting informs that this deed is worth three thousand and five hundred Union credits to an official chartered station.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/TradeGoods/deed.rsi
@@ -554,7 +554,7 @@
   parent: BaseItem
   id: TradeDeedHigh
   name: deed of delivery
-  description: A printed deed of delivery. Blocky letting informs that this deed is worth three thousand and five hundred Union credits to an official chartered station.
+  description: A printed deed of delivery. Blocky letting informs that this deed is worth four thousand and five hundred Union credits to an official chartered station.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/TradeGoods/deed.rsi
@@ -565,7 +565,7 @@
   parent: BaseItem
   id: TradeDeedVeryHigh
   name: deed of delivery
-  description: A printed deed of delivery. Blocky letting informs that this deed is worth five thousand Union credits to an official chartered station.
+  description: A printed deed of delivery. Blocky letting informs that this deed is worth six thousand Union credits to an official chartered station.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/TradeGoods/deed.rsi
@@ -576,7 +576,7 @@
   parent: BaseItem
   id: TradeDeedExotic
   name: deed of delivery
-  description: A printed deed of delivery. Blocky letting informs that this deed is worth eight thousand Union credits to an official chartered station.
+  description: A printed deed of delivery. Blocky letting informs that this deed is worth ten thousand Union credits to an official chartered station.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/TradeGoods/deed.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

fixes #271 
Changes the desc of cargo deeds to be accurate to the intended payout (it wasn't before)
Fixed it so all cargo deeds who didn't have payouts now do, includes but is not limited to the following payouts:
Low
Normal
High
VeryHigh

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [X] Add the according space cash ammount to the corresponding deeds
- [X] Adjust price payout in deed description
---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/48c83b07-b59f-4023-88b9-5c17af73bebb


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog

:cl:
- fix: Cargo deeds now hand in the correct indicated value
- fix: Cargo deeds now all give payouts.