### PR TITLE
enable freelook on player characters, you can now press spacebar to toggle it

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -39,6 +39,7 @@
   - type: Eye
   - type: ContentEye
   - type: CameraRecoil
+  - type: Telescope
   - type: MindContainer
   - type: MovementSpeedModifier
   - type: Polymorphable


### PR DESCRIPTION
EscalRot14. Our Certainly Furious Escalation.

enables freelook for players. that's it. peakium.

https://github.com/user-attachments/assets/85ebf615-68db-41a7-81cf-6267cd9d9988

# Changelog
:cl: Ghost581
- add: You can now free look by pressing spacebar. The key is rebindable.
