### PR TITLE
SHI SVBT-2 and BULWARK-2 speed update

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
@@ -61,8 +61,8 @@
         Heat: 15
         Caustic: 15
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCorpsec
 
@@ -131,8 +131,8 @@
         Heat: 35
         Caustic: 35
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: GroupExamine


### PR DESCRIPTION
Brings SHI armor items SVBT-2 and BULWARK-2 speeds up to modern standards.

- Decreases the speed malus on the SBVT-2 from 30% to 10% (like all other hardsuits in-game)
- Decreases the speed malus on the BULWARK-2 from 10% of 0 (like all other non-atmospheric armors in-game)