### PR TITLE
Random events fix

### DIFF
--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -4,10 +4,9 @@ using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.StationEvents.Components;
 using Content.Shared.Administration;
-using Content.Shared.CCVar;
+using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using JetBrains.Annotations;
-using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Toolshed;
@@ -24,15 +23,18 @@ namespace Content.Server.StationEvents
     {
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly EventManagerSystem _event = default!;
-        [Dependency] private readonly IConfigurationManager _config = default!;
 
-        public const float MinEventTime = 60 * 3;
-        public const float MaxEventTime = 60 * 10;
+        protected override void Started(EntityUid uid, BasicStationEventSchedulerComponent component, GameRuleComponent gameRule,
+            GameRuleStartedEvent args)
+        {
+            // A little starting variance so schedulers dont all proc at once.
+            component.TimeUntilNextEvent = RobustRandom.NextFloat(component.MinimumTimeUntilFirstEvent, component.MinimumTimeUntilFirstEvent + 120);
+        }
 
         protected override void Ended(EntityUid uid, BasicStationEventSchedulerComponent component, GameRuleComponent gameRule,
             GameRuleEndedEvent args)
         {
-            component.TimeUntilNextEvent = BasicStationEventSchedulerComponent.MinimumTimeUntilFirstEvent;
+            component.TimeUntilNextEvent = component.MinimumTimeUntilFirstEvent;
         }
 
 
@@ -52,10 +54,10 @@ namespace Content.Server.StationEvents
                 if (eventScheduler.TimeUntilNextEvent > 0)
                 {
                     eventScheduler.TimeUntilNextEvent -= frameTime;
-                    return;
+                    continue;
                 }
 
-                _event.RunRandomEvent();
+                _event.RunRandomEvent(eventScheduler.ScheduledGameRules);
                 ResetTimer(eventScheduler);
             }
         }
@@ -65,8 +67,7 @@ namespace Content.Server.StationEvents
         /// </summary>
         private void ResetTimer(BasicStationEventSchedulerComponent component)
         {
-            component.TimeUntilNextEvent = _random.Next(_config.GetCVar(CCVars.GameEventsBasicMinimumTime),
-                _config.GetCVar(CCVars.GameEventsBasicMaximumTime));
+            component.TimeUntilNextEvent = component.MinMaxEventTiming.Next(_random);
         }
     }
 
@@ -74,7 +75,8 @@ namespace Content.Server.StationEvents
     public sealed class StationEventCommand : ToolshedCommand
     {
         private EventManagerSystem? _stationEvent;
-        private BasicStationEventSchedulerSystem? _basicScheduler;
+        private EntityTableSystem? _entityTable;
+        private IComponentFactory? _compFac;
         private IRobustRandom? _random;
 
         /// <summary>
@@ -92,10 +94,11 @@ namespace Content.Server.StationEvents
         ///     to even exist) so I think it's fine.
         /// </remarks>
         [CommandImplementation("simulate")]
-        public IEnumerable<(string, float)> Simulate(EntityPrototype eventScheduler, int rounds, int playerCount, float roundEndMean, float roundEndStdDev)
+        public IEnumerable<(string, float)> Simulate([CommandArgument] EntityPrototype eventScheduler, [CommandArgument] int rounds, [CommandArgument] int playerCount, [CommandArgument] float roundEndMean, [CommandArgument] float roundEndStdDev)
         {
             _stationEvent ??= GetSys<EventManagerSystem>();
-            _basicScheduler ??= GetSys<BasicStationEventSchedulerSystem>();
+            _entityTable ??= GetSys<EntityTableSystem>();
+            _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _random ??= IoCManager.Resolve<IRobustRandom>();
 
             var occurrences = new Dictionary<string, int>();
@@ -104,6 +107,13 @@ namespace Content.Server.StationEvents
             {
                 occurrences.Add(ev.Key.ID, 0);
             }
+
+            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+            {
+                return occurrences.Select(p => (p.Key, (float)p.Value)).OrderByDescending(p => p.Item2);
+            }
+
+            var compMinMax = basicScheduler.MinMaxEventTiming; // we gotta do this since we cant execute on comp w/o an ent.
 
             for (var i = 0; i < rounds; i++)
             {
@@ -115,9 +125,16 @@ namespace Content.Server.StationEvents
                 while (curTime.TotalSeconds < randomEndTime)
                 {
                     // sim an event
-                    curTime += TimeSpan.FromSeconds(_random.NextFloat(BasicStationEventSchedulerSystem.MinEventTime, BasicStationEventSchedulerSystem.MaxEventTime));
+                    curTime += TimeSpan.FromSeconds(compMinMax.Next(_random));
+
+                    if (!_stationEvent.TryBuildLimitedEvents(basicScheduler.ScheduledGameRules, out var selectedEvents))
+                    {
+                        continue; // doesnt break because maybe the time is preventing events being available.
+                    }
                     var available = _stationEvent.AvailableEvents(false, playerCount, curTime);
-                    var ev = _stationEvent.FindEvent(available);
+                    var plausibleEvents = new Dictionary<EntityPrototype, StationEventComponent>(available.Intersect(selectedEvents)); // C# makes me sad
+
+                    var ev = _stationEvent.FindEvent(plausibleEvents);
                     if (ev == null)
                         continue;
 
@@ -129,26 +146,40 @@ namespace Content.Server.StationEvents
         }
 
         [CommandImplementation("lsprob")]
-        public IEnumerable<(string, float)> LsProb(EntityPrototype eventScheduler)
+        public IEnumerable<(string, float)> LsProb([CommandArgument] EntityPrototype eventScheduler)
         {
+            _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _stationEvent ??= GetSys<EventManagerSystem>();
-            var events = _stationEvent.AllEvents();
 
-            var totalWeight = events.Sum(x => x.Value.Weight);
+            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+                yield break;
 
-            foreach (var (proto, comp) in events)
+            if (!_stationEvent.TryBuildLimitedEvents(basicScheduler.ScheduledGameRules, out var events))
+                yield break;
+
+            var totalWeight = events.Sum(x => x.Value.Weight); // Well this shit definitely isnt correct now, and I see no way to make it correct.
+                                                               // Its probably *fine* but it wont be accurate if the EntityTableSelector does any subsetting.
+            foreach (var (proto, comp) in events)              // The only solution I see is to do a simulation, and we already have that, so...!
             {
                 yield return (proto.ID, comp.Weight / totalWeight);
             }
         }
 
         [CommandImplementation("lsprobtime")]
-        public IEnumerable<(string, float)> LsProbTime(EntityPrototype eventScheduler, float time)
+        public IEnumerable<(string, float)> LsProbTime([CommandArgument] EntityPrototype eventScheduler, [CommandArgument] float time)
         {
+            _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _stationEvent ??= GetSys<EventManagerSystem>();
-            var events = _stationEvent.AllEvents().Where(pair => pair.Value.EarliestStart <= time).ToList();
 
-            var totalWeight = events.Sum(x => x.Value.Weight);
+            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+                yield break;
+
+            if (!_stationEvent.TryBuildLimitedEvents(basicScheduler.ScheduledGameRules, out var untimedEvents))
+                yield break;
+
+            var events = untimedEvents.Where(pair => pair.Value.EarliestStart <= time).ToList();
+
+            var totalWeight = events.Sum(x => x.Value.Weight); // same subsetting issue as lsprob.
 
             foreach (var (proto, comp) in events)
             {
@@ -157,12 +188,18 @@ namespace Content.Server.StationEvents
         }
 
         [CommandImplementation("prob")]
-        public float Prob(EntityPrototype eventScheduler, string eventId)
+        public float Prob([CommandArgument] EntityPrototype eventScheduler, [CommandArgument] string eventId)
         {
+            _compFac ??= IoCManager.Resolve<IComponentFactory>();
             _stationEvent ??= GetSys<EventManagerSystem>();
-            var events = _stationEvent.AllEvents();
 
-            var totalWeight = events.Sum(x => x.Value.Weight);
+            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+                return 0f;
+
+            if (!_stationEvent.TryBuildLimitedEvents(basicScheduler.ScheduledGameRules, out var events))
+                return 0f;
+
+            var totalWeight = events.Sum(x => x.Value.Weight); // same subsetting issue as lsprob.
             var weight = 0f;
             if (events.TryFirstOrNull(p => p.Key.ID == eventId, out var pair))
             {

--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -1,14 +1,35 @@
-﻿namespace Content.Server.StationEvents.Components;
+﻿using Content.Shared.Destructible.Thresholds;
+using Content.Shared.EntityTable.EntitySelectors;
+
+
+namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(BasicStationEventSchedulerSystem))]
 public sealed partial class BasicStationEventSchedulerComponent : Component
 {
-    public const float MinimumTimeUntilFirstEvent = 300;
+    /// <summary>
+    /// How long the the scheduler waits to begin starting rules.
+    /// </summary>
+    [DataField]
+    public float MinimumTimeUntilFirstEvent = 200;
 
     /// <summary>
-    /// How long until the next check for an event runs
+    /// The minimum and maximum time between rule starts in seconds.
     /// </summary>
-    /// Default value is how long until first event is allowed
-    [ViewVariables(VVAccess.ReadWrite)]
-    public float TimeUntilNextEvent = MinimumTimeUntilFirstEvent;
+    [DataField]
+    public MinMax MinMaxEventTiming = new(3 * 60, 10 * 60);
+
+    /// <summary>
+    /// How long until the next check for an event runs, is initially set based on MinimumTimeUntilFirstEvent & MinMaxEventTiming.
+    /// </summary>
+    [DataField]
+    public float TimeUntilNextEvent;
+
+    /// <summary>
+    /// The gamerules that the scheduler can choose from
+    /// </summary>
+    /// Reminder that though we could do all selection via the EntityTableSelector, we also need to consider various <see cref="StationEventComponent"/> restrictions.
+    /// As such, we want to pass a list of acceptable game rules, which are then parsed for restrictions by the <see cref="EventManagerSystem"/>.
+    [DataField(required: true)]
+    public EntityTableSelector ScheduledGameRules = default!;
 }

--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -1,42 +1,41 @@
-﻿namespace Content.Server.StationEvents.Components;
+﻿using Content.Shared.EntityTable.EntitySelectors;
+
+namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(RampingStationEventSchedulerSystem))]
 public sealed partial class RampingStationEventSchedulerComponent : Component
 {
     /// <summary>
-    ///     The maximum number by which the event rate will be multiplied when shift time reaches the end time.
+    ///     Average ending chaos modifier for the ramping event scheduler. Higher means faster.
+    ///     Max chaos chosen for a round will deviate from this
     /// </summary>
     [DataField]
-    public float ChaosModifier = 3f;
+    public float AverageChaos = 6f;
 
     /// <summary>
-    ///     The minimum number by which the event rate will be multiplied when the shift has just begun.
+    ///     Average time (in minutes) for when the ramping event scheduler should stop increasing the chaos modifier.
+    ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     [DataField]
-    public float StartingChaosRatio = 0.1f;
+    public float AverageEndTime = 40f;
 
-    /// <summary>
-    ///     The number by which all event delays will be multiplied. Unlike chaos, remains constant throughout the shift.
-    /// </summary>
     [DataField]
-    public float EventDelayModifier = 1f;
-
-    /// <summary>
-    ///     The number by which average expected shift length is multiplied. Higher values lead to slower chaos growth.
-    /// </summary>
-    [DataField]
-    public float ShiftLengthModifier = 1f;
-
-    // Everything below is overridden in the RampingStationEventSchedulerSystem based on CVars
-    [DataField("endTime"), ViewVariables(VVAccess.ReadWrite)]
     public float EndTime;
 
-    [DataField("maxChaos"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float MaxChaos;
 
-    [DataField("startingChaos"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float StartingChaos;
 
-    [DataField("timeUntilNextEvent"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float TimeUntilNextEvent;
+
+    /// <summary>
+    /// The gamerules that the scheduler can choose from
+    /// </summary>
+    /// Reminder that though we could do all selection via the EntityTableSelector, we also need to consider various <see cref="StationEventComponent"/> restrictions.
+    /// As such, we want to pass a list of acceptable game rules, which are then parsed for restrictions by the <see cref="EventManagerSystem"/>.
+    [DataField(required: true)]
+    public EntityTableSelector ScheduledGameRules = default!;
 }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -9,6 +9,9 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Psionics.Glimmer;
 using Content.Shared.Psionics.Glimmer;
+using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.EntityTable;
+
 namespace Content.Server.StationEvents;
 
 public sealed class EventManagerSystem : EntitySystem
@@ -17,7 +20,7 @@ public sealed class EventManagerSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
-    [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
     [Dependency] public readonly GameTicker GameTicker = default!;
     [Dependency] private readonly GlimmerSystem _glimmerSystem = default!; //Nyano - Summary: pulls in the glimmer system.
 
@@ -34,7 +37,8 @@ public sealed class EventManagerSystem : EntitySystem
     /// <summary>
     /// Randomly runs a valid event.
     /// </summary>
-    public string RunRandomEvent()
+    [Obsolete("use overload taking EnityTableSelector instead or risk unexpected results")]
+    public void RunRandomEvent()
     {
         var randomEvent = PickRandomEvent();
 
@@ -42,14 +46,86 @@ public sealed class EventManagerSystem : EntitySystem
         {
             var errStr = Loc.GetString("station-event-system-run-random-event-no-valid-events");
             Log.Error(errStr);
-            return errStr;
+            return;
         }
 
-        var ent = GameTicker.AddGameRule(randomEvent);
-        var str = Loc.GetString("station-event-system-run-event",("eventName", ToPrettyString(ent)));
-        _chat.SendAdminAlert(str);
-        Log.Info(str);
-        return str;
+        GameTicker.AddGameRule(randomEvent);
+    }
+
+    /// <summary>
+    /// Randomly runs an event from provided EntityTableSelector.
+    /// </summary>
+    public void RunRandomEvent(EntityTableSelector limitedEventsTable)
+    {
+        if (!TryBuildLimitedEvents(limitedEventsTable, out var limitedEvents))
+        {
+            Log.Warning("Provided event table could not build dict!");
+            return;
+        }
+
+        var randomLimitedEvent = FindEvent(limitedEvents); // this picks the event, It might be better to use the GetSpawns to do it, but that will be a major rebalancing fuck.
+        if (randomLimitedEvent == null)
+        {
+            Log.Warning("The selected random event is null!");
+            return;
+        }
+
+        if (!_prototype.TryIndex(randomLimitedEvent, out _))
+        {
+            Log.Warning("A requested event is not available!");
+            return;
+        }
+
+        GameTicker.AddGameRule(randomLimitedEvent);
+    }
+
+    /// <summary>
+    /// Returns true if the provided EntityTableSelector gives at least one prototype with a StationEvent comp.
+    /// </summary>
+    public bool TryBuildLimitedEvents(EntityTableSelector limitedEventsTable, out Dictionary<EntityPrototype, StationEventComponent> limitedEvents)
+    {
+        limitedEvents = new Dictionary<EntityPrototype, StationEventComponent>();
+
+        var availableEvents = AvailableEvents(); // handles the player counts and individual event restrictions
+
+        if (availableEvents.Count == 0)
+        {
+            Log.Warning("No events were available to run!");
+            return false;
+        }
+
+        var selectedEvents = _entityTable.GetSpawns(limitedEventsTable);
+
+        if (selectedEvents.Any() != true) // This is here so if you fuck up the table it wont die.
+            return false;
+
+        foreach (var eventid in selectedEvents)
+        {
+            if (!_prototype.TryIndex(eventid, out var eventproto))
+            {
+                Log.Warning("An event ID has no prototype index!");
+                continue;
+            }
+
+            if (limitedEvents.ContainsKey(eventproto)) // This stops it from dying if you add duplicate entries in a fucked table
+                continue;
+
+            if (eventproto.Abstract)
+                continue;
+
+            if (!eventproto.TryGetComponent<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
+                continue;
+
+            if (!availableEvents.ContainsKey(eventproto))
+                continue;
+
+            limitedEvents.Add(eventproto, stationEvent);
+        }
+
+        if (!limitedEvents.Any())
+            return false;
+
+        return true;
     }
 
     /// <summary>
@@ -168,7 +244,7 @@ public sealed class EventManagerSystem : EntitySystem
 
     private bool CanRun(EntityPrototype prototype, StationEventComponent stationEvent, int playerCount, TimeSpan currentTime)
     {
-        if (GameTicker.IsGameRuleAdded(prototype.ID))
+        if (GameTicker.IsGameRuleActive(prototype.ID))
             return false;
 
         if (stationEvent.MaxOccurrences.HasValue && GetOccurrences(prototype) >= stationEvent.MaxOccurrences.Value)

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -1,22 +1,20 @@
 ﻿using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
-using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
-using Content.Server.StationEvents.Events;
-using Content.Shared.CCVar;
 using Content.Shared.GameTicking.Components;
-using Robust.Shared.Configuration;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents;
 
 public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingStationEventSchedulerComponent>
 {
-    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly EventManagerSystem _event = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
 
+    /// <summary>
+    /// Returns the ChaosModifier which increases as round time increases to a point.
+    /// </summary>
     public float GetChaosModifier(EntityUid uid, RampingStationEventSchedulerComponent component)
     {
         var roundTime = (float) _gameTicker.RoundDuration().TotalSeconds;
@@ -30,15 +28,12 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
     {
         base.Started(uid, component, gameRule, args);
 
-        var avgChaos = _cfg.GetCVar(CCVars.EventsRampingAverageChaos) * component.ChaosModifier;
-        var avgTime = _cfg.GetCVar(CCVars.EventsRampingAverageEndTime) * component.ShiftLengthModifier;
-
         // Worlds shittiest probability distribution
         // Got a complaint? Send them to
-        component.MaxChaos = avgChaos * _random.NextFloat(0.75f, 1.25f);
+        component.MaxChaos = _random.NextFloat(component.AverageChaos - component.AverageChaos / 4, component.AverageChaos + component.AverageChaos / 4);
         // This is in minutes, so *60 for seconds (for the chaos calc)
-        component.EndTime = avgTime * _random.NextFloat(0.75f, 1.25f) * 60f;
-        component.StartingChaos = component.MaxChaos * component.StartingChaosRatio;
+        component.EndTime = _random.NextFloat(component.AverageEndTime - component.AverageEndTime / 4, component.AverageEndTime + component.AverageEndTime / 4) * 60f;
+        component.StartingChaos = component.MaxChaos / 10;
 
         PickNextEventTime(uid, component);
     }
@@ -54,25 +49,27 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
         while (query.MoveNext(out var uid, out var scheduler, out var gameRule))
         {
             if (!GameTicker.IsGameRuleActive(uid, gameRule))
-                return;
+                continue;
 
             if (scheduler.TimeUntilNextEvent > 0f)
             {
                 scheduler.TimeUntilNextEvent -= frameTime;
-                return;
+                continue;
             }
 
             PickNextEventTime(uid, scheduler);
-            _event.RunRandomEvent();
+            _event.RunRandomEvent(scheduler.ScheduledGameRules);
         }
     }
 
+    /// <summary>
+    /// Sets the timing of the next event addition.
+    /// </summary>
     private void PickNextEventTime(EntityUid uid, RampingStationEventSchedulerComponent component)
     {
-        component.TimeUntilNextEvent = _random.NextFloat(
-            _cfg.GetCVar(CCVars.GameEventsRampingMinimumTime),
-            _cfg.GetCVar(CCVars.GameEventsRampingMaximumTime));
+        var mod = GetChaosModifier(uid, component);
 
-        component.TimeUntilNextEvent *= component.EventDelayModifier / GetChaosModifier(uid, component);
+        // 4-12 minutes baseline. Will get faster over time as the chaos mod increases.
+        component.TimeUntilNextEvent = _random.NextFloat(240f / mod, 720f / mod);
     }
 }

--- a/Content.Shared/CCVar/CCVars.Events.cs
+++ b/Content.Shared/CCVar/CCVars.Events.cs
@@ -9,18 +9,4 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool>
         EventsEnabled = CVarDef.Create("events.enabled", true, CVar.ARCHIVE | CVar.SERVERONLY);
-
-    /// <summary>
-    ///     Average time (in minutes) for when the ramping event scheduler should stop increasing the chaos modifier.
-    ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
-    /// </summary>
-    public static readonly CVarDef<float>
-        EventsRampingAverageEndTime = CVarDef.Create("events.ramping_average_end_time", 180f, CVar.ARCHIVE | CVar.SERVERONLY);
-
-    /// <summary>
-    ///     Average ending chaos modifier for the ramping event scheduler.
-    ///     Max chaos chosen for a round will deviate from this
-    /// </summary>
-    public static readonly CVarDef<float>
-        EventsRampingAverageChaos = CVarDef.Create("events.ramping_average_chaos", 0.2f, CVar.ARCHIVE | CVar.SERVERONLY);
 }

--- a/Resources/Locale/en-US/_Crescent/events/events.ftl
+++ b/Resources/Locale/en-US/_Crescent/events/events.ftl
@@ -1,13 +1,11 @@
-station-event-bluespace-pangtai-trader = Corporate trader vessel, PTA Gu Tian, has entered the Sector with valid commercial license. The Gu Tian will anchor nearby and offer it's wares.
-station-event-bluespace-pangtai-trader-end = Corporate trader vessel, PTA Gu Tian, has fulfilled profit quota. It will be leaving the Sector.
+station-event-pang-tai-trader-announcement = Corporate trader vessel, PTA Gu Tian, has entered the Sector with valid commercial license. The Gu Tian will anchor nearby and offer it's wares.
+station-event-pang-tai-trader-complete-announcement = Corporate trader vessel, PTA Gu Tian, has fulfilled profit quota. It will be leaving the Sector.
 
-station-event-bluespace-shinohara-trader = Corporate trader vessel, SHI Kitamura Jeon, has entered the Sector with valid commercial license. The Kitamura Jeon will anchor nearby and offer it's wares.
-station-event-bluespace-shinohara-trader-end = Corporate trader vessel, SHI Kitamura Jeon, has fulfilled profit quota. It will be leaving the Sector.
+station-event-shinohara-trader-announcement = Corporate trader vessel, SHI Kitamura Jeon, has entered the Sector with valid commercial license. The Kitamura Jeon will anchor nearby and offer it's wares.
+station-event-shinohara-trader-complete-announcement = Corporate trader vessel, SHI Kitamura Jeon, has fulfilled profit quota. It will be leaving the Sector.
 
-station-event-bluespace-probe = Naval Command advises all spaceborne pilots that a derelict NanoTrasen probe has been towed out of bluespace. Navalcomm recommends extreme caution to all prospectors that are looking to potentially scavenge the site, and recommends a medical checkup thereafter to check for psychic contaminants.
+station-event-nano-trasen-probe-announcement = Naval Command advises all spaceborne pilots that a derelict NanoTrasen probe has been towed out of bluespace. Navalcomm recommends extreme caution to all prospectors that are looking to potentially scavenge the site, and recommends a medical checkup thereafter to check for psychic contaminants.
+station-event-nano-trasen-probe-complete-announcement = Naval Command informs all spaceborne pilots that the derelict NanoTrasen surveyor probe has been towed into a secure location; participant groups have been rewarded for their diligence in clearing the vessel.
 
-station-event-bluespace-probe-end = Naval Command informs all spaceborne pilots that the derelict NanoTrasen surveyor probe has been towed into a secure location; participant groups have been rewarded for their diligence in clearing the vessel.
-
-station-event-bluespace-infestation = Naval Command informs all spaceborne pilots that an unaffiliated Hearth-class mobile outpost has experienced a contamination field failure and is now broadcasting for help. Navcomm will reward all sovereign groups who interfere.
-
-station-event-bluespace-infestation-end = Naval Command informs all spaceborne pilots that the Hearth-class mobile outpost has been towed into unstable bluespace for deconstruction and decontamination. Participants have been rewarded.
+station-event-infested-station-announcement = Naval Command informs all spaceborne pilots that an unaffiliated Hearth-class mobile outpost has experienced a contamination field failure and is now broadcasting for help. Navcomm will reward all sovereign groups who interfere.
+station-event-infested-station-complete-announcement = Naval Command informs all spaceborne pilots that the Hearth-class mobile outpost has been towed into unstable bluespace for deconstruction and decontamination. Participants have been rewarded.

--- a/Resources/Locale/en-US/_Crescent/events/events.ftl
+++ b/Resources/Locale/en-US/_Crescent/events/events.ftl
@@ -1,8 +1,8 @@
-station-event-pang-tai-trader-announcement = Corporate trader vessel, PTA Gu Tian, has entered the Sector with valid commercial license. The Gu Tian will anchor nearby and offer it's wares.
-station-event-pang-tai-trader-complete-announcement = Corporate trader vessel, PTA Gu Tian, has fulfilled profit quota. It will be leaving the Sector.
+station-event-pang-tai-trader-announcement = Corporate trader vessel, PTA Gu Tian, has entered the Sector with valid commercial license. The Gu Tian will anchor nearby and offer its wares.
+station-event-pang-tai-trader-complete-announcement = Corporate trader vessel, PTA Gu Tian, has fulfilled its profit quota. It will be leaving the Sector.
 
-station-event-shinohara-trader-announcement = Corporate trader vessel, SHI Kitamura Jeon, has entered the Sector with valid commercial license. The Kitamura Jeon will anchor nearby and offer it's wares.
-station-event-shinohara-trader-complete-announcement = Corporate trader vessel, SHI Kitamura Jeon, has fulfilled profit quota. It will be leaving the Sector.
+station-event-shinohara-trader-announcement = Corporate trader vessel, SHI Kitamura Jeon, has entered the Sector with valid commercial license. The Kitamura Jeon will anchor nearby and offer its wares.
+station-event-shinohara-trader-complete-announcement = Corporate trader vessel, SHI Kitamura Jeon, has fulfilled its profit quota. It will be leaving the Sector.
 
 station-event-nano-trasen-probe-announcement = Naval Command advises all spaceborne pilots that a derelict NanoTrasen probe has been towed out of bluespace. Navalcomm recommends extreme caution to all prospectors that are looking to potentially scavenge the site, and recommends a medical checkup thereafter to check for psychic contaminants.
 station-event-nano-trasen-probe-complete-announcement = Naval Command informs all spaceborne pilots that the derelict NanoTrasen surveyor probe has been towed into a secure location; participant groups have been rewarded for their diligence in clearing the vessel.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -28,7 +28,6 @@
     children:
     - id: ClosetSkeleton
     - id: DragonSpawn
-    - id: KingRatMigration
     - id: NinjaSpawn
     - id: RevenantSpawn
     - id: SleeperAgents

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -1,3 +1,39 @@
+- type: entityTable
+  id: BasicCalmEventsTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: AnomalySpawn
+    - id: BluespaceArtifact
+    - id: BluespaceLocker
+    - id: BreakerFlip
+    - id: BureaucraticError
+    - id: ClericalError
+    - id: CockroachMigration
+    - id: GasLeak
+    - id: IonStorm # its calm like 90% of the time smh
+    - id: KudzuGrowth
+    - id: MassHallucinations
+    - id: MimicVendorRule
+    - id: MouseMigration
+    - id: PowerGridCheck
+    - id: SlimesSpawn
+    - id: SolarFlare
+    - id: SpiderClownSpawn
+    - id: SpiderSpawn
+    - id: VentClog
+
+- type: entityTable
+  id: BasicAntagEventsTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: ClosetSkeleton
+    - id: DragonSpawn
+    - id: KingRatMigration
+    - id: NinjaSpawn
+    - id: RevenantSpawn
+    - id: SleeperAgents
+    - id: ZombieOutbreak
+
 - type: entity
   id: BaseStationEvent
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -259,12 +259,24 @@
       - MindRoleInitialInfected
 
 # event schedulers
+
+- type: entityTable
+  id: BasicGameRulesTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+      - !type:NestedSelector
+        tableId: BasicCalmEventsTable
+      - !type:NestedSelector
+        tableId: BasicAntagEventsTable
+
 - type: entity
   id: BasicStationEventScheduler
   parent: BaseGameRule
   categories: [ HideSpawnMenu ]
   components:
   - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: BasicGameRulesTable
 
 - type: entity
   id: RampingStationEventScheduler
@@ -272,43 +284,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: RampingStationEventScheduler
-
-- type: entity
-  id: HellshiftStationEventScheduler
-  parent: BaseGameRule
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: RampingStationEventScheduler
-    chaosModifier: 5 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
-    startingChaosRatio: 0.1
-    shiftLengthModifier: 2.5
-
-- type: entity
-  id: IrregularStationEventScheduler
-  parent: BaseGameRule
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: OscillatingStationEventScheduler
-    minChaos: 0.8
-    maxChaos: 14
-    startingSlope: 0.2
-    downwardsLimit: -0.35
-    upwardsLimit: 0.4
-
-# More likely to go down than up, so calmness prevails
-- type: entity
-  id: IrregularExtendedStationEventScheduler
-  parent: BaseGameRule
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: OscillatingStationEventScheduler
-    minChaos: 0.8
-    maxChaos: 8
-    startingSlope: -1
-    downwardsLimit: -0.4
-    upwardsLimit: 0.3
-    downwardsBias: -1.1
-    upwardsBias: 0.9
+    scheduledGameRules: !type:NestedSelector
+      tableId: BasicGameRulesTable
 
 # variation passes
 - type: entity

--- a/Resources/Prototypes/_Crescent/Events/ship_gamerules.yml
+++ b/Resources/Prototypes/_Crescent/Events/ship_gamerules.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   stations:
     trader:
-      stationProto: StandardCrescentOutpost
+      stationProto: StandardCrescentPOI
       components:
         - type: StationNameSetup
           mapNameTemplate: 'PTA Gu Tian'
@@ -20,7 +20,7 @@
   minPlayers: 0
   stations:
     shitrader:
-      stationProto: StandardCrescentOutpost
+      stationProto: StandardCrescentPOI
       components:
         - type: StationNameSetup
           mapNameTemplate: 'SHI Kitamura Jeon'

--- a/Resources/Prototypes/_Crescent/GameRules/hullrotGamemodes.yml
+++ b/Resources/Prototypes/_Crescent/GameRules/hullrotGamemodes.yml
@@ -12,6 +12,7 @@
   description: The last days of Taypan. Lasts 2-4 hours.
   rules:
   - Adventure
+  - HullrotEventScheduler
 
 
 # GAMERULES ARE WAHT DECIDES WHAT SPAWNS IN, BY EVERYTHING IN THE ADVENTURERULE COMPONENT

--- a/Resources/Prototypes/_Crescent/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Crescent/GameRules/roundstart.yml
@@ -1,0 +1,20 @@
+- type: entity
+  id: HullrotEventScheduler
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: HullrotEventsTable
+    minimumTimeUntilFirstEvent: 1500 # 25 minutes
+    minMaxEventTiming:
+      min: 1800 # min 30 minutes between events
+      max: 3600 # max 60 minutes between events
+
+- type: entityTable
+  id: HullrotEventsTable
+  table: !type:AllSelector
+    children:
+    - id: ShinoharaTrader
+    - id: PangTaiTrader
+    - id: NanoTrasenProbe
+    - id: InfestedStation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -19,7 +19,7 @@
   name: hellshift-title
   description: hellshift-description
   rules:
-    - HellshiftStationEventScheduler
+    - RampingStationEventScheduler
     - BasicRoundstartVariation
     - SubGamemodesRule
     - LavalandStormScheduler # Lavaland Change
@@ -31,7 +31,7 @@
   name: irregular-title
   description: irregular-description
   rules:
-    - IrregularStationEventScheduler
+    - BasicStationEventScheduler
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -42,7 +42,7 @@
   name: irregular-extended-title
   description: irregular-extended-description
   rules:
-    - IrregularExtendedStationEventScheduler
+    - BasicStationEventScheduler
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 


### PR DESCRIPTION
fixes #402, fixes #403 

This PR could use some scrutiny since it's relatively complex, but it's been tested and is mostly a port of upstream code.

# Description

Fix for random events not firing.

- Fixed a prototype error on the SHI and PTA trade ship events
- Manually ported minimal required portions of space-wizards/space-station-14#29320
- Added HullrotEventScheduler to the Freeplay game mode
- Fixed broken event descriptions
- Assorted tweaks for compatibility

# Media


https://github.com/user-attachments/assets/308b7a11-d439-44f8-8ac0-761bda23ee0d

Video uses minimal "time before event" and "time between events" values for testing only.

# Changelog

- fix: Random events work again