### PR TITLE
Add's Volgin Shocking Glove

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/NCWL/Hands/gloves.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/NCWL/Hands/gloves.yml
@@ -15,3 +15,26 @@
     fiberMaterial: fibers-durathread
     fiberColor: fibers-black
   - type: FingerprintMask
+
+- type: entity
+  parent: ClothingHandsBase
+  id: ClothingHandsAdmiralParadeGlovesShocking
+  name: major admiral's parade gloves
+  description: A pair of long crimson gloves traditionally worn by Majors during parades, tribunals, and “diplomatic visits.” The material feels expensive, thick satin that hides more than it shows. This pair is fastened with faintly glimmering crystals and lined with needle-like contacts that bite into the wearer's nerves. It hums faintly, as though charged with something unnatural, waiting to be discharged.
+  components:
+  - type: Sprite
+    sprite: _Crescent/Clothing/NCWL/Hands/ncwl_admiral_gloves.rsi
+  - type: Clothing
+    sprite: _Crescent/Clothing/NCWL/Hands/ncwl_admiral_gloves.rsi
+  - type: GloveHeatResistance
+    heatResistance: 1400
+  - type: Insulated
+  - type: Fiber
+    fiberMaterial: fibers-durathread
+    fiberColor: fibers-black
+  - type: FingerprintMask
+  - type: ClothingGrantPsionicPower
+    power: NoosphericZap
+  - type: Psionic
+    removable: false
+    roller: false


### PR DESCRIPTION
Added a new entity for the Major's Gloves, granting the Noospheric Zap ability.


# Description
Added a new entity for the Major's Gloves, granting the Noospheric Zap ability.




# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun New Major glove entity with Shocking Psionic power

