### PR TITLE
imperial light mech doesn't require T2 mechatronics anymore

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -439,11 +439,11 @@
   result: WandererFlatpack
   completetime: 2
   materials:
-    AdvancedMechatronics: 3500
-    AdvancedElectronics: 2000
+    BasicMechatronics: 2500
+    AdvancedElectronics: 1000
     Gold: 600
     Silver: 650
-    Steel: 4250
+    Steel: 3000
     Tungsten: 1500
 
 - type: latheRecipe


### PR DESCRIPTION
Parity with NCWL's light mech cost. I had used the paladin's recipe as a base. tee hee.