### PR TITLE
Removes the Ore Processor flatpacks from the Flatpack Vending Machine

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -1,7 +1,6 @@
 - type: vendingMachineInventory
   id: FlatpackVendInventory
   startingInventory:
-    OreProcessorFlatpack: 10
     HydroponicsTrayEmptyFlatpack: 16
     MaterialReclaimerFlatpack: 4
     UniformPrinterFlatpack: 6


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

Removes the Ore Processor flatpacks from the Flatpack Vending Machine. This is to stay more in line with the games vision of forcing you to return to faction controlled outposts to make use of the ore you mine, so that you cannot just plop down an Ore Processor onto your Gazpachov and become an industrial smelter. I think I did this right but I've been awake for nearly 21 hours so if I missed an instance please let me know.

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->



---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: ore processor flatpack 