### PR TITLE
fix missing parent on HeadBorgService recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -224,6 +224,7 @@
   result: RightLegBorgService
 
 - type: latheRecipe
+  parent: BaseBorgLimbRecipe
   id: HeadBorgService
   result: HeadBorgService
 


### PR DESCRIPTION
fixes #342 

# Description

Fixes service cyborg head recipe having no cost, which could be used to print infinite quantities.