### PR TITLE
SHI Research Overhaul

### DIFF
--- a/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
+++ b/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
@@ -145,3 +145,4 @@ research-technology-shinohara-gilgamesh = mR-815 Prototype Exosuit
 research-technology-shinohara-ballisticfab = TF-22 Armaments Foundry
 research-technology-shinohara-dermalarmor = KOURINDO-U Dermal Armor
 research-technology-shinohara-shiverblade = SHI-RIP9 Shiver Blade
+research-technology-shinohara-premierballistics = Corporate Premier Ballistics

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/electronics.yml
@@ -3,17 +3,16 @@
   result: BasicElectronics1
   completetime: 0.5
   materials:
-    Steel: 100
-    Copper: 50
+    Copper: 200
 
 - type: latheRecipe
   id: WeakLaserLocus1Electronics
   result: WeakLaserLocus1
   completetime: 0.5
   materials:
-    Glass: 250
+    Glass: 100
     Steel: 100
-    BasicElectronics: 100
+    BasicElectronics: 500
 
 
 - type: latheRecipe
@@ -21,9 +20,8 @@
   result: HardsuitElectronics1
   completetime: 0.5
   materials:
-    Silver: 50
     Steel: 100
-    BasicElectronics: 250
+    BasicElectronics: 500
 
 - type: latheRecipe
   id: EMPGrenadeElectronics

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/mechatronics.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/mechatronics.yml
@@ -4,7 +4,6 @@
   completetime: 0.5
   materials:
     Steel: 200
-    Silver: 50
 
 - type: latheRecipe
   id: PlastitaniumFibreAlloy1Mechatronics
@@ -13,7 +12,7 @@
   materials:
     Plasteel: 400
     Silver: 100
-    Gold: 50
+    Gold: 100
 
 - type: latheRecipe
   id: WeaponPistolMk58Mechatronics

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/shinohara.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/shinohara.yml
@@ -77,7 +77,7 @@
   materials:
     Durathread: 1000
     Steel: 1000
-    Tungsten: 500
+    Tungsten: 200
 
 - type: latheRecipe
   id: ClothingHeadHatShinoharaHelmet
@@ -86,7 +86,7 @@
   materials:
     Durathread: 500
     Steel: 500
-    Tungsten: 250
+    Tungsten: 100
 
 - type: latheRecipe
   id: ClothingOuterArmorShinoharaArmorBulwark
@@ -188,8 +188,9 @@
   result: WeaponPistolZodum
   completetime: 2
   materials:
-    Steel: 1500
+    Steel: 1000
     Plastic: 500
+    Tungsten: 200
     BallisticCycler: 500
 
 - type: latheRecipe
@@ -197,8 +198,9 @@
   result: WeaponPistolSmartpistol
   completetime: 2
   materials:
-    Steel: 2500
+    Steel: 1000
     Plastic: 500
+    Tungsten: 100
     BasicElectronics: 500
     BallisticCycler: 500
 
@@ -208,7 +210,7 @@
   completetime: 2
   materials:
     Steel: 2500
-    Plastic: 1000
+    Plastic: 1500
     BallisticCycler: 500
 
 - type: latheRecipe
@@ -217,8 +219,7 @@
   completetime: 2
   materials:
     Steel: 2500
-    Silver: 1000
-    BallisticCycler: 500
+    Plastic: 1000
 
 - type: latheRecipe
   id: WeaponPistolMk58SHI
@@ -234,9 +235,9 @@
   completetime: 2
   materials:
     Steel: 1500
-    Plastic: 500
-    Silver: 1000
-    BallisticCycler: 1000
+    Plastic: 1500
+    Silver: 600
+    BallisticCycler: 500
 
 - type: latheRecipe
   id: WeaponRevolverMateba
@@ -245,7 +246,7 @@
   materials:
     Steel: 1500
     Plastic: 500
-    Silver: 1000
+    Silver: 300
 
 - type: latheRecipe
   id: WeaponRevolverInspector
@@ -254,7 +255,7 @@
   materials:
     Steel: 1500
     Plastic: 500
-    Silver: 500
+    Silver: 300
 
 - type: latheRecipe
   id: WeaponRifleHoundMarksman
@@ -263,7 +264,6 @@
   materials:
     Steel: 2500
     Plastic: 1500
-    Silver: 1000
     BallisticCycler: 500
 
 - type: latheRecipe
@@ -281,10 +281,33 @@
   result: WeaponLightMachineGunL6
   completetime: 2
   materials:
-    Steel: 3500
-    Plastic: 1500
+    Steel: 4000
+    Plastic: 2000
     Silver: 1000
+    Tungsten: 300
     BallisticCycler: 1500
+
+- type: latheRecipe
+  id: WeaponRifleBarghest
+  result: WeaponRifleBarghest
+  completetime: 2
+  materials:
+    Steel: 3000
+    Plastic: 2000
+    Silver: 600
+    Tungsten: 200
+    BallisticCycler: 500
+
+- type: latheRecipe
+  id: WeaponSniperHristov
+  result: WeaponSniperHristov
+  completetime: 2
+  materials:
+    Steel: 3000
+    Plastic: 2000
+    Silver: 600
+    Tungsten: 200
+    BallisticCycler: 500
 
 - type: latheRecipe
   id: WeaponSubMachineGunMP49
@@ -292,8 +315,7 @@
   completetime: 2
   materials:
     Steel: 1500
-    Plastic: 500
-    Silver: 500
+    Plastic: 1500
     BallisticCycler: 500
 
 - type: latheRecipe
@@ -302,7 +324,8 @@
   completetime: 2
   materials:
     Steel: 2500
-    Silver: 1000
+    Plastic: 1500
+    Silver: 500
     BallisticCycler: 500
 
 - type: latheRecipe
@@ -410,9 +433,9 @@
   result: WeaponLauncherMilkor
   completetime: 2
   materials:
-    Steel: 2500
-    Gold: 1000
-    TubeLoader: 500
+    Steel: 3000
+    Silver: 1000
+    TubeLoader: 1000
 
 - type: latheRecipe
   id: WeaponLauncherDisposableRocket
@@ -436,8 +459,8 @@
   result: VariableCommodityFabricatorFlatpack
   completetime: 2
   materials:
-    Gold: 1000
-    Silver: 2500
+    Gold: 2500
+    Silver: 500
     Steel: 2500
 
 - type: latheRecipe
@@ -445,8 +468,8 @@
   result: AutoloomFablatheFlatpack
   completetime: 2
   materials:
-    Gold: 1000
-    Silver: 2500
+    Gold: 2500
+    Silver: 500
     Steel: 2500
 
 - type: latheRecipe
@@ -456,8 +479,8 @@
   materials:
     BasicMechatronics: 2500
     BasicElectronics: 2500
-    Gold: 1500
-    Silver: 2500
+    Gold: 3000
+    Silver: 1000
     Steel: 3000
 
 - type: latheRecipe
@@ -467,8 +490,8 @@
   materials:
     BasicMechatronics: 2500
     BasicElectronics: 2500
-    Gold: 1500
-    Silver: 2500
+    Gold: 3000
+    Silver: 1000
     Steel: 3000
 
 - type: latheRecipe
@@ -570,7 +593,7 @@
   completetime: 2
   materials:
     BasicMechatronics: 1000
-    Silver: 500
+    Gold: 500
     Steel: 2500
     TubeLoader: 1000
 
@@ -580,7 +603,7 @@
   completetime: 2
   materials:
     AdvancedMechatronics: 1000
-    Silver: 500
+    Gold: 500
     Steel: 2500
     TubeLoader: 1000
 
@@ -591,8 +614,8 @@
   materials:
     NanotrasenElectronics: 1000
     BasicMechatronics: 1000
-    Silver: 1500
-    Steel: 2500
+    Steel: 1500
+    Gold: 1500
     HardlightGenerator: 3000
 
 - type: latheRecipe
@@ -601,7 +624,7 @@
   completetime: 2
   materials:
     BasicMechatronics: 1500
-    Silver: 1000
+    Gold: 1000
     Steel: 5000
     BallisticCycler: 1000
 
@@ -621,37 +644,32 @@
   result: HardlightGenerator1
   completetime: 2
   materials:
-    AdvancedElectronics: 300
-    Gold: 300
-    Silver: 300
-    Glass: 500
+    BasicElectronics: 2000
+    Plasma: 500
 
 - type: latheRecipe
   id: AdvancedMechatronics1
   result: AdvancedMechatronics1
   completetime: 2
   materials:
-    BasicMechatronics: 1000
-    Gold: 1500
-    Steel: 1500
+    BasicMechatronics: 2000
+    Silver: 1000
 
 - type: latheRecipe
   id: AdvancedElectronics1
   result: AdvancedElectronics1
   completetime: 2
   materials:
-    BasicMechatronics: 1000
-    Copper: 1500
-    Silver: 1500
+    BasicElectronics: 2000
+    Gold: 1000
 
 - type: latheRecipe
   id: PlastitaniumFibreAlloySHI
   result: PlastitaniumFibreAlloy1
   completetime: 2
   materials:
-    Steel: 1000
-    Plasma: 1500
-    Silver: 1500
+    Steel: 100
+    Plasma: 100
 
 - type: latheRecipe
   id: HardsuitElectronicsSHI
@@ -666,25 +684,24 @@
   result: LaserLocus1
   completetime: 2
   materials:
-    BasicElectronics: 1500
-    Silver: 1500
+    BasicElectronics: 1000
+    Plasma: 500
 
 - type: latheRecipe
   id: TubeLoader1
   result: TubeLoader1
   completetime: 2
   materials:
-    AdvancedMechatronics: 500
-    Silver: 1000
-    Steel: 1500
+    BasicMechatronics: 2000
+    Plasma: 500
 
 - type: latheRecipe
   id: BallisticCycler1
   result: BallisticCycler1
   completetime: 2
   materials:
-    AdvancedMechatronics: 1000
-    Steel: 1500
+    BasicMechatronics: 1000
+    Plasma: 500
 
 - type: latheRecipe
   id: TelescopicBatonSHI

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -648,9 +648,12 @@
       - AdvancedVariableCommodityFablatheFlatpack
       - WeaponRifleGoro
       - WeaponRifleLecterSHI
+      - WeaponShotgunEnforcer
       - WeaponRevolverMateba
       - WeaponSubMachineGunSabre
       - WeaponLightMachineGunL6
+      - WeaponSniperHristov
+      - WeaponRifleBarghest
       - WeaponLauncherMilkor
       - BoriaticComposterFlatpack
       - CyberneticsMantisBladeRight

--- a/Resources/Prototypes/_Crescent/Research/shinohara.yml
+++ b/Resources/Prototypes/_Crescent/Research/shinohara.yml
@@ -1,6 +1,37 @@
 # Tier 1
 
 - type: technology
+  id: ShinoharaAdvancedMaterials
+  name: research-technology-shinohara-advancedmaterials
+  icon:
+    sprite: _Crescent/Objects/Materials/materials.rsi
+    state: advancedmechanic
+  discipline: Corporate
+  tier: 1
+  cost: 9000
+  recipeUnlocks:
+  - AdvancedElectronics1
+  - AdvancedMechatronics1
+  - PlastitaniumFibreAlloySHI
+  - HardlightGenerator1
+  technologyPrerequisites:
+  - ShinoharaBasicFactory
+
+- type: technology
+  id: ShinoharaWeaponComponents
+  name: research-technology-shinohara-weaponcomponents
+  icon:
+    sprite: _Crescent/Objects/Materials/materials.rsi
+    state: tubeloaderrobotics
+  discipline: Corporate
+  tier: 1
+  cost: 10000
+  recipeUnlocks:
+  - BallisticCycler1
+  - TubeLoader1
+  - LaserLocus1
+
+- type: technology
   id: ShinoharaClothes
   name: research-technology-shinohara-clothes
   icon:
@@ -18,16 +49,16 @@
   - ClothingOuterHardsuitHEV
 
 - type: technology
-  id: ShinoharaDisposableLauncher
-  name: research-technology-shinohara-disposablelauncher
+  id: ShinoharaBoriaticComposting
+  name: research-technology-shinohara-boriaticcomposting
   icon:
-    sprite: _Crescent/Objects/Weapons/Guns/disposablerpg.rsi
-    state: icon
+    sprite: _Crescent/Objects/Misc/fuelcan.rsi
+    state: jug
   discipline: Corporate
   tier: 1
-  cost: 5000
+  cost: 8000
   recipeUnlocks:
-  - WeaponLauncherDisposableRocket
+  - BoriaticComposterFlatpack
 
 - type: technology
   id: ShinoharaShipyardManufactorum
@@ -52,35 +83,6 @@
   cost: 5000
   recipeUnlocks:
   - ScrapRefinerFlatpack
-
-- type: technology
-  id: ShinoharaSecurity
-  name: research-technology-shinohara-security
-  icon:
-    sprite: _Crescent/Clothing/Corpo/OuterClothing/ballisticvest.rsi
-    state: icon
-  discipline: Corporate
-  tier: 1
-  cost: 2500
-  recipeUnlocks:
-  - ClothingUniformJumpsuitShinoharaSecurity
-  - ClothingOuterArmorShinoharaArmorBulwark
-  - ClothingHeadHatShinoharaNonevaHelm
-  - TelescopicBatonSHI
-  - SHIKatana
-  - ClothingBeltSheathSHIKatana
-
-- type: technology
-  id: ShinoharaCybereyes
-  name: research-technology-shinohara-cybereyes
-  icon:
-    sprite: _Crescent/Objects/Misc/cybernetics.rsi
-    state: shinoharaoptics
-  discipline: Corporate
-  tier: 1
-  cost: 5000
-  recipeUnlocks:
-  - ShinoharaOptics
 
 - type: technology
   id: ShinoharaBasicMechGuns
@@ -110,19 +112,21 @@
   - WeaponFighterAutocannon
 
 - type: technology
-  id: ShinoharaHighsec
-  name: research-technology-shinohara-highsec
+  id: ShinoharaSecurity
+  name: research-technology-shinohara-security
   icon:
-    sprite: _Crescent/Clothing/SHI/OuterClothing/highsec.rsi
+    sprite: _Crescent/Clothing/Corpo/OuterClothing/ballisticvest.rsi
     state: icon
   discipline: Corporate
   tier: 1
-  cost: 9000
+  cost: 2500
   recipeUnlocks:
-  - ClothingUniformJumpsuitShinoharaHighsec
-  - ClothingOuterArmorShinoharaArmorHighsec
-  - ClothingHeadHatShinoharaHelmet
-  - ClothingOuterHardsuitHighsec
+  - ClothingUniformJumpsuitShinoharaSecurity
+  - ClothingOuterArmorShinoharaArmorBulwark
+  - ClothingHeadHatShinoharaNonevaHelm
+  - TelescopicBatonSHI
+  - SHIKatana
+  - ClothingBeltSheathSHIKatana
 
 - type: technology
   id: ShinoharaDisposableGuns
@@ -180,29 +184,7 @@
   recipeUnlocks:
   - AutoloomFablatheFlatpack
 
-- type: technology
-  id: ShinoharaHardpoint
-  name: research-technology-shinohara-hardpoint
-  icon:
-    sprite: _Crescent/Structures/fixedHardpoint.rsi
-    state: large
-  discipline: Corporate
-  tier: 1
-  cost: 8000
-  recipeUnlocks:
-  - FixedHardpointFlatpack
-
-- type: technology
-  id: ShinoharaSlugthrower
-  name: research-technology-shinohara-slugthrower
-  icon:
-    sprite: _Crescent/Objects/ShuttleWeapons/50cal.rsi
-    state: space_artillery
-  discipline: Corporate
-  tier: 1
-  cost: 10000
-  recipeUnlocks:
-  - SlugthrowerFlatpack
+# Tier 2
 
 - type: technology
   id: ShinoharaExhumer
@@ -211,7 +193,7 @@
     sprite: _Crescent/Objects/ShuttleWeapons/mininglaser.rsi
     state: states
   discipline: Corporate
-  tier: 1
+  tier: 2
   cost: 6500
   recipeUnlocks:
   - ExhumerFlatpack
@@ -223,41 +205,73 @@
     sprite: _Crescent/Objects/ShuttleWeapons/lasersmall.rsi
     state: lse-400c
   discipline: Corporate
-  tier: 1
+  tier: 2
   cost: 5000
   recipeUnlocks:
   - PlasmaRepeaterFlatpack
 
 - type: technology
-  id: ShinoharaAdvancedMaterials
-  name: research-technology-shinohara-advancedmaterials
+  id: ShinoharaSlugthrower
+  name: research-technology-shinohara-slugthrower
   icon:
-    sprite: _Crescent/Objects/Materials/materials.rsi
-    state: advancedmechanic
-  discipline: Corporate
-  tier: 2
-  cost: 9000
-  recipeUnlocks:
-  - AdvancedElectronics1
-  - AdvancedMechatronics1
-  - PlastitaniumFibreAlloySHI
-  - HardlightGenerator1
-  technologyPrerequisites:
-  - ShinoharaBasicFactory
-
-- type: technology
-  id: ShinoharaWeaponComponents
-  name: research-technology-shinohara-weaponcomponents
-  icon:
-    sprite: _Crescent/Objects/Materials/materials.rsi
-    state: tubeloaderrobotics
+    sprite: _Crescent/Objects/ShuttleWeapons/50cal.rsi
+    state: space_artillery
   discipline: Corporate
   tier: 2
   cost: 10000
   recipeUnlocks:
-  - BallisticCycler1
-  - TubeLoader1
-  - LaserLocus1
+  - SlugthrowerFlatpack
+
+- type: technology
+  id: ShinoharaHardpoint
+  name: research-technology-shinohara-hardpoint
+  icon:
+    sprite: _Crescent/Structures/fixedHardpoint.rsi
+    state: large
+  discipline: Corporate
+  tier: 2
+  cost: 8000
+  recipeUnlocks:
+  - FixedHardpointFlatpack
+
+- type: technology
+  id: ShinoharaHighsec
+  name: research-technology-shinohara-highsec
+  icon:
+    sprite: _Crescent/Clothing/SHI/OuterClothing/highsec.rsi
+    state: icon
+  discipline: Corporate
+  tier: 2
+  cost: 9000
+  recipeUnlocks:
+  - ClothingUniformJumpsuitShinoharaHighsec
+  - ClothingOuterArmorShinoharaArmorHighsec
+  - ClothingHeadHatShinoharaHelmet
+  - ClothingOuterHardsuitHighsec
+
+- type: technology
+  id: ShinoharaDisposableLauncher
+  name: research-technology-shinohara-disposablelauncher
+  icon:
+    sprite: _Crescent/Objects/Weapons/Guns/disposablerpg.rsi
+    state: icon
+  discipline: Corporate
+  tier: 2
+  cost: 5000
+  recipeUnlocks:
+  - WeaponLauncherDisposableRocket
+
+- type: technology
+  id: ShinoharaCybereyes
+  name: research-technology-shinohara-cybereyes
+  icon:
+    sprite: _Crescent/Objects/Misc/cybernetics.rsi
+    state: shinoharaoptics
+  discipline: Corporate
+  tier: 2
+  cost: 5000
+  recipeUnlocks:
+  - ShinoharaOptics
 
 - type: technology
   id: ShinoharaWeaponTorpedo
@@ -274,20 +288,6 @@
   - IdnaTorpedo
 
 - type: technology
-  id: ShinoharaAdvancedFab
-  name: research-technology-shinohara-advancedfactory
-  icon:
-    sprite: _Crescent/Structures/factorystructures.rsi
-    state: advancedfab
-  discipline: Corporate
-  tier: 2
-  cost: 12500
-  recipeUnlocks:
-  - AdvancedVariableCommodityFablatheFlatpack
-  technologyPrerequisites:
-  - ShinoharaAdvancedMaterials
-
-- type: technology
   id: ShinoharaAdvancedBallistics
   name: research-technology-shinohara-advancedballistics
   icon:
@@ -295,13 +295,13 @@
     state: icon
   discipline: Corporate
   tier: 2
-  cost: 12500
+  cost: 10000
   recipeUnlocks:
   - WeaponRifleGoro
   - WeaponRifleLecterSHI
+  - WeaponShotgunEnforcer
   - WeaponRevolverMateba
   - WeaponSubMachineGunSabre
-  - WeaponLightMachineGunL6
 
 - type: technology
   id: ShinoharaGrenadeLauncher
@@ -316,18 +316,6 @@
   - WeaponLauncherMilkor
 
 - type: technology
-  id: ShinoharaBoriaticComposting
-  name: research-technology-shinohara-boriaticcomposting
-  icon:
-    sprite: _Crescent/Objects/Misc/fuelcan.rsi
-    state: jug
-  discipline: Corporate
-  tier: 2
-  cost: 8000
-  recipeUnlocks:
-  - BoriaticComposterFlatpack
-
-- type: technology
   id: ShinoharaMantisblades
   name: research-technology-shinohara-mantisblades
   icon:
@@ -339,6 +327,36 @@
   recipeUnlocks:
   - CyberneticsMantisBladeRight
   - CyberneticsMantisBladeLeft
+
+- type: technology
+  id: ShinoharaDermalArmor
+  name: research-technology-shinohara-dermalarmor
+  icon:
+    sprite: _Crescent/Objects/Misc/cybernetics.rsi
+    state: dermalarmor
+  discipline: Corporate
+  tier: 2
+  cost: 9000
+  recipeUnlocks:
+  - CyberneticsDermalArmor
+
+# Tier 3
+
+- type: technology
+  id: ShinoharaPremierBallistics
+  name: research-technology-shinohara-premierballistics
+  icon:
+    sprite: _Crescent/Objects/Weapons/Guns/l6saw.rsi
+    state: icon
+  discipline: Corporate
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - WeaponLightMachineGunL6
+  - WeaponRifleBarghest
+  - WeaponSniperHristov
+  - WeaponPistolSmartpistol
+  - WeaponPistolZodum
 
 - type: technology
   id: ShinoharaAdvancedMechWeapons
@@ -391,16 +409,18 @@
   - GilgameshFlatpack
 
 - type: technology
-  id: ShinoharaDermalArmor
-  name: research-technology-shinohara-dermalarmor
+  id: ShinoharaAdvancedFab
+  name: research-technology-shinohara-advancedfactory
   icon:
-    sprite: _Crescent/Objects/Misc/cybernetics.rsi
-    state: dermalarmor
+    sprite: _Crescent/Structures/factorystructures.rsi
+    state: advancedfab
   discipline: Corporate
   tier: 3
-  cost: 9000
+  cost: 12500
   recipeUnlocks:
-  - CyberneticsDermalArmor
+  - AdvancedVariableCommodityFablatheFlatpack
+  technologyPrerequisites:
+  - ShinoharaAdvancedMaterials
 
 - type: technology
   id: ShinoharaBallisticFab


### PR DESCRIPTION
Completely overhauls SHI research to be much, much more functional with the flow of the round and somewhat more expansive in what is available. Also revamps the components system to have much more sensible progression from one component to another and adjusts weapon prices slightly to fit the newly-added tier progression of weapons (t1 guns take plastic/steel only, t2 take plastic/steel/silver, t3 take plastic/steel/silver/tungsten-carbide) and makes some weapon prices more sensible (eg the double barrel shotgun doesn't need a gas system to cycle because that's not how break actions work).

There's way too much to cover but I will try to explain in as much detail what the PR changes in the discord.
The crux of it is:

Tiers have been reworked
T1: Basic manufacturing technology, basic small arms and armor, ballistic and advanced components, basic mech and fighter weapons.
T2: Cybernetics, ship weapons and hardpoints, advanced weapons and armor, disposable/basic explosives.
T3: Exotic ballistics, mechsuits, advanced mech weaponry, shields, ballistic/advanced commodity autofabricators.

With how the tech tree works now, Shinohara has to be able to make their exclusive parts at t1, because other factions depend on the availability of these items to make a majority of their technology. By the time that Shinohara reaches tier 2 in the current system, the other factions are at the point that they're waiting on SHI to get their components, which usually takes half an hour of waiting by this point in the round. With the new change, SHI gets these components first at roughly the time that the other factions begin to need them, and go on to unlock their specialty weapons/technologies after their bases have been covered, which is much more functional of a system than before.