### PR TITLE
SHI Gear & Playtime Fixes

### DIFF
--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
@@ -4,6 +4,8 @@
   description: job-description-board
   playTimeTracker: JobBoardSHI
   requirements:
+    - !type:CharacterOverallTimeRequirement
+      min: 14400
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement
@@ -49,6 +51,8 @@
     jumpsuit: ClothingUniformJumpsuitShinoharaSuit
     shoes: ClothingShoesBootsLaceup
     neck: ClothingNeckTieRed
+    outerClothing: ClothingOuterShinoharaSuitJacket
     id: BoardPDA
     pocket1: TradePassport
     ears: ClothingHeadsetShinohara
+    back: ClothingBackpackSHISatchel

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/employee.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/employee.yml
@@ -49,3 +49,6 @@
     id: EmployeePDA
     pocket1: TradePassport
     ears: ClothingHeadsetShinohara
+    gloves: ClothingHandsGlovesFingerless
+    outerClothing: ClothingOuterShinoharaVest
+    back: ClothingBackpackSHISatchel

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
@@ -5,6 +5,8 @@
   playTimeTracker: JobExecutiveSHI
   requirements:
     - !type:CharacterWhitelistRequirement
+    - !type:CharacterOverallTimeRequirement
+      min: 36000
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
@@ -5,8 +5,6 @@
   playTimeTracker: JobExecutiveSHI
   requirements:
     - !type:CharacterWhitelistRequirement
-    - !type:CharacterOverallTimeRequirement
-      min: 36000
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement
@@ -87,3 +85,4 @@
     id: ExecutivePDA
     pocket1: TradePassport
     ears: ClothingHeadsetShinohara
+    back: ClothingBackpackSHISatchel

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
@@ -5,6 +5,8 @@
   playTimeTracker: JobHighsecSHI
   requirements:
     - !type:CharacterWhitelistRequirement
+    - !type:CharacterOverallTimeRequirement
+      min: 35000
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
@@ -5,8 +5,6 @@
   playTimeTracker: JobHighsecSHI
   requirements:
     - !type:CharacterWhitelistRequirement
-    - !type:CharacterOverallTimeRequirement
-      min: 35000
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement
@@ -51,11 +49,9 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitShinoharaHighsec
     shoes: ClothingShoesBootsCombat
-    belt: WeaponLaserSvalinn
-    head: ClothingHeadHatShinoharaHelmet
-    outerClothing: ClothingOuterArmorShinoharaArmorHighsec
     gloves: ClothingHandsGlovesCombat
     id: HighsecPDA
     ears: ClothingHeadsetShinohara
     pocket1: Handcuffs
     pocket2: TradePassport
+    back: ClothingBackpackSHISatchel

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/medtech.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/medtech.yml
@@ -50,3 +50,6 @@
     pocket1: TradePassport
     eyes: ClothingEyesGlassesChemical
     ears: ClothingHeadsetShinohara
+    gloves: ClothingHandsGlovesLatex
+    outerClothing: ClothingOuterCoatLab
+    back: ClothingBackpackSHISatchel

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/security.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/security.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobSecuritySHI
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 18000
+      min: 7200
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement
@@ -49,9 +49,9 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitShinoharaSecurity
     shoes: ClothingShoesBootsCombat
-    belt: WeaponLaserSvalinn
     gloves: ClothingHandsGlovesCombat
     id: CorpsecPDA
     ears: ClothingHeadsetShinohara
     pocket1: Handcuffs
     pocket2: TradePassport
+    back: ClothingBackpackSHISatchel


### PR DESCRIPTION
Updates the Shinohara roles' default loadouts, and changed playtime requirements for specific roles.

- Added Shinohara courier bags as a default option for all SHI roles.
- Gave Board Executive their suit jacket back.
- Removed HighSec's armor.
- Removed HighSec's and CorpSec's laser pistol.
- Gave Salaryman their high-vis vest and fingerless gloves back.
- Gave MedSpec Researchers latex gloves and a labcoat.
- Reduced playtime requirement for CorpSec from 5 hours to 2.
- Added playtime requirement for Board Executive: 4 hours.