### PR TITLE
port oni rage "mechanic" and felinids being faster from legacy

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/felinid.yml
@@ -37,11 +37,11 @@
     left hand:
       part: LeftHandHuman
     right leg:
-      part: RightLegHuman
+      part: RightLegFelinid
       connections:
       - right foot
     left leg:
-      part: LeftLegHuman
+      part: LeftLegFelinid
       connections:
       - left foot
     right foot:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -17,18 +17,21 @@
         Blunt: 1.35
         Slash: 1.25
         Piercing: 1.25
-        Asphyxiation: 1.35
-  - type: Damageable
-    damageModifierSet: Oni
   - type: Body
     prototype: Human
+  - type: Damageable
+    damageModifierSet: Oni
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      60: 1.2  # 0.7 is base speed.
+      80: 1.6  # 0.5 is base speed.
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 220
+        density: 222 # 20% more mass
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -15,7 +15,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.28
-        density: 140
+        density: 120 # 65% less mass
         restitution: 0.0
         mask:
         - MobMask
@@ -27,6 +27,8 @@
     damageModifierSet: Felinid
   - type: SlowOnDamage
     speedModifierThresholds:
+      0: 1.2 # move faster when not hurt
+      30: 1 # move slower when hurt
       60: 0.85  # 0.7 is base speed.
       80: 0.75  # 0.5 is base speed.
   - type: MeleeWeapon

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -27,8 +27,7 @@
     damageModifierSet: Felinid
   - type: SlowOnDamage
     speedModifierThresholds:
-      0: 1.2 # move faster when not hurt
-      30: 1 # move slower when hurt
+      30: 0.9 # move slower when hurt
       60: 0.85  # 0.7 is base speed.
       80: 0.75  # 0.5 is base speed.
   - type: MeleeWeapon

--- a/Resources/Prototypes/_Crescent/Entities/Body/Parts/felinid.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Body/Parts/felinid.yml
@@ -1,0 +1,27 @@
+- type: entity
+  parent: LeftLegHuman
+  id: LeftLegFelinid
+  name: "left felinid leg"
+  components:
+  - type: BodyPart
+    children:
+      right foot:
+        id: "right foot"
+        type: Foot
+  - type: MovementBodyPart # 20% faster movespeed
+    walkSpeed: 3.6
+    sprintSpeed: 6 
+
+- type: entity
+  parent: RightLegHuman
+  id: RightLegFelinid
+  name: "right felinid leg"
+  components:
+  - type: BodyPart
+    children:
+      left foot:
+        id: "left foot"
+        type: Foot
+  - type: MovementBodyPart # 20% faster movespeed
+    walkSpeed: 3.6
+    sprintSpeed: 6


### PR DESCRIPTION
makes onis move faster the lower their HP is instead of slowing them down
makes felinids move faster than average
slightly adjust the mass of both species aswell

removes unneeded aphyx damage modifier from onis aswell which was there for some reason even though no melee in the game deals asphyx damage