### PR TITLE
Adds in the DSM plasma mech weapons + tech

### DIFF
--- a/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
+++ b/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
@@ -77,6 +77,7 @@ research-technology-imperial-laelaps = Imperial Assault Frigate
 research-technology-imperial-nobleweapons = Imperial Nobility Swords
 research-technology-imperial-sunesis = Imperial Exploration Cruiser
 research-technology-imperial-frigate = Imperial Assault Frigate
+research-technology-imperial-plasmamechguns = Plasma Mechasuit Weaponry
 research-technology-imperial-paladin = Imperial Combat Exosuit
 research-technology-imperial-wanderer = Imperial Scout Exosuit
 research-technology-imperial-carrion = Imperial Utility Exosuit

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Ammunition/Projectiles/mech.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Ammunition/Projectiles/mech.yml
@@ -22,7 +22,7 @@
     damage:
       types:
         Piercing: 90
-        Structural: 400 
+        Structural: 400
     harmorPenetration: 80
     stoppingPower: 12
   - type: ExplodeOnTrigger
@@ -100,3 +100,71 @@
     proto: PelletShotgun
     count: 3
     spread: 15
+
+- type: entity
+  id: ExosuitPlasmaBoltLight
+  name: plasma bolt
+  parent: BaseBulletTrigger
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ShipWeaponProjectile
+  - type: ProjectileIFF
+    visualType: Circle
+    color: Blue
+  - type: Projectile
+    damage:
+      types:
+        Heat: 50
+        Radiation: 15
+        Structural: 100
+    harmorPenetration: 60
+    stoppingPower: 6
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 8
+    intensitySlope: 14
+    totalIntensity: 20
+    maxTileBreak: 2
+  - type: PointLight
+    radius: 3.5
+    color: Orange
+    energy: 0.5
+  - type: Sprite
+    sprite: _NF/Objects/SpaceArtillery/plasmahardpoint.rsi
+    layers:
+      - state: icon
+
+- type: entity
+  id: ExosuitPlasmaBoltHeavy
+  name: plasma sphere
+  parent: BaseBulletTrigger
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ShipWeaponProjectile
+  - type: ProjectileIFF
+    visualType: Circle
+    color: Cyan
+  - type: Projectile
+    damage:
+      types:
+        Heat: 70
+        Radiation: 30
+        Structural: 300
+    harmorPenetration: 80
+    stoppingPower: 8
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 10
+    intensitySlope: 20
+    totalIntensity: 100
+    maxTileBreak: 4
+  - type: PointLight
+    radius: 3.5
+    color: Red
+    energy: 0.5
+  - type: Sprite
+    sprite: _NF/Objects/SpaceArtillery/plasmaheavy.rsi
+    layers:
+      - state: icon

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Specific/mech_weapons.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Specific/mech_weapons.yml
@@ -382,3 +382,58 @@
   - type: Tag
     tags:
     - ScoutMechEquipment
+
+- type: entity
+  id: WeaponMechCombatPlasmaRifle
+  name: IRM 'Verdict' 250c exosuit plasma repeater
+  description: An arm-mounted exosuit sized plasma repeater that draws from the mech connected power supply. Developed by the Scribes Guild as one of their first projects in understanding NanoTrasens technology, producing a weapon beloved by the Imperial Cavalry for battlefields despite its often wasteful power use.
+  suffix: Mech Weapon, Gun, Combat, Plasma Repeater
+  parent: [ BaseMechWeaponRange, ScoutMechEquipment ]
+  components:
+  - type: Sprite
+    sprite: _Crescent/Objects/Specific/mechaweapons.rsi
+    state: plasmarifle
+  - type: Gun
+    fireRate: 0.8
+    selectedMode: FullAuto
+    availableModes:
+      - FullAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/ship_svalinn.ogg
+  - type: ProjectileBatteryAmmoProvider
+    proto: ExosuitPlasmaBoltLight
+    fireCost: 30
+  - type: Appearance
+  - type: AmmoCounter
+  - type: Tag
+    tags:
+    - ScoutMechEquipment
+
+- type: entity
+  id: WeaponMechCombatPlasmaCannon
+  name: IRM 'Judgement' 600c exosuit plasma cannon
+  description: Physical proof of the Imperial industry taken form in an experimental exosuit-sized plasma cannon linked to a mech power supply. Through cleverly designed capacitors, and cycling heat-banks, it is able to fire agitated plasma hot enough to burn through military hulls but is liable to completely drain its power supply with even sparse usage.
+  suffix: Mech Weapon, Gun, Combat, Plasma Cannon
+  parent: [ BaseMechWeaponRange, MediumMechEquipment ]
+  components:
+  - type: Sprite
+    sprite: _Crescent/Objects/Specific/mechaweapons.rsi
+    state: plasmacannon
+  - type: Gun
+    fireRate: 0.5
+    selectedMode: FullAuto
+    availableModes:
+      - FullAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/ship_svalinn.ogg
+  - type: Battery
+    maxCharge: 250
+    startingCharge: 250
+  - type: ProjectileBatteryAmmoProvider
+    proto: ExosuitPlasmaBoltHeavy
+    fireCost: 250
+  - type: Appearance
+  - type: AmmoCounter
+  - type: Tag
+    tags:
+    - MediumMechEquipment

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -426,6 +426,31 @@
     Tungsten: 1500
 
 - type: latheRecipe
+  id: WeaponMechCombatPlasmaRifle
+  result: WeaponMechCombatPlasmaRifle
+  completetime: 2
+  materials:
+    Steel: 2000
+    Plasma: 1000
+    Copper: 3000
+    BasicElectronics: 3500
+    BasicMechatronics: 1000
+    WeakLaserLocus: 5000
+
+- type: latheRecipe
+  id: WeaponMechCombatPlasmaCannon
+  result: WeaponMechCombatPlasmaCannon
+  completetime: 2
+  materials:
+    Steel: 5000
+    Plasma: 2000
+    Copper: 2500
+    Tungsten: 2500
+    AdvancedElectronics: 3000
+    AdvancedMechatronics: 1500
+    LaserLocus: 4000
+
+- type: latheRecipe
   id: LaelapsLPC
   result: ShipVoucherLaelaps
   completetime: 1

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -528,6 +528,8 @@
       - LaelapsLPC
       - PaladinFlatpack
       - WandererFlatpack
+      - WeaponMechCombatPlasmaRifle
+      - WeaponMechCombatPlasmaCannon
       - WeaponRifleDSMLegionnaire
       - WeaponSubMachineGunC20rImperial
       - WeaponPistolNeoVolker

--- a/Resources/Prototypes/_Crescent/Research/imperial.yml
+++ b/Resources/Prototypes/_Crescent/Research/imperial.yml
@@ -200,6 +200,19 @@
   - WeaponPistolNeoVolker
 
 - type: technology
+  id: ImperialPlasmaMechGuns
+  name: research-technology-imperial-plasmamechguns
+  icon:
+    sprite: _Crescent/Objects/Specific/mechaweapons.rsi
+    state: plasmarifle
+  discipline: Imperial
+  tier: 2
+  cost: 9000
+  recipeUnlocks:
+  - WeaponMechCombatPlasmaRifle
+  - WeaponMechCombatPlasmaCannon
+
+- type: technology
   id: ImperialSRM
   name: research-technology-imperial-srmimitation
   icon:


### PR DESCRIPTION
Uses the existing plasma rifle and plasma cannon mech sprites as the following weapons for the DSM to research:

IRM 'Verdict' 250c exosuit plasma repeater: Basically a mech portable plasma caster with a lightly changed damage values, less deadly explosion, and higher than average energy usage.

IRM 'Judgement' 600c exosuit plasma cannon: A far superior upgrade that has the worst power consumption to only have 30 shots before depowering the mech, BUT is able to kill most mechs in two to three shots and heavily damage ships.
