### PR TITLE
RITTERS ROUNDSTART LIGHT MECH "WANDERER"

### DIFF
--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ritter.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ritter.yml
@@ -63,3 +63,5 @@
     head: ClothingHeadHelmetImperialRitter
     outerClothing: ClothingOuterCoatImperialRitter
     gloves: ClothingHandsGlovesImperialLonggloves
+  inhand:
+    - WandererFlatpack


### PR DESCRIPTION
RITTERS GET THE LIGHT MECH FORMALLY KNOWN AS "WANDERER" ON ROUNDSTART WITH THIS PULL REQUEST.
