### PR TITLE
Fix broken event descriptions

### DIFF
--- a/Resources/Locale/en-US/_Crescent/events/events.ftl
+++ b/Resources/Locale/en-US/_Crescent/events/events.ftl
@@ -1,13 +1,11 @@
-station-event-bluespace-pangtai-trader = Corporate trader vessel, PTA Gu Tian, has entered the Sector with valid commercial license. The Gu Tian will anchor nearby and offer it's wares.
-station-event-bluespace-pangtai-trader-end = Corporate trader vessel, PTA Gu Tian, has fulfilled profit quota. It will be leaving the Sector.
+station-event-pang-tai-trader-announcement = Corporate trader vessel, PTA Gu Tian, has entered the Sector with valid commercial license. The Gu Tian will anchor nearby and offer it's wares.
+station-event-pang-tai-trader-complete-announcement = Corporate trader vessel, PTA Gu Tian, has fulfilled profit quota. It will be leaving the Sector.
 
-station-event-bluespace-shinohara-trader = Corporate trader vessel, SHI Kitamura Jeon, has entered the Sector with valid commercial license. The Kitamura Jeon will anchor nearby and offer it's wares.
-station-event-bluespace-shinohara-trader-end = Corporate trader vessel, SHI Kitamura Jeon, has fulfilled profit quota. It will be leaving the Sector.
+station-event-shinohara-trader-announcement = Corporate trader vessel, SHI Kitamura Jeon, has entered the Sector with valid commercial license. The Kitamura Jeon will anchor nearby and offer it's wares.
+station-event-shinohara-trader-complete-announcement = Corporate trader vessel, SHI Kitamura Jeon, has fulfilled profit quota. It will be leaving the Sector.
 
-station-event-bluespace-probe = Naval Command advises all spaceborne pilots that a derelict NanoTrasen probe has been towed out of bluespace. Navalcomm recommends extreme caution to all prospectors that are looking to potentially scavenge the site, and recommends a medical checkup thereafter to check for psychic contaminants.
+station-event-nano-trasen-probe-announcement = Naval Command advises all spaceborne pilots that a derelict NanoTrasen probe has been towed out of bluespace. Navalcomm recommends extreme caution to all prospectors that are looking to potentially scavenge the site, and recommends a medical checkup thereafter to check for psychic contaminants.
+station-event-nano-trasen-probe-complete-announcement = Naval Command informs all spaceborne pilots that the derelict NanoTrasen surveyor probe has been towed into a secure location; participant groups have been rewarded for their diligence in clearing the vessel.
 
-station-event-bluespace-probe-end = Naval Command informs all spaceborne pilots that the derelict NanoTrasen surveyor probe has been towed into a secure location; participant groups have been rewarded for their diligence in clearing the vessel.
-
-station-event-bluespace-infestation = Naval Command informs all spaceborne pilots that an unaffiliated Hearth-class mobile outpost has experienced a contamination field failure and is now broadcasting for help. Navcomm will reward all sovereign groups who interfere.
-
-station-event-bluespace-infestation-end = Naval Command informs all spaceborne pilots that the Hearth-class mobile outpost has been towed into unstable bluespace for deconstruction and decontamination. Participants have been rewarded.
+station-event-infested-station-announcement = Naval Command informs all spaceborne pilots that an unaffiliated Hearth-class mobile outpost has experienced a contamination field failure and is now broadcasting for help. Navcomm will reward all sovereign groups who interfere.
+station-event-infested-station-complete-announcement = Naval Command informs all spaceborne pilots that the Hearth-class mobile outpost has been towed into unstable bluespace for deconstruction and decontamination. Participants have been rewarded.


### PR DESCRIPTION
fixes #403 

# Description

Changes `events.ftl` to match default formatting so that event descriptions display correctly in chat.

Alternate solution would be changing the "startAnnouncement" and "endAnnouncement" fields of each event prototype (in the StationEvent component) to specify a particular Fluent message, rather than setting them to "true".