### PR TITLE
Readds artifacts to the commissary

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_science.yml
@@ -9,6 +9,16 @@
   group: market
 
 - type: cargoProduct
+  id: RandomArtifact
+  icon:
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    state: ano13
+  product: RandomArtifactSpawner
+  cost: 5000
+  category: cargoproduct-category-name-science
+  group: market
+
+- type: cargoProduct
   id: ScienceBiosuit
   icon:
     sprite: Clothing/Head/Hoods/Bio/scientist.rsi


### PR DESCRIPTION
being unable to buy artifacts for 5k as every faction is kind of fucked up and evil even for a rebase override

In all seriousness, there are many occasions where artifact buying is realistically the only way a faction is going to progress in tech (for example, they are just short of a tech they want, they either go find more tech or buy a new artifact)

By making it cost 5k, we have it so artifact buying will almost always run a deficit, and as such be reserved as a secondary source of artifacts, not primary (unless you splurge and get lucky with a artifact that doesn't roadblock instantly)


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Adds Artifacts to the Commissary
