### PR TITLE
Fix Circuit Imprinters not accepting Basic Electronic Parts

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -643,6 +643,7 @@
       tags:
       - Sheet
       - RawMaterial
+      - CraftMaterials
       - Ingot
       - Wooden
       - ClothMade


### PR DESCRIPTION
Fixed an issue where the circuit imprinter would not accept basic electronic parts despite many recipes requiring them

:cl: Pockets
- fix: Fix Circuit Imprinters not accepting Basic Electronic Parts
