### PR TITLE
NCWL ACCESS + SMALL TWEAKS

### DIFF
--- a/Resources/Maps/_Crescent/Stations/novabalreska.yml
+++ b/Resources/Maps/_Crescent/Stations/novabalreska.yml
@@ -58265,23 +58265,6 @@ entities:
     - type: Transform
       pos: -13.5,5.5
       parent: 1
-- proto: NCWLAdmiralVolginPhoto
-  entities:
-  - uid: 1375
-    components:
-    - type: Transform
-      pos: 23.589022,3.5922225
-      parent: 1
-  - uid: 2043
-    components:
-    - type: Transform
-      pos: -21.5,-5.5
-      parent: 1
-  - uid: 2075
-    components:
-    - type: Transform
-      pos: -21.460718,6.6145854
-      parent: 1
 - proto: NCWLCargoDispenser
   entities:
   - uid: 8610

--- a/Resources/Maps/_Crescent/Stations/novabalreska.yml
+++ b/Resources/Maps/_Crescent/Stations/novabalreska.yml
@@ -58265,6 +58265,23 @@ entities:
     - type: Transform
       pos: -13.5,5.5
       parent: 1
+- proto: NCWLAdmiralVolginPhoto
+  entities:
+  - uid: 1375
+    components:
+    - type: Transform
+      pos: 23.589022,3.5922225
+      parent: 1
+  - uid: 2043
+    components:
+    - type: Transform
+      pos: -21.5,-5.5
+      parent: 1
+  - uid: 2075
+    components:
+    - type: Transform
+      pos: -21.460718,6.6145854
+      parent: 1
 - proto: NCWLCargoDispenser
   entities:
   - uid: 8610

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_commandant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_commandant.yml
@@ -87,7 +87,7 @@
 - type: startingGear
   id: CommandantNCWLGear
   equipment:
-    shoes: ClothingShoesBootsNCWLAdmiralParade
+    shoes: ClothingShoesBootsJack
     jumpsuit: ClothingUniformJumpsuitNCWLCommunications
     id: NCWLFactionLeaderPDA
     outerClothing: ClothingOuterArmorNCWLOpremeCarapace
@@ -95,7 +95,7 @@
     pocket1: WeaponRevolverPython
     pocket2: WeaponRevolverPython
     back: ClothingBackpackNCWL
-    gloves: ClothingHandsGlovesNCWLAdmiralParade
+    gloves: ClothingHandsGlovesCombat
     head: ClothingHeadHatNCWLBeretAdmiral
     mask: ClothingMaskNCWLGasmask
     ears: ClothingHeadsetNCWL

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_doctor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_doctor.yml
@@ -44,6 +44,7 @@
   - Command
   - Maintenance
   - Service
+  - NCWLJail #needed for balreska morgue
   - NCWLGeneral
   - External
   - Mercenary # Frontier

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_fleetkapitan.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_fleetkapitan.yml
@@ -77,7 +77,6 @@
   - Hydroponics
   - Atmospherics
   - NCWLGeneral
-  - NCWLKommissar
   - NCWLJail
   - NCWLArmory
   - NCWLCommand

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_industry_taskmaster.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_industry_taskmaster.yml
@@ -77,7 +77,6 @@
   - Hydroponics
   - Atmospherics
   - NCWLGeneral
-  - NCWLKommissar
   - NCWLJail
   - NCWLArmory
   - NCWLCommand

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_partisan.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_partisan.yml
@@ -43,6 +43,7 @@
   - Service
   - NCWLGeneral
   - NCWLJail
+  - NCWLArmory
   - External
   - Mercenary # Frontier
   - Captain # Frontier

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_partisan.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_partisan.yml
@@ -33,7 +33,8 @@
         rank: crescent-rank-ncwl-home-soldat
       - type: LanguageKnowledge
         speaks:
-        - Dockta
+          - Dockta
+          - Tradeband
         understands:
           - Dockta
           - Tradeband

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_worker.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_worker.yml
@@ -31,8 +31,10 @@
       - type: LanguageKnowledge
         speaks:
           - Dockta
+          - Tradeband
         understands:
           - Dockta
+          - Tradeband
   access:
   - Command
   - Maintenance

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_worker_overboss.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_worker_overboss.yml
@@ -77,7 +77,6 @@
   - Hydroponics
   - Atmospherics
   - NCWLGeneral
-  - NCWLKommissar
   - NCWLJail
   - NCWLArmory
   - NCWLCommand


### PR DESCRIPTION
- fixes ncwl access on balreska
- - doctors get jail access (for morgue)
- - kommissar gets no administrator/kommandante access
- - partisans get armory access
- - civ leads get no kommissar access
- union workers get tradeband. fixed yaml formatting on partisan languages
- parade gear taken off of kommandante, since balreska spawns it in a locker