### PR TITLE
Psionic Braineating

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -278,6 +278,11 @@ public sealed class PsionicAbilitiesSystem : EntitySystem
                 Loc,
                 psionicComponent,
                 psionicPower);
+
+        var ev = new PsionicPowersModifiedEvent(
+            psionicComponent.ActivePowers
+        );
+        RaiseLocalEvent(uid, ref ev);
     }
 
     public void RemovePsionicPower(EntityUid uid, PsionicPowerPrototype psionicPower, bool forced = false)
@@ -296,6 +301,11 @@ public sealed class PsionicAbilitiesSystem : EntitySystem
                 Loc,
                 psionicComponent,
                 psionicPower);
+
+        var ev = new PsionicPowersModifiedEvent(
+            psionicComponent.ActivePowers
+        );
+        RaiseLocalEvent(uid, ref ev);
     }
 
     private void UpdatePowerSlots(PsionicComponent psionic)

--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -135,6 +135,12 @@ public sealed class PsionicAbilitiesSystem : EntitySystem
 
         RefreshPsionicModifiers(uid, psionic);
         UpdatePowerSlots(psionic);
+
+        // HULLROT EDIT
+        var ev = new PsionicPowersModifiedEvent(
+            psionic.ActivePowers
+        );
+        RaiseLocalEvent(uid, ref ev);
     }
 
     /// <summary>

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -83,3 +83,16 @@ public sealed partial class FoodComponent : Component
     [DataField]
     public HashSet<string> MoodletsOnEat = new();
 }
+
+// HULLROT EDIT
+
+[ByRefEvent]
+public sealed class FoodEatenFullyEvent
+{
+    public EntityUid Edible;
+
+    public FoodEatenFullyEvent(EntityUid edible)
+    {
+        Edible = edible;
+    }
+}

--- a/Content.Server/Nutrition/Components/FoodComponent.cs
+++ b/Content.Server/Nutrition/Components/FoodComponent.cs
@@ -83,16 +83,3 @@ public sealed partial class FoodComponent : Component
     [DataField]
     public HashSet<string> MoodletsOnEat = new();
 }
-
-// HULLROT EDIT
-
-[ByRefEvent]
-public sealed class FoodEatenFullyEvent
-{
-    public EntityUid Edible;
-
-    public FoodEatenFullyEvent(EntityUid edible)
-    {
-        Edible = edible;
-    }
-}

--- a/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
+++ b/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
@@ -49,9 +49,7 @@ namespace Content.Server._Crescent.Magic
 
             foreach (var power in entity.Comp.PowerPrototypes)
             {
-                // Generate a float between 0 and 1, if it's less than ChancePerPower, give the power.
-                var roll = _random.NextFloat(1f);
-                if (roll >= entity.Comp.ChancePerPower)
+                if (_random.Prob(entity.Comp.ChancePerPower))
                     continue;
 
                 if (!_prototypeManager.TryIndex<PsionicPowerPrototype>(power, out var powerProto))

--- a/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
+++ b/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Psionics;
 using Robust.Server.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server._Crescent.Magic
@@ -17,6 +18,7 @@ namespace Content.Server._Crescent.Magic
     public sealed class PsionicBrainEatingSystem : EntitySystem
     {
 
+        [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly ContainerSystem _container = default!;
         [Dependency] private readonly PsionicAbilitiesSystem _psionics = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -42,8 +44,16 @@ namespace Content.Server._Crescent.Magic
             if (HasComp<MindbrokenComponent>(args.User))
                 return;
 
+            if (!TryComp<PsionicComponent>(args.User, out var psiComp) && entity.Comp.RequiresLatent)
+                return;
+
             foreach (var power in entity.Comp.PowerPrototypes)
             {
+                // Generate a float between 0 and 1, if it's less than ChancePerPower, give the power.
+                var roll = _random.NextFloat(1f);
+                if (roll >= entity.Comp.ChancePerPower)
+                    continue;
+
                 if (!_prototypeManager.TryIndex<PsionicPowerPrototype>(power, out var powerProto))
                     return;
 

--- a/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
+++ b/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
@@ -1,0 +1,26 @@
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.Magic.Events;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Crescent.Magic
+{
+    public sealed class PsionicBrainEatingSystem : EntitySystem
+    {
+
+        [Dependency] private readonly StorageSystem _storage = default!;
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<PsionicComponent, PsionicPowersModifiedEvent>(OnPowersModified);
+        }
+
+        private void OnPowersModified(Entity<PsionicComponent> entity, ref PsionicPowersModifiedEvent args)
+        {
+            var powers = args.Powers;
+
+            // Get the brain of the entity
+        }
+    }
+}

--- a/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
+++ b/Content.Server/_Crescent/Magic/PsionicBrainEatingSystem.cs
@@ -1,6 +1,9 @@
 using Content.Server.Storage.EntitySystems;
+using Content.Shared._Crescent.Magic;
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.Magic.Events;
+using Content.Shared.PowerCell.Components;
+using Robust.Server.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Utility;
 
@@ -9,10 +12,17 @@ namespace Content.Server._Crescent.Magic
     public sealed class PsionicBrainEatingSystem : EntitySystem
     {
 
-        [Dependency] private readonly StorageSystem _storage = default!;
+        [Dependency] private readonly ContainerSystem _container = default!;
+
+        // sawmill
+        [Dependency] private readonly ILogManager _logManager = default!;
+        private ISawmill? _sawmill;
         public override void Initialize()
         {
             base.Initialize();
+
+            _sawmill = _logManager.GetSawmill("fine_dining");
+
             SubscribeLocalEvent<PsionicComponent, PsionicPowersModifiedEvent>(OnPowersModified);
         }
 
@@ -20,7 +30,60 @@ namespace Content.Server._Crescent.Magic
         {
             var powers = args.Powers;
 
-            // Get the brain of the entity
+            if (_sawmill == null)
+                _sawmill = _logManager.GetSawmill("fine_dining");
+
+            // Get the torso of the entity
+            if (!_container.TryGetContainer(entity.Owner, "body_root_part", out var torsoContainer))
+                return;
+
+            _sawmill.Info("step 1");
+
+            if (torsoContainer.ContainedEntities.Count == 0)
+                return;
+
+            var torso = torsoContainer.ContainedEntities[0];
+
+            _sawmill.Info("step 1.5");
+
+            // Get the head of the entity
+            if (!_container.TryGetContainer(torso, "body_part_slot_head", out var headContainer))
+                return;
+
+            _sawmill.Info("step 2 (3??)");
+
+            if (headContainer.ContainedEntities.Count == 0)
+                return;
+
+            var head = headContainer.ContainedEntities[0];
+
+            _sawmill.Info("step 3 (4???) [let me leave this hell]");
+
+            // NOW we can get the brain (jesus finally)
+            if (!_container.TryGetContainer(head, "body_organ_slot_brain", out var brain))
+                return;
+
+            _sawmill.Info("step 4 (5???) [almost there]");
+
+            if (brain.ContainedEntities.Count == 0)
+                return;
+
+            var brainEntity = brain.ContainedEntities[0];
+
+            _sawmill.Info("step 5 (6???) [i can see the light]");
+
+            // FINALLY, add PsionicBrainComponent to the brain if it doesn't already exist, and set its powers.
+
+            var psibraincomp = EnsureComp<PsionicBrainComponent>(brainEntity);
+
+            psibraincomp.PowerPrototypes = new List<string>();
+
+            foreach (var power in powers)
+            {
+                psibraincomp.PowerPrototypes.Add(power.ID);
+            }
+
+            // Why did I do this.
         }
     }
 }

--- a/Content.Shared/Psionics/PsionicComponent.cs
+++ b/Content.Shared/Psionics/PsionicComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Abilities.Psionics;
 using Content.Shared.DoAfter;
 using Content.Shared.Psionics;
 using Content.Shared.Random;
@@ -230,5 +231,17 @@ namespace Content.Shared.Abilities.Psionics
 
         [DataField]
         public Dictionary<string, float> AvailablePowers = new();
+    }
+}
+
+// HULLROT EDIT
+[ByRefEvent]
+public sealed class PsionicPowersModifiedEvent
+{
+    public HashSet<PsionicPowerPrototype> Powers;
+
+    public PsionicPowersModifiedEvent(HashSet<PsionicPowerPrototype> powers)
+    {
+        Powers = powers;
     }
 }

--- a/Content.Shared/_Crescent/Magic/PsionicBrainComponent.cs
+++ b/Content.Shared/_Crescent/Magic/PsionicBrainComponent.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Content.Shared.Psionics;
+
+namespace Content.Shared._Crescent.Magic
+{
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    public sealed partial class PsionicBrainComponent : Component
+    {
+        // networking is not fucking me over this time
+        [DataField, AutoNetworkedField]
+        public List<string> PowerPrototypes = new();
+    }
+}

--- a/Content.Shared/_Crescent/Magic/PsionicBrainComponent.cs
+++ b/Content.Shared/_Crescent/Magic/PsionicBrainComponent.cs
@@ -13,5 +13,13 @@ namespace Content.Shared._Crescent.Magic
         // networking is not fucking me over this time
         [DataField, AutoNetworkedField]
         public List<string> PowerPrototypes = new();
+
+        // Do you need to be a Psion to take the power from this brain?
+        [DataField, AutoNetworkedField]
+        public bool RequiresLatent = true;
+
+        // What's the per-power chance of getting a power from this brain?
+        [DataField, AutoNetworkedField]
+        public float ChancePerPower = 1.0f;
     }
 }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Whenever you eat a former Psion's brain, you will get whatever powers they had. This can be extended by defining a new brain in .YML that has a set of powers already.

This PR was a commision by `bomk.` on Discord.
