### PR TITLE
SMES ship price inflation fix

### DIFF
--- a/Content.Server/Power/Components/BatteryComponent.cs
+++ b/Content.Server/Power/Components/BatteryComponent.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Power.Components
         /// The price per one joule. Default is 1 credit for 10kJ.
         /// </summary>
         [DataField]
-        public float PricePerJoule = 0.0001f;
+        public float PricePerJoule = 0f;
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -6,7 +6,6 @@
   - type: Item
     storedRotation: -90
   - type: Battery
-    pricePerJoule: 0.15
   - type: PowerCell
   - type: Explosive
     explosionType: Default

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -37,7 +37,6 @@
     - type: PowerSink
     - type: Battery
       maxCharge: 7500000
-      pricePerJoule: 0.0003
     - type: ExaminableBattery
     - type: PowerConsumer
       voltage: High


### PR DESCRIPTION
Removes electricity:credit conversion from the game since its not actually viable in Hurrot and only inflates ship price.