### PR TITLE
NTID Chips Worth Money

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/idchips.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/idchips.yml
@@ -8,6 +8,8 @@
     sprite: _Crescent/Objects/Misc/ntid.rsi
     layers:
       - state: chip
+  - type: StaticPrice
+    price: 5000
 
 - type: entity
   parent: BaseItem
@@ -19,6 +21,8 @@
     sprite: _Crescent/Objects/Misc/ntid.rsi
     layers:
       - state: chip
+  - type: StaticPrice
+    price: 8500
 
 - type: entity
   parent: BaseItem
@@ -30,6 +34,8 @@
     sprite: _Crescent/Objects/Misc/ntid.rsi
     layers:
       - state: abyssal
+  - type: StaticPrice
+    price: 10000
 
 - type: startingGear
   id: LowRiskCriminalLoot


### PR DESCRIPTION
# Description

Gave the NTID chips a static sell price. Below are the prices for the chips ordered from lowest to highest. You can sell these NTID chips for money at any sell pad. Temporary addition until Aisha adds in a proper bounty post, mostly meant for NCWL so they can get on their feet.

Low-Tier Criminal: 5,000 Taypani Yen
Regular Criminal: 8,500 Taypani Yen
Abyssal Creature: 10,000 Taypani Yen

---

# TODO

- [x] Give NTID Chips a static sell price

---

# Changelog

:cl: ShirouAjisai
- add: Gave NTID chips a static sell price.