### PR TITLE
lancer MRM is called a medium instead of light missile system now

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/turrets.yml
@@ -648,7 +648,7 @@
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretLancer
-  name: light 'Lancer' MRM missile system
+  name: medium 'Lancer' MRM missile system
   components:
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/lancemissile.rsi


### PR DESCRIPTION
swarmers are the lightest missile peashoters, lancers are the medium versions according to some nerds that noticed this discrepancy