### PR TITLE
Anti Psionic Response Teams

### DIFF
--- a/Resources/Locale/en-US/_Crescent/job/job-names.ftl
+++ b/Resources/Locale/en-US/_Crescent/job/job-names.ftl
@@ -133,3 +133,9 @@ job-name-conscript-dsm-smg = Squire (SMG)
 job-name-conscript-dsm-shotgun = Squire (Shotgun)
 job-name-conscript-dsm-rifleman = Armsman (Rifle)
 job-name-conscript-dsm-cadet = Recruit
+
+#anti psionic response teams ath
+
+job-name-aprt-kanoneer = Panzerfeldwebel
+job-name-aprt-sanitat = Panzersanitat
+job-name-aprt-soldat = Panzergrenadier

--- a/Resources/Locale/en-US/_Crescent/rank/ranks.ftl
+++ b/Resources/Locale/en-US/_Crescent/rank/ranks.ftl
@@ -94,8 +94,8 @@ crescent-rank-servile = Servile
 crescent-rank-kommandant = Kommandant
 crescent-rank-leutnant = Lt.
 crescent-rank-soldatATH = PvT.
-crescent-rank-sanitat = PvT.
-crescent-rank-kanoneer = Cpl.
+crescent-rank-sanitat = Cpl.
+crescent-rank-kanoneer = Sgt.
 crescent-rank-steward = Steward
 crescent-rank-logistat = Marshallie
 

--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
@@ -393,3 +393,95 @@
     containers:
       item:
       - DSMRapier
+
+# Anti Psionic Response Team - ATH
+
+- type: entity
+  id: ClothingBeltAuthorityWebbingFilled
+  parent: ClothingBeltAuthorityWebbing
+  name: ballistic combat webbing
+  suffix: Filled
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,7,1
+  - type: StorageFill
+    contents:
+    - id: MagazineRifle
+      amount: 5
+    - id: PTAWarcrimeHandgrenade
+      amount: 2
+    - id: PTAImpactHandgrenade
+      amount: 2
+
+- type: entity
+  id: ClothingBeltAuthorityPouchesFilled
+  parent: ClothingBeltAuthorityPouches
+  name: tactical combat pouches
+  suffix: Filled
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,7,1
+  - type: StorageFill
+    contents:
+    - id: MagazineRifle
+      amount: 5
+    - id: PTAWarcrimeHandgrenade
+      amount: 2
+    - id: PTAImpactHandgrenade
+      amount: 2
+
+- type: entity
+  id: ClothingBeltAuthorityDroppouchesFilled
+  parent: ClothingBeltAuthorityDroppouches
+  name: tactical droppouches
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: MagazineRifle
+      amount: 3
+    - id: EpinephrineChemistryBottle
+      amount: 1
+    - id: EphedrineChemistryBottle
+      amount: 1
+    - id: OmnizineChemistryBottle
+    - id: MedkitCombatFilled
+    - id: Syringe
+      amount: 1
+    - id: Gauze
+      amount: 1
+
+# Anti Psionic Response Team - SRM
+
+- type: entity
+  id: ClothingBeltTacticalRigFilled
+  parent: ClothingBeltTacticalRig
+  name: tactical rig
+  suffix: Filled
+  components:
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,7,1
+  - type: StorageFill
+    contents:
+    - id: MagazineLightRifle
+      amount: 4
+    - id: M14IncendiaryHandgrenade
+      amount: 1
+    - id: M18SmokeHandgrenade
+      amount: 1
+    - id: F1Handgrenade
+      amount: 1
+    - id: Gauze
+      amount: 1

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Devices/pda.yml
@@ -1192,6 +1192,50 @@
   - type: Icon
     state: pda-bartender
 
+#anti psionic response team
+
+- type: entity
+  parent: BasePDA
+  id: APRTKanoneerPDA
+  name: panzerfeldwebel's PDA
+  description: Gunmetal gray.
+  components:
+  - type: Pda
+    id: APRTIDCardKanoneer
+    state: pda-bartender
+  - type: PdaBorderColor
+    borderColor: "#535961"
+  - type: Icon
+    state: pda-bartender
+
+- type: entity
+  parent: BasePDA
+  id: APRTSanitatPDA
+  name: panzersanitat's PDA
+  description: Gunmetal gray.
+  components:
+  - type: Pda
+    id: APRTIDCardSanitat
+    state: pda-bartender
+  - type: PdaBorderColor
+    borderColor: "#535961"
+  - type: Icon
+    state: pda-bartender
+
+- type: entity
+  parent: BasePDA
+  id: APRTSoldatPDA
+  name: panzergrenadier's PDA
+  description: Gunmetal gray.
+  components:
+  - type: Pda
+    id: APRTIDCardSoldat
+    state: pda-bartender
+  - type: PdaBorderColor
+    borderColor: "#535961"
+  - type: Icon
+    state: pda-bartender
+
 
 #misc
 

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/identification_cards.yml
@@ -1063,6 +1063,45 @@
   - type: PresetIdCard
     job: ArbeiterATH
 
+#anti psionic response team
+
+- type: entity
+  parent: IDCardStandard
+  id: APRTIDCardKanoneer
+  name: 43rd battlegroup ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: default
+    - state: idquartermaster
+  - type: PresetIdCard
+    job: APRTKanoneerATH
+
+- type: entity
+  parent: IDCardStandard
+  id: APRTIDCardSanitat
+  name: 43rd battlegroup ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: default
+    - state: idquartermaster
+  - type: PresetIdCard
+    job: APRTSanitatATH
+
+- type: entity
+  parent: IDCardStandard
+  id: APRTIDCardSoldat
+  name: 43rd battlegroup ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: default
+    - state: idquartermaster
+  - type: PresetIdCard
+    job: APRTSoldatATH
+
+
 #misc
 
 - type: entity

--- a/Resources/Prototypes/_Crescent/Maps/Ships/ATH/archon.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/ATH/archon.yml
@@ -29,5 +29,6 @@
         - type: StationJobs
           overflowJobs: []
           availableJobs:
-            SoldatATH: [ 2, 2 ]
-            KanoneerATH: [ 1, 1 ]
+            APRTKanoneerATH: [ 1, 1 ]
+            APRTSanitatATH: [ 1, 1 ]
+            APRTSoldatATH: [ 2, 2 ]

--- a/Resources/Prototypes/_Crescent/Maps/Ships/SRM/spider.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SRM/spider.yml
@@ -23,3 +23,9 @@
             prefixCreator: '14'
         - type: VesselDesignation
           designation: vessel-designation-expeditions
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            APRTMontagneSRM: [ 1, 1 ]
+            APRTHunterSRM: [ 2, 2 ]
+            AcolyteSRM: [ 1, 1 ]

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzerfeldwebel.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzerfeldwebel.yml
@@ -1,0 +1,79 @@
+- type: job
+  id: APRTKanoneerATH
+  name: job-name-aprt-kanoneer
+  description: job-description-kanoneer
+  playTimeTracker: JobKanoneerATH
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Human
+        - Reptilian
+        - Oni
+    - !type:FactionRequirement
+      factionID: "ATH"
+  weight: 82
+  startingGear: APRTKanoneerGear
+  alwaysUseSpawner: true
+  icon: "JobIconKanoneer"
+  requireAdminNotify: false
+  supervisors: job-supervisors-ath
+  canBeAntag: false
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: ChatRank
+        rank: crescent-rank-kanoneer
+  access:
+  - EmergencyShuttleRepealAll
+  - Captain
+  - HeadOfPersonnel
+  - ChiefEngineer
+  - ChiefMedicalOfficer
+  - HeadOfSecurity
+  - ResearchDirector
+  - Frontier # Frontier
+  - Cryogenics
+  - Security
+  - Detective
+  - Armory
+  - Brig
+  - Lawyer
+  - Engineering
+  - Mail # Frontier
+  - Medical
+  - Quartermaster
+  - Salvage
+  - Cargo
+  - Research
+  - StationTrafficController # Frontier
+  - Maintenance
+  - External
+  - Theatre
+  - Bar
+  - Chemistry
+  - Kitchen
+  - Chapel
+  - Hydroponics
+  - Atmospherics
+  - Command
+  - Maintenance
+  - Service
+  - External
+  - Authority
+
+- type: startingGear
+  id: APRTKanoneerGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAuthorityKanoneer
+    shoes: ClothingShoesBootsMagCombat
+    head: ClothingHeadHatAuthorityKanoneer
+    gloves: ClothingHandsGlovesCombat
+    outerClothing: ClothingOuterHardsuitAuthorityPanzer
+    suitstorage: JetpackBlueFilled
+    id: APRTKanoneerPDA
+    ears: ClothingHeadsetAuthority
+    pocket1: HandHeldMassScannerEE
+    pocket2: ExtendedEmergencyOxygenTankFilled
+    belt: ClothingBeltAuthorityWebbingFilled
+  inhand:
+  - WeaponRifleTakemura

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzergrenadier.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzergrenadier.yml
@@ -1,0 +1,79 @@
+- type: job
+  id: APRTSoldatATH
+  name: job-name-aprt-soldat
+  description: job-description-soldat
+  playTimeTracker: JobSoldatATH
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Human
+        - Reptilian
+        - Oni
+    - !type:FactionRequirement
+      factionID: "ATH"
+  weight: 80
+  startingGear: APRTSoldatGear
+  alwaysUseSpawner: true
+  icon: "JobIconSoldat"
+  requireAdminNotify: true
+  supervisors: job-supervisors-ath
+  canBeAntag: false
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: ChatRank
+        rank: crescent-rank-soldatATH
+  access:
+  - EmergencyShuttleRepealAll
+  - Captain
+  - HeadOfPersonnel
+  - ChiefEngineer
+  - ChiefMedicalOfficer
+  - HeadOfSecurity
+  - ResearchDirector
+  - Frontier # Frontier
+  - Cryogenics
+  - Security
+  - Detective
+  - Armory
+  - Brig
+  - Lawyer
+  - Engineering
+  - Mail # Frontier
+  - Medical
+  - Quartermaster
+  - Salvage
+  - Cargo
+  - Research
+  - StationTrafficController # Frontier
+  - Maintenance
+  - External
+  - Theatre
+  - Bar
+  - Chemistry
+  - Kitchen
+  - Chapel
+  - Hydroponics
+  - Atmospherics
+  - Command
+  - Maintenance
+  - Service
+  - External
+  - Authority
+
+- type: startingGear
+  id: APRTSoldatGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAuthoritySoldat
+    shoes: ClothingShoesBootsMagCombat
+    head: ClothingHeadHatAuthoritySoldat
+    gloves: ClothingHandsGlovesCombat
+    outerClothing: ClothingOuterHardsuitAuthorityPanzer
+    suitstorage: JetpackBlueFilled
+    id: APRTIDCardSoldat
+    ears: ClothingHeadsetAuthority
+    pocket1: HandHeldMassScannerEE
+    pocket2: ExtendedEmergencyOxygenTankFilled
+    belt: ClothingBeltAuthorityPouchesFilled
+  inhand:
+  - WeaponRifleTakemura

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzersanitat.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzersanitat.yml
@@ -1,0 +1,83 @@
+- type: job
+  id: APRTSanitatATH
+  name: job-name-aprt-sanitat
+  description: job-description-sanitat
+  playTimeTracker: JobSanitatATH
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Human
+        - Reptilian
+        - Oni
+    - !type:FactionRequirement
+      factionID: "ATH"
+  weight: 81
+  startingGear: APRTSanitatGear
+  alwaysUseSpawner: true
+  icon: "JobIconSanitat"
+  requireAdminNotify: true
+  supervisors: job-supervisors-ath
+  canBeAntag: false
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: ChatRank
+        rank: crescent-rank-sanitat
+      - type: CPRTraining
+      - type: SurgerySpeedModifier
+        speedModifier: 2
+  access:
+  - EmergencyShuttleRepealAll
+  - Captain
+  - HeadOfPersonnel
+  - ChiefEngineer
+  - ChiefMedicalOfficer
+  - HeadOfSecurity
+  - ResearchDirector
+  - Frontier # Frontier
+  - Cryogenics
+  - Security
+  - Detective
+  - Armory
+  - Brig
+  - Lawyer
+  - Engineering
+  - Mail # Frontier
+  - Medical
+  - Quartermaster
+  - Salvage
+  - Cargo
+  - Research
+  - StationTrafficController # Frontier
+  - Maintenance
+  - External
+  - Theatre
+  - Bar
+  - Chemistry
+  - Kitchen
+  - Chapel
+  - Hydroponics
+  - Atmospherics
+  - Command
+  - Maintenance
+  - Service
+  - External
+  - Authority
+  - Authoritymed
+
+- type: startingGear
+  id: APRTSanitatGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAuthoritySanitat
+    shoes: ClothingShoesBootsMagCombat
+    head: ClothingHeadHatAuthoritySanitat
+    gloves: ClothingHandsGlovesCombat
+    outerClothing: ClothingOuterHardsuitAuthorityPanzer
+    suitstorage: JetpackBlueFilled
+    id: APRTIDCardSanitat
+    ears: ClothingHeadsetAuthority
+    pocket1: HandHeldMassScannerEE
+    pocket2: ExtendedEmergencyOxygenTankFilled
+    belt: ClothingBeltAuthorityDroppouchesFilled
+  inhand:
+  - WeaponRifleTakemura

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/srmhunter.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/srmhunter.yml
@@ -1,0 +1,48 @@
+- type: job
+  id: APRTHunterSRM
+  name: job-name-hunter
+  description: job-description-hunter
+  playTimeTracker: JobHunterSRM
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterOverallTimeRequirement
+      min: 20000
+    - !type:FactionRequirement
+      factionID: "SRM"
+  weight: 22
+  startingGear: APRTHunterGear
+  alwaysUseSpawner: true
+  icon: "JobIconHunter"
+  requireAdminNotify: false
+  supervisors: job-supervisors-imperial
+  canBeAntag: false
+  access:
+  - Command
+  - Hunter
+  - Maintenance
+  - Service
+  - External
+  - Mercenary # Frontier
+  - Captain # Frontier
+  special:
+    - !type:AddComponentSpecial
+      components:
+        - type: Telepathic
+
+- type: startingGear
+  id: APRTHunterGear
+  equipment:
+    id: HunterPDA
+    ears: ClothingHeadsetHunter
+    jumpsuit: ClothingUniformJumpsuitHunter
+    shoes: ClothingShoesBootsMagCombat
+    outerClothing: ClothingOuterHardsuitHunter
+    suitstorage: JetpackBlueFilled
+    gloves: ClothingHandsGlovesHunter
+    pocket1: HandHeldMassScannerEE
+    pocket2: ExtendedEmergencyOxygenTankFilled
+    belt: ClothingBeltTacticalRigFilled
+  inhand:
+  - WeaponRifleMiller

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/srmmontagne.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/srmmontagne.yml
@@ -1,0 +1,47 @@
+- type: job
+  id: APRTMontagneSRM
+  name: job-name-montagne
+  description: job-description-montagne
+  playTimeTracker: JobMontagneSRM
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Human
+    - !type:CharacterOverallTimeRequirement
+      min: 40000
+    - !type:FactionRequirement
+      factionID: "SRM"
+  weight: 22
+  startingGear: APRTMontagneGear
+  alwaysUseSpawner: true
+  icon: "JobIconMontagne"
+  requireAdminNotify: false
+  supervisors: job-supervisors-imperial
+  canBeAntag: false
+  access:
+  - Command
+  - Hunter
+  - HunterSenior
+  - Maintenance
+  - Service
+  - External
+  - Mercenary # Frontier
+  - Captain # Frontier
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: Telepathic
+
+- type: startingGear
+  id: APRTMontagneGear
+  equipment:
+    id: MontagnePDA
+    ears: ClothingHeadsetHunter
+    jumpsuit: ClothingUniformJumpsuitHunter
+    shoes: ClothingShoesBootsMagCombat
+    outerClothing: ClothingOuterHardsuitHunterElite
+    suitstorage: JetpackBlueFilled
+    gloves: ClothingHandsGlovesHunter
+    pocket1: HandHeldMassScannerEE
+    pocket2: ExtendedEmergencyOxygenTankFilled
+    belt: ClothingBeltSheathKhopeshFilled

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/Shared/gliessiandockmaster.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/Shared/gliessiandockmaster.yml
@@ -27,6 +27,6 @@
     shoes: ClothingShoesBootsLaceup
     jumpsuit: ClothingUniformJumpsuitCapFormal
     head: ClothingHeadHatCapcap
-    belt: ClothingBeltSheath
+    belt: ClothingBeltSheathFilled
     id: GliessDockmasterPDA
     back: ClothingBackpackSatchelLeatherFilledDSM


### PR DESCRIPTION
PR intending to make it easier for Storytellers to spawn mid round teams that'll lower the glimmer/fog level somehow with less hoop jumping and micromanaging to equip them.

**Added:**
ATH Panzerteam, an Authoritat killteam consisting of two Panzergrenadiers, a Panzersanitat and a Panzerfeldwebel. All suited up in Panzer hardsuits and armed with Takemuras because they were supplied by PTA dead stock. Panzergrenadiers and Panzerfeldwebels get belts with five magazines, two willie petes and two impact grenades. Panzersanitats get a belt with three reloads and some medical supplies.

SRM Fireteam, what it says on the tin. A Montagne, two Hunters and an Apprentice. The Montagne gets the elite hardsuit and a vibrokhopesh, Hunters get salvaged hardsuits and Millers. Apprentice gets nothing. Hunters get a belt with four reloads, gauze and a selection grenades, smoke, incendiary and explosive.

The above teams all get a filled Jetpack, Mass Scanner (EE) and a filled extended oxygen tank, except the Apprentice who gets nothing.

**Changed:**
ATH Archon now has lobbyspawn the APRT type of ATH.
SRM Spider now sort of lobbyspawns the APRT type of SRM, it needs a cryo mapped in to work, else it glitches out bad. 
**The Spider needs fixing up for the rebase, hardpoints aren't setup on it.**

Some ATH ranks changed a bit to have better structure.

Filled the Dockmaster's sabre sheath because it annoyed me during testing.
