### PR TITLE
Shipguns have machine boards now

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Bullets/cartridges.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Bullets/cartridges.yml
@@ -470,6 +470,9 @@
   components:
   - type: Item
     size: Normal
+  - type: Tag
+    tags:
+      - SmartBomb
   - type: CartridgeAmmo
     proto: SmartBombBase
     deleteOnSpawn: true

--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Bullets/tags.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Bullets/tags.yml
@@ -80,3 +80,8 @@
 
 - type: Tag
   id: VulcanCartridgeBox
+
+#smartbomb tag
+
+- type: Tag
+  id: SmartBomb

--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/fixedpoints.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/fixedpoints.yml
@@ -1,9 +1,10 @@
 #plasma repeater
 
 - type: entity
-  id: ShuttleGunPlasmaRepeater
   parent: BaseFixedShipgun
+  id: ShuttleGunPlasmaRepeater
   name: SHI 400c plasma bolt repeater
+  suffix: ShipGun
   description: A fixedpoint self-defense tool based on recovered NT technology, subpar in terms of power use to firepower ratio - mostly seen on civilian models.
   components:
   - type: ApcPowerReceiver
@@ -15,13 +16,8 @@
     layers:
     - state: lse-400c
     - state: mag-unshaded-9
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
+  - type: Machine
+    board: ShuttleGunPlasmaRepeaterCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -30,8 +26,10 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
   - type: Gun
     projectileSpeed: 95
     fireRate: 1.2
@@ -59,14 +57,20 @@
   - type: HardpointAnchorableOnly
     class: Energy
     size: Small
-
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #exhumer
 
 - type: entity
-  id: ShuttleGunExhumer
   parent: BaseFixedShipgun
+  id: ShuttleGunExhumer
   name: SHI 250c "Exhumer" kinetic pulser
+  suffix: ShipGun
   description: A fixedpoint mining tool that accelerates sound waves to kinetically slice through rock - mostly seen on civilian miner models.
   components:
   - type: ApcPowerReceiver
@@ -78,10 +82,8 @@
     layers:
     - state: states
     - state: mag-7
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
+  - type: Machine
+    board: ShuttleGunExhumerCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -90,8 +92,10 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
   - type: Gun
     projectileSpeed: 65
     fireRate: 3
@@ -119,13 +123,20 @@
   - type: HardpointAnchorableOnly
     class: Ballistic
     size: Small
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #bizmuth
 
 - type: entity
-  id: ShuttleGunBizmuth
   parent: BaseFixedShipgun
+  id: ShuttleGunBizmuth
   name: 500i "Bizmuth" ion gatling
+  suffix: ShipGun
   description: An interceptor's bread and butter, the Bizmuth fires supercharged balls of electricty to pelt the powergrids of unsuspecting targets. Most often seen on interceptor vessels.
   components:
   - type: ApcPowerReceiver
@@ -137,10 +148,8 @@
     layers:
     - state: base
     - state: mag-7
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
+  - type: Machine
+    board: ShuttleGunBizmuthCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -149,8 +158,10 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
   - type: Gun
     projectileSpeed: 95
     fireRate: 2.4
@@ -178,13 +189,20 @@
   - type: HardpointAnchorableOnly
     class: Energy
     size: Medium
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #idna
 
 - type: entity
-  id: ShuttleGunTorpedo
   parent: BaseFixedShipgun
+  id: ShuttleGunTorpedo
   name: SHI 180mm "Idna" small torpedo pod
+  suffix: ShipGun
   description: A small fixedpoint rocketpod with basic heatseeking function.
   components:
   - type: ApcPowerReceiver
@@ -198,11 +216,8 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-2
       map: ["enum.GunVisualLayers.Mag"]
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
-      ballistic-ammo: !type:Container
+  - type: Machine
+    board: ShuttleGunTorpedoCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -211,8 +226,11 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+      ballistic-ammo: !type:Container
   - type: Gun
     projectileSpeed: 30
     fireRate: 0.4
@@ -226,7 +244,7 @@
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/empty.ogg
   - type: BallisticAmmoProvider
-    proto: IdnaTorpedo
+    #proto: IdnaTorpedo - on being rebuilt from destruction this gives it free ammo
     whitelist:
       tags:
         - Torpedo
@@ -241,14 +259,21 @@
     class: Missile
     size: Small
   - type: Appearance
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 
 #kurosawa
 
 - type: entity
-  id: ShuttleGunKurosawa
   parent: BaseFixedShipgun
+  id: ShuttleGunKurosawa
   name: NCWL-3 48mm "Kurosawa" rocket pod
+  suffix: ShipGun
   description: A small fixedpoint rocketpod with a capacity of two rockets. Must be reloaded by hand.
   components:
   - type: ApcPowerReceiver
@@ -261,11 +286,8 @@
     - state: rocket
     - state: mag-7
       map: ["enum.GunVisualLayers.Mag"]
-  - type: ContainerContainer
-    containers:
-      machine_board: !type:Container
-      machine_parts: !type:Container
-      ballistic-ammo: !type:Container
+  - type: Machine
+    board: ShuttleGunKurosawaCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -274,8 +296,11 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+      ballistic-ammo: !type:Container
   - type: Gun
     projectileSpeed: 135
     fireRate: 1
@@ -292,7 +317,7 @@
     class: Missile
     size: Small
   - type: BallisticAmmoProvider
-    proto: CartridgeRocketLowYield
+    #proto: CartridgeRocketLowYield - on being rebuilt from destruction this gives it free ammo
     whitelist:
       tags:
         - Rocket48mm
@@ -303,13 +328,20 @@
     magState: mag
     steps: 8
     zeroVisible: false
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #sumitomo
 
 - type: entity
-  id: ShuttleGunMissileRack
   parent: BaseFixedShipgun
+  id: ShuttleGunMissileRack
   name: NT-6 48mm "Sumitomo" missile rack
+  suffix: ShipGun
   description: A massive, ship-mounted missile rack with a unique feeding mechanism. Requires a rocket magazine to operate.
   components:
   - type: ApcPowerReceiver
@@ -322,6 +354,8 @@
     - state: rocket
     - state: mag-7
       map: ["enum.GunVisualLayers.Mag"]
+  - type: Machine
+    board: ShuttleGunMissileRackCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -330,8 +364,6 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
   - type: ContainerContainer
     containers:
       machine_board: !type:Container
@@ -359,7 +391,7 @@
       gun_magazine:
         name: Magazine
         priority: 2
-        startingItem: MagazineRocketLowYield
+        #startingItem: MagazineRocketLowYield - on being rebuilt from destruction this gives it free ammo
         whitelist:
           tags:
           - MagazineRocket48mm
@@ -368,59 +400,41 @@
           params:
             pitch: 2
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
-
   - type: MagazineAmmoProvider
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #43mm (slugthrower)
 
 - type: entity
+  parent: BaseFixedShipgun
   id: SlugthrowerCannon
   name: SHI 43mm "Dasher" ballistic slugthrower
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: An outdated, gas-operated slugthrower. Usually found mounted on older civilian models. Ballistic-fed.
   components:
   - type: ApcPowerReceiver
     powerLoad: 3000
   - type: StaticPrice
     price: 8000
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 400
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:PlaySoundBehavior
-            sound:
-              collection: MetalGlassBreak
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              SheetSteel1:
-                min: 2
-                max: 4
   - type: Sprite
     sprite: _Crescent/Objects/ShuttleWeapons/50cal.rsi
     layers:
     - state: space_artillery
-  - type: ItemSlots
-    slots:
-      gun_magazine:
-        name: Magazine
-        startingItem: MagazineLightRifleBoxSlug
-        insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
-        priority: 2
-        whitelist:
-          tags:
-            - SlugthrowerCartridgeBox
-      gun_chamber:
-        name: Chamber
-        startingItem: CartridgeMachineGunArmorPiercing
-        priority: 1
-        whitelist:
-          tags:
-            - CartridgeMachineGun
+  - type: Machine
+    board: SlugthrowerCannonCircuitboard
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+        - !type:ChangeConstructionNodeBehavior
+          node: machineFrame
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
@@ -437,19 +451,50 @@
     size: Medium
   - type: AutoShootGun
   - type: ChamberMagazineAmmoProvider
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        #startingItem: MagazineLightRifleBoxSlug - on being rebuilt from destruction this gives it free ammo
+        insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - SlugthrowerCartridgeBox
+      gun_chamber:
+        name: Chamber
+        startingItem: CartridgeMachineGunArmorPiercing
+        priority: 1
+        whitelist:
+          tags:
+            - CartridgeMachineGun
 
 #hardliner
 
 - type: entity
+  parent: BaseFixedShipgun
   id: HardlineBeamPulser
   name: NT-9 3100c 'Hardliner' plasma lance turret
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: A ship-mounted, fixed-point artillery turret using military laser technology as a base - an outdated model from the now-defunct NanoTrasen, although tried and tested in many battles. Requires upkeep in the form of liquid coolant to stay operational.
   components:
   - type: ApcPowerReceiver
     powerLoad: 1000
   - type: StaticPrice
     price: 10000
+  - type: Sprite
+    sprite: _Crescent/Objects/ShuttleWeapons/bigfuckinglaser.rsi
+    layers:
+    - state: space_artillery
+  - type: Machine
+    board: HardlineBeamPulserCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -458,17 +503,11 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
-  - type: Sprite
-    sprite: _Crescent/Objects/ShuttleWeapons/bigfuckinglaser.rsi
-    layers:
-    - state: space_artillery
-  - type: BasicEntityAmmoProvider
-    proto: BulletMachineGunPlasmaShuttleLarge
   - type: ContainerContainer
     containers:
       SpaceArtillery-CoolantSlot: !type:ContainerSlot {}
+  - type: BasicEntityAmmoProvider
+    proto: BulletMachineGunPlasmaShuttleLarge
   - type: Gun
     fireRate: 0.7
     projectileSpeed: 70
@@ -496,19 +535,32 @@
             whitelist:
                 components:
                 - Stack
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #120mm
 
 - type: entity
+  parent: BaseFixedShipgun
   id: Type99Artillery
   name: SHI Type 99 120mm artillery
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: A heavier, bulkier version of the slugthrower. An antiquated SHI design. Requires manual reloading after its two chambers.
   components:
   - type: ApcPowerReceiver
     powerLoad: 3000
   - type: StaticPrice
     price: 7500
+  - type: Sprite
+    sprite: _Crescent/Objects/ShuttleWeapons/artillery.rsi
+    layers:
+    - state: artillery
+  - type: Machine
+    board: Type99ArtilleryCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -517,27 +569,21 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
-  - type: Sprite
-    sprite: _Crescent/Objects/ShuttleWeapons/artillery.rsi
-    layers:
-    - state: artillery
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+        ents: []
   - type: BallisticAmmoProvider
-    soundInsert: 
+    soundInsert:
       path: /Audio/Weapons/Guns/UnionfallWeapons/amr_close_1.ogg
     fillWithDoAfter: true
     fillDelay: 1
     cycleable: true
     capacity: 2
-    proto: CartridgeShellArmorPiercing
+    #proto: CartridgeShellArmorPiercing - on being rebuilt from destruction this gives it free ammo
     whitelist:
       tags:
       - CartridgeShell
-  - type: ContainerContainer
-    containers:
-      ballistic-ammo: !type:Container
-        ents: []
   - type: Gun
     fireRate: 0.5
     projectileSpeed: 95
@@ -548,19 +594,32 @@
   - type: HardpointAnchorableOnly
     class: Ballistic
     size: Large
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #320mm
 
 - type: entity
+  parent: BaseFixedShipgun
   id: AcceleratorCannon
   name: 320mm Imperial high-frequency accelerator cannon
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: A product of the Imperial war machine. Produced as an experimental solution to various insurgencies in the Crescent Sector - and later stolen by the insurgents themselves. Still a rare sight aboard most vessels.
   components:
   - type: ApcPowerReceiver
     powerLoad: 6000
   - type: StaticPrice
     price: 20000
+  - type: Sprite
+    sprite: _Crescent/Objects/ShuttleWeapons/bigcannon.rsi
+    layers:
+    - state: deck_turret_loaded
+  - type: Machine
+    board: AcceleratorCannonCircuitboard
   - type: Destructible
     thresholds:
     - trigger:
@@ -569,27 +628,21 @@
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
-        - !type:DoActsBehavior
-          acts: ["Destruction"]
-  - type: Sprite
-    sprite: _Crescent/Objects/ShuttleWeapons/bigcannon.rsi
-    layers:
-    - state: deck_turret_loaded
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+        ents: []
+      SpaceArtillery-CoolantSlot: !type:ContainerSlot {}
   - type: Battery
     maxCharge: 1000000
     startingCharge: 1000000
   - type: BallisticAmmoProvider
     cycleable: false
     capacity: 5
-    proto: CartridgeRailHighExplosive
+    #proto: CartridgeRailHighExplosive - on being rebuilt from destruction this gives it free ammo
     whitelist:
       tags:
       - Cartridge
-  - type: ContainerContainer
-    containers:
-      ballistic-ammo: !type:Container
-        ents: []
-      SpaceArtillery-CoolantSlot: !type:ContainerSlot {}
   - type: Gun
     fireRate: 0.1
     projectileSpeed: 135
@@ -617,44 +670,52 @@
             whitelist:
                 components:
                 - Stack
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #vulcan
 
 - type: entity
+  parent: BaseFixedShipgun
   id: NTVulcanTurret
   name: NT 20mm "Vulcan" machineturret
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: An antiquated NanoTrasen model, commonly fitted on mid-tech fighters.
   components:
   - type: ApcPowerReceiver
     powerLoad: 3000
   - type: StaticPrice
     price: 2500
+  - type: Sprite
+    sprite: _Crescent/Objects/ShuttleWeapons/vulcan.rsi
+    layers:
+    - state: space_artillery
+  - type: Machine
+    board: NTVulcanTurretCircuitboard
   - type: Destructible
     thresholds:
       - trigger:
           !type:DamageTrigger
           damage: 500
         behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
           - !type:PlaySoundBehavior
             sound:
               collection: MetalGlassBreak
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              SheetSteel1:
-                min: 2
-                max: 4
-  - type: Sprite
-    sprite: _Crescent/Objects/ShuttleWeapons/vulcan.rsi
-    layers:
-    - state: space_artillery
+          - !type:ChangeConstructionNodeBehavior
+            node: machineFrame
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+        ents: []
   - type: ItemSlots
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineVulcan
+        #startingItem: MagazineVulcan - on being rebuilt from destruction this gives it free ammo
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -668,10 +729,6 @@
         whitelist:
           tags:
             - VulcanCartridgeBox
-  - type: ContainerContainer
-    containers:
-      ballistic-ammo: !type:Container
-        ents: []
   - type: Gun
     fireRate: 12
     projectileSpeed: 135
@@ -684,44 +741,52 @@
     size: Small
   - type: AutoShootGun
   - type: ChamberMagazineAmmoProvider
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #cleanser
 
 - type: entity
+  parent: BaseFixedShipgun
   id: SAWCleanser
   name: SAW 20mm "Cleanser" gatlingun
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: A retrofit of the 20mm vulcan made by TSFC SAW Engineers. All safety considerations seem to be missing on this..
   components:
   - type: ApcPowerReceiver
     powerLoad: 3000
   - type: StaticPrice
     price: 8000
+  - type: Sprite
+    sprite: _Crescent/Objects/ShuttleWeapons/gatling.rsi
+    layers:
+    - state: space_artillery
+  - type: Machine
+    board: SAWCleanserCircuitboard
   - type: Destructible
     thresholds:
       - trigger:
           !type:DamageTrigger
           damage: 250 # retrofits make it a bit flimsy
         behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
+          - !type:ChangeConstructionNodeBehavior
+            node: machineFrame
           - !type:PlaySoundBehavior
             sound:
               collection: MetalGlassBreak
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              SheetSteel1:
-                min: 2
-                max: 4
-  - type: Sprite
-    sprite: _Crescent/Objects/ShuttleWeapons/gatling.rsi
-    layers:
-    - state: space_artillery
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+        ents: []
   - type: ItemSlots
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineVulcan
+        #startingItem: MagazineVulcan - on being rebuilt from destruction this gives it free ammo
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -735,10 +800,6 @@
         whitelist:
           tags:
             - VulcanCartridgeBox
-  - type: ContainerContainer
-    containers:
-      ballistic-ammo: !type:Container
-        ents: []
   - type: Gun
     fireRate: 36
     maxAngle: 4
@@ -753,44 +814,52 @@
     size: Medium
   - type: AutoShootGun
   - type: ChamberMagazineAmmoProvider
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board
 
 #wasp
 
 - type: entity
+  parent: BaseFixedShipgun
   id: WaspSwarmPlatform
   name: ATH 70mm 'Wasp' swarmrocket platform
-  parent: BaseFixedShipgun
+  suffix: ShipGun
   description: A light, stationary rocket platform intended to apply pressure to a target with its guided projectiles.
   components:
   - type: ApcPowerReceiver
     powerLoad: 2000
   - type: StaticPrice
     price: 8000
+  - type: Sprite
+    sprite: _Crescent/Objects/ShuttleWeapons/wasp.rsi
+    layers:
+    - state: base
+  - type: Machine
+    board: WaspSwarmPlatformCircuitboard
   - type: Destructible
     thresholds:
       - trigger:
           !type:DamageTrigger
           damage: 500 #
         behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
+          - !type:ChangeConstructionNodeBehavior
+            node: machineFrame
           - !type:PlaySoundBehavior
             sound:
               collection: MetalGlassBreak
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              SheetSteel1:
-                min: 2
-                max: 4
-  - type: Sprite
-    sprite: _Crescent/Objects/ShuttleWeapons/wasp.rsi
-    layers:
-    - state: base
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+        ents: []
   - type: ItemSlots
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: SwarmrocketClip
+        #startingItem: SwarmrocketClip - on being rebuilt from destruction this gives it free ammo
         priority: 2
         whitelist:
           tags:
@@ -800,10 +869,6 @@
           params:
             pitch: 2
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
-  - type: ContainerContainer
-    containers:
-      ballistic-ammo: !type:Container
-        ents: []
   - type: Gun
     projectileSpeed: 60
     fireRate: 3.4
@@ -819,3 +884,9 @@
     size: Small
   - type: AutoShootGun
   - type: MagazineAmmoProvider
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_parts
+    - machine_board

--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/machineboards.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/machineboards.yml
@@ -1,0 +1,443 @@
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: ShuttleGunPlasmaRepeaterCircuitboard
+  name: SHI 400c plasma bolt repeater machine board
+  description: A machine printed circuit board for a SHI plasma bolt repeater.
+  components:
+    - type: MachineBoard
+      prototype: ShuttleGunPlasmaRepeater
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: ShuttleGunExhumerCircuitboard
+  name: SHI 250c "Exhumer" kinetic pulser machine board
+  description: A machine printed circuit board for a SHI 250c "Exhumer" kinetic pulser
+  components:
+    - type: MachineBoard
+      prototype: ShuttleGunExhumer
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: ShuttleGunBizmuthCircuitboard
+  name: 500i "Bizmuth" ion gatling machine board
+  description: A machine printed circuit board for a 500i "Bizmuth" ion gatling
+  components:
+    - type: MachineBoard
+      prototype: ShuttleGunBizmuth
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: ShuttleGunTorpedoCircuitboard
+  name: SHI 180mm "Idna" small torpedo pod machine board
+  description: A machine printed circuit board for a SHI 180mm "Idna" small torpedo pod
+  components:
+    - type: MachineBoard
+      prototype: ShuttleGunTorpedo
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: ShuttleGunKurosawaCircuitboard
+  name: NCWL-3 48mm "Kurosawa" rocket pod machine board
+  description: A machine printed circuit board for a NCWL-3 48mm "Kurosawa" rocket pod
+  components:
+    - type: MachineBoard
+      prototype: ShuttleGunKurosawa
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: ShuttleGunMissileRackCircuitboard
+  name: NT-6 48mm "Sumitomo" missile rack machine board
+  description: A machine printed circuit board for a NT-6 48mm "Sumitomo" missile rack
+  components:
+    - type: MachineBoard
+      prototype: ShuttleGunMissileRack
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: SlugthrowerCannonCircuitboard
+  name: SHI 43mm "Dasher" ballistic slugthrower machine board
+  description: A machine printed circuit board for a SHI 43mm "Dasher" ballistic slugthrower
+  components:
+    - type: MachineBoard
+      prototype: SlugthrowerCannon
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: HardlineBeamPulserCircuitboard
+  name: NT-9 3100c 'Hardliner' plasma lance turret machine board
+  description: A machine printed circuit board for a NT-9 3100c 'Hardliner' plasma lance turret
+  components:
+    - type: MachineBoard
+      prototype: HardlineBeamPulser
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: Type99ArtilleryCircuitboard
+  name: SHI Type 99 120mm artillery machine board
+  description: A machine printed circuit board for a SHI Type 99 120mm artillery
+  components:
+    - type: MachineBoard
+      prototype: Type99Artillery
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: AcceleratorCannonCircuitboard
+  name: 320mm Imperial high-frequency accelerator cannon machine board
+  description: A machine printed circuit board for a 320mm Imperial high-frequency accelerator cannon
+  components:
+    - type: MachineBoard
+      prototype: AcceleratorCannon
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: NTVulcanTurretCircuitboard
+  name: NT 20mm "Vulcan" machineturret machine board
+  description: A machine printed circuit board for a NT 20mm "Vulcan" machineturret
+  components:
+    - type: MachineBoard
+      prototype: NTVulcanTurret
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: SAWCleanserCircuitboard
+  name: SAW 20mm "Cleanser" gatlingun machine board
+  description: A machine printed circuit board for a SAW 20mm "Cleanser" gatlingun
+  components:
+    - type: MachineBoard
+      prototype: SAWCleanser
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WaspSwarmPlatformCircuitboard
+  name: ATH 70mm 'Wasp' swarmrocket platform machine board
+  description: A machine printed circuit board for a ATH 70mm 'Wasp' swarmrocket platform
+  components:
+    - type: MachineBoard
+      prototype: WaspSwarmPlatform
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretPDTCircuitboard
+  name: SHI MG-213 light dual machinegun 20x135mm machine board
+  description: A machine printed circuit board for a SHI MG-213 light dual machinegun 20x135mm
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretPDT
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretPDTNCSPCircuitboard
+  name: SHI MG-213 light dual machinegun 20x135mm Mk. II machine board
+  description: A machine printed circuit board for a SHI MG-213 light dual machinegun 20x135mm Mk. II
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretPDTNCSP
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretVulcanCircuitboard
+  name: 20mm PTA "Operator" gatling turret platform machine board
+  description: A machine printed circuit board for a 20mm PTA "Operator" gatling turret
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretVulcan
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretSwarmerCircuitboard
+  name: swarmer missile launcher machine board
+  description: A machine printed circuit board for a swarmer missile launcher
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretSwarmer
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretCoilgunCircuitboard
+  name: 60mm NT "Derecho" exotic blaster machine board
+  description: A machine printed circuit board for a 60mm NT "Derecho" exotic blaster
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretCoilgun
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretMortarCircuitboard
+  name: 90mm heavy mortar-pounder machine board
+  description: A machine printed circuit board for a 90mm heavy mortar-pounder
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretMortar
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretLaserCircuitboard
+  name: SHI 180c 'Torch' pressure gatling machine board
+  description: A machine printed circuit board for a SHI 180c 'Torch' pressure gatling
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretLaser
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretSmartbombCircuitboard
+  name: NCWL 88mm 'Pilum' propelled mine launcher machine board
+  description: A machine printed circuit board for a NCWL 88mm 'Pilum' propelled mine launcher
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretSmartbomb
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: WeaponTurretNeedlerCircuitboard
+  name: 60mm PTA 'Needler' heavy precision autogun machine board
+  description: A machine printed circuit board for a 60mm PTA 'Needler' heavy precision autogun
+  components:
+    - type: MachineBoard
+      prototype: WeaponTurretNeedler
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: PointNFireCannonExampleCircuitboard
+  name: NT MG-02 dual machinegun 20x135mm machine board
+  description: A machine printed circuit board for a NT MG-02 dual machinegun 20x135mm
+  components:
+    - type: MachineBoard
+      prototype: PointNFireCannonExample
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretGargoyleCircuitboard
+  name: heavy 'Gargoyle' LRM cruise missile launcher machine board
+  description: A machine printed circuit board for a heavy 'Gargoyle' LRM cruise missile launcher
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretGargoyle
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretLancerCircuitboard
+  name: medium 'Lancer' MRM missile system machine board
+  description: A machine printed circuit board for a medium 'Lancer' MRM missile system
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretLancer
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretBattlemortarCircuitboard
+  name: 230mm 'Hephaeustus' assault artillery platform machine board
+  description: A machine printed circuit board for a 230mm 'Hephaeustus' assault artillery platform
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretBattlemortar
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: FlakCannonTurretCircuitboard
+  name: 88mm 'Prince' flak-screen turret machine board
+  description: A machine printed circuit board for a 88mm 'Prince' flak-screen turret
+  components:
+    - type: MachineBoard
+      prototype: FlakCannonTurret
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: CatapultTorpedoCircuitboard
+  name: MU91 323mm "Catapult" LRM torpedo launcher machine board
+  description: A machine printed circuit board for a MU91 323mm "Catapult" LRM torpedo launcher
+  components:
+    - type: MachineBoard
+      prototype: CatapultTorpedo
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretHeavyPlasmaRimwardCircuitboard
+  name: 800c "Rimward" hybrid plasma blaster machine board
+  description: A machine printed circuit board for a 800c "Rimward" hybrid plasma blaster
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretHeavyPlasmaRimward
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretHeavyPlasmaCircuitboard
+  name: 350c "Compakt" hybrid energy gatling machine board
+  description: A machine printed circuit board for a 350c "Compakt" hybrid energy gatling
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretHeavyPlasma
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretSolarisCircuitboard
+  name: 90mm "Solaris" antimatter blaster machine board
+  description: A machine printed circuit board for a 90mm "Solaris" antimatter blaster
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretSolaris
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretJeongCircuitboard
+  name: 70mm "Jeong" swarmrocket platform machine board
+  description: A machine printed circuit board for a 70mm "Jeong" swarmrocket platform
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretJeong
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretMagwellCircuitboard
+  name: SHI 180mm "Magwell" torpedo launcher machine board
+  description: A machine printed circuit board for a SHI 180mm "Magwell" torpedo launcher
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretMagwell
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: BaseWeaponTurretSlugspitterCircuitboard
+  name: SHI 43mm "Hullpiercer" slugspitter machine board
+  description: A machine printed circuit board for a SHI 43mm "Hullpiercer" slugspitter
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretSlugspitter
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: FlakCannonRegentCircuitboard
+  name: NT 88mm 'Regent' flak-screen turret machine board
+  description: A machine printed circuit board for a NT 88mm 'Regent' flak-screen turret
+  components:
+    - type: MachineBoard
+      prototype: FlakCannonRegent
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  id: MissilePodSnapdragonCircuitboard
+  name: NT 'Snapdragon' SRM missile system machine board
+  description: A machine printed circuit board for a NT 'Snapdragon' SRM missile system
+  components:
+    - type: MachineBoard
+      prototype: MissilePodSnapdragon
+      requirements:
+        MatterBin: 1
+
+- type: entity
+  id: BaseWeaponTurretKomodoCircuitboard
+  suffix: ShipGunMachineCircuitBoard
+  parent: BaseMachineCircuitboard
+  name: NT 400c 'Komodo' chemical blaster machine board
+  description: A machine printed circuit board for a NT 400c 'Komodo' chemical blaster
+  components:
+    - type: MachineBoard
+      prototype: BaseWeaponTurretKomodo
+      requirements:
+        MatterBin: 1

--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/turrets.yml
@@ -3,16 +3,16 @@
 - type: entity
   parent: BaseTurretShipgun
   id: WeaponTurretPDT
+  suffix: ShipGun
   name: SHI MG-213 light dual machinegun 20x135mm
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/lightautoturret.rsi
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: WeaponTurretPDTCircuitboard
     - type: Damageable
       damageContainer: Inorganic
     - type: Destructible
@@ -21,16 +21,14 @@
             !type:DamageTrigger
             damage: 500
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 145
       fireRate: 5
@@ -54,56 +52,56 @@
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Small
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 - type: entity
   parent: WeaponTurretPDT
-  name: SHI MG-213 light dual machinegun 20x135mm Mk. II
   id: WeaponTurretPDTNCSP
-  suffix: Tier 2
+  suffix: ShipGun, Tier 2
+  name: SHI MG-213 light dual machinegun 20x135mm Mk. II
   components:
     - type: Gun
       projectileSpeed: 145
       fireRate: 5.5
+    - type: Machine
+      board: WeaponTurretPDTNCSPCircuitboard
 
 # VULCAN TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: WeaponTurretVulcan
+  suffix: ShipGun
   name: 20mm PTA "Operator" gatling turret
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/vulcangatling.rsi
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: WeaponTurretVulcanCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       fireRate: 12
       projectileSpeed: 120
@@ -115,7 +113,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: MagazineVulcan
+          #startingItem: MagazineVulcan - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -135,47 +133,44 @@
       class: Ballistic
       size: Small
     - type: MagazineAmmoProvider
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # SWARMER TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretSwarmer
+  suffix: ShipGun
   name: swarmer missile launcher
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/swarmermissile.rsi
       drawdepth: Mobs
       layers:
         - state: swarmer
-
+    - type: Machine
+      board: BaseWeaponTurretSwarmerCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 75
       fireRate: 0.5
@@ -187,7 +182,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: MagazineSwarmer
+          #startingItem: MagazineSwarmer - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -208,12 +203,19 @@
       size: Small
     - type: MagazineAmmoProvider
     - type: ProjectileIFF
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # DERECHO TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: WeaponTurretCoilgun
+  suffix: ShipGun
   name: 60mm NT "Derecho" exotic blaster
   components:
     - type: Sprite
@@ -221,29 +223,21 @@
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: WeaponTurretCoilgunCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+
     - type: Gun
       projectileSpeed: 130
       fireRate: 2
@@ -267,43 +261,45 @@
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # MORTAR TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: WeaponTurretMortar
+  suffix: ShipGun
   name: 90mm heavy mortar-pounder
   components:
-
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/heavymortar.rsi
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: WeaponTurretMortarCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 130
       fireRate: 0.2
@@ -315,7 +311,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: MagazineMortar
+          #startingItem: MagazineMortar - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -329,55 +325,49 @@
           whitelist:
             tags:
               - MortarShell
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 2000
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Medium
     - type: MagazineAmmoProvider
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # PLASMA LASER TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: WeaponTurretLaser
+  suffix: ShipGun
   name: SHI 180c 'Torch' pressure gatling
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/plasmacannonnormal.rsi
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: WeaponTurretLaserCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 95
       fireRate: 4
@@ -401,45 +391,43 @@
     - type: HardpointAnchorableOnly
       class: Energy
       size: Small
-      
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
+
 # SMARTBOMB TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretSmartbomb
+  suffix: ShipGun
   name: NCWL 88mm 'Pilum' propelled mine launcher
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/smartmissile.rsi
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: BaseWeaponTurretSmartbombCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 500
           # TODO: Construction graph
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+          - trigger:
+              !type:DamageTrigger
+              damage: 500
+            behaviors:
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 14
       fireRate: 0.09
@@ -448,17 +436,27 @@
         - FullAuto
       soundGunshot: /Audio/Weapons/Guns/Gunshots/rpgfire.ogg
     - type: BallisticAmmoProvider
-      proto: SmartBomb
-      capacity: 99999
+      #proto: SmartBomb - on being rebuilt from destruction this gives it free ammo
+      whitelist:
+        tags:
+          - SmartBomb
+      capacity: 2
     - type: HardpointAnchorableOnly
       class: Missile
       size: Small
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # NEEDLER TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: WeaponTurretNeedler
+  suffix: ShipGun
   name: 60mm PTA 'Needler' heavy precision autogun
   components:
     - type: Sprite
@@ -466,29 +464,25 @@
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: WeaponTurretNeedlerCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 130
       fireRate: 0.6
@@ -501,7 +495,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: MagazineNeedler
+          #startingItem: MagazineNeedler - - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -515,56 +509,49 @@
           whitelist:
             tags:
               - NeedlerShell
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 3500
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # STATION PDT TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: PointNFireCannonExample
+  suffix: ShipGun, CAPITAL/STATION ONLY
   name: NT MG-02 dual machinegun 20x135mm
-  suffix: CAPITAL/STATION ONLY
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/lightautoturret.rsi
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
+    - type: Machine
+      board: PointNFireCannonExampleCircuitboard
     - type: Damageable
       damageContainer: Inorganic
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
             damage: 500
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       fireRate: 7
       projectileSpeed: 145
@@ -580,12 +567,19 @@
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Small
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # GARGOYLE TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretGargoyle
+  suffix: ShipGun
   name: heavy 'Gargoyle' LRM cruise missile launcher
   components:
     - type: Sprite
@@ -593,32 +587,25 @@
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: BaseWeaponTurretGargoyleCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 1600
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 1600
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 30
       fireRate: 0.4
@@ -629,25 +616,28 @@
     - type: BallisticAmmoProvider
       cycleable: false
       capacity: 3
-      proto: TorpGarg
+      #proto: TorpGarg - on being rebuilt from destruction this gives it free ammo
       whitelist:
         tags:
         - TorpedoGarg
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 6500
     - type: HardpointAnchorableOnly
       class: Missile
       size: Large
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # LANCER TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretLancer
+  suffix: ShipGun
   name: medium 'Lancer' MRM missile system
   components:
     - type: Sprite
@@ -655,32 +645,25 @@
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: BaseWeaponTurretLancerCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 85
       fireRate: 0.9
@@ -691,25 +674,28 @@
     - type: BallisticAmmoProvider
       cycleable: false
       capacity: 15
-      proto: LanceRocketCartridge
+      #proto: LanceRocketCartridge - on being rebuilt from destruction this gives it free ammo
       whitelist:
         tags:
         - LanceRocket
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 4000
     - type: HardpointAnchorableOnly
       class: Missile
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # HEPHAESTUS TURRET (230MM)
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretBattlemortar
+  suffix: ShipGun
   name: 230mm 'Hephaeustus' assault artillery platform
   components:
     - type: Sprite
@@ -717,32 +703,25 @@
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: BaseWeaponTurretBattlemortarCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 3000
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 3000
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 130
       fireRate: 0.2
@@ -753,25 +732,28 @@
     - type: BallisticAmmoProvider
       cycleable: false
       capacity: 3
-      proto: HeavyMortarCartridge
+      #proto: HeavyMortarCartridge - on being rebuilt from destruction this gives it free ammo
       whitelist:
         tags:
         - HeavyMortarShell
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 4000
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Large
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # PRINCE FLAK TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: FlakCannonTurret
+  suffix: ShipGun
   name: 88mm 'Prince' flak-screen turret
   components:
     - type: Sprite
@@ -779,32 +761,25 @@
       drawdepth: Mobs
       layers:
         - state: syndie_lethal
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: FlakCannonTurretCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 1600
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 1600
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 90
       fireRate: 0.8
@@ -817,7 +792,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: MagazineFlak
+          #startingItem: MagazineFlak - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -831,21 +806,24 @@
           whitelist:
             tags:
               - FlakShell
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 6500
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Large
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # 323MM CATAPULT TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: CatapultTorpedo
+  suffix: ShipGun
   name: MU91 323mm "Catapult" LRM torpedo launcher
   components:
     - type: Sprite
@@ -853,31 +831,24 @@
       drawdepth: Mobs
       layers:
         - state: catapult
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: CatapultTorpedoCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 1600
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 1600
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       projectileSpeed: 30
       fireRate: 0.2
@@ -888,59 +859,53 @@
     - type: BallisticAmmoProvider
       cycleable: false
       capacity: 6
-      proto: TorpCatapult
+      #proto: TorpCatapult - on being rebuilt from destruction this gives it free ammo
       whitelist:
         tags:
         - TorpedoCatapult
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 6500
     - type: HardpointAnchorableOnly
       class: Missile
       size: Large
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # RIMWARD TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretHeavyPlasmaRimward
+  suffix: ShipGun
   name: 800c "Rimward" hybrid plasma blaster
   description: A heavy laser turret combining antimatter and plasma technology.
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/atlas.rsi
       drawdepth: Mobs
       layers:
         - state: atlas
+    - type: Machine
+      board: BaseWeaponTurretHeavyPlasmaRimwardCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 75
       fireRate: 1.7
@@ -964,46 +929,44 @@
     - type: HardpointAnchorableOnly
       class: Energy
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # COMPAKT TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretHeavyPlasma
+  suffix: ShipGun
   name: 350c "Compakt" hybrid energy gatling
   description: A versatile energy turret with interchangable lenses for varied effect.
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/lasergatling.rsi
       drawdepth: Mobs
       layers:
         - state: lasergatling
+    - type: Machine
+      board: BaseWeaponTurretHeavyPlasmaCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 95
       fireRate: 12
@@ -1016,7 +979,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: LensInfared
+          #startingItem: LensInfared - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -1028,46 +991,44 @@
     - type: HardpointAnchorableOnly
       class: Energy
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # SOLARIS TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretSolaris
+  suffix: ShipGun
   name: 90mm "Solaris" antimatter blaster
   description: A versatile ballistic turret that fires specialized antimatter rounds. A hybrid of machinegun and artillery.
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/solaris.rsi
       drawdepth: Mobs
       layers:
         - state: solaris
+    - type: Machine
+      board: BaseWeaponTurretSolarisCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 95
       fireRate: 3.5
@@ -1080,7 +1041,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: StandardAntimatterCanister
+          #startingItem: StandardAntimatterCanister - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -1092,46 +1053,44 @@
     - type: HardpointAnchorableOnly
       class: Energy
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # JEONG TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretJeong
+  suffix: ShipGun
   name: 70mm "Jeong" swarmrocket platform
   description: A heavy, ship-mounted rocket platform that spits out a barrage of guided, small rockets.
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/jeong.rsi
       drawdepth: Mobs
       layers:
         - state: jeong
+    - type: Machine
+      board: BaseWeaponTurretJeongCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 60
       fireRate: 3.4
@@ -1147,7 +1106,7 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: SwarmrocketClip
+          #startingItem: SwarmrocketClip - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
@@ -1159,18 +1118,22 @@
     - type: HardpointAnchorableOnly
       class: Missile
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # MAGWELL TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretMagwell
+  suffix: ShipGun
   name: SHI 180mm "Magwell" torpedo launcher
   description: A small torpedo launcher that fires cheaply-manufactured, heat-seeking projectiles.
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/magwell.rsi
       drawdepth: Mobs
@@ -1179,29 +1142,23 @@
         map: ["enum.GunVisualLayers.Base"]
       - state: mag-1
         map: ["enum.GunVisualLayers.Mag"]
+    - type: Machine
+      board: BaseWeaponTurretMagwellCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 30
       fireRate: 0.5
@@ -1210,7 +1167,7 @@
         - FullAuto
       soundGunshot: /Audio/Weapons/Guns/Gunshots/rpgfire.ogg
     - type: BallisticAmmoProvider
-      proto: IdnaTorpedo
+      #proto: IdnaTorpedo - on being rebuilt from destruction this gives it free ammo
       whitelist:
         tags:
           - Torpedo
@@ -1227,12 +1184,19 @@
       steps: 7
       zeroVisible: false
     - type: Appearance
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # SLUGSPITTER TURRET (SLUGTHROWER)
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretSlugspitter
+  suffix: ShipGun
   name: SHI 43mm "Hullpiercer" slugspitter
   description: A low-tech alternative to the sophisticated Needler turrets. Easy to maintain, produce, and fire. Suffers from overheating issues and frequent jamming, though.
   components:
@@ -1241,29 +1205,24 @@
       drawdepth: Mobs
       layers:
         - state: slugspitter
+    - type: Machine
+      board: BaseWeaponTurretSlugspitterCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          ents: []
     - type: Gun
       fireRate: 3
       projectileSpeed: 80
@@ -1279,28 +1238,31 @@
       slots:
         gun_magazine:
           name: Magazine
-          startingItem: MagazineLightRifleBoxSlug
+          #startingItem: MagazineLightRifleBoxSlug - on being rebuilt from destruction this gives it free ammo
           insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
           ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
           priority: 2
           whitelist:
             tags:
               - SlugthrowerCartridgeBox
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
-          ents: []
     - type: ApcPowerReceiver
       powerLoad: 4000
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Medium
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # REGENT FLAK TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: FlakCannonRegent
+  suffix: ShipGun
   name: NT 88mm 'Regent' flak-screen turret
   description: A flak-screen turret recovered and fabricated with Abyssal materials and designed according to old NanoTrasen schematics. Fires a trio of explosive slugs and uses surrounding trace exotic matter in space to manufacture it's own ammunition.
   components:
@@ -1309,31 +1271,20 @@
       drawdepth: Mobs
       layers:
         - state: regent
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: FlakCannonRegentCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 1600
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 1600
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
     - type: Gun
       projectileSpeed: 95
@@ -1358,12 +1309,19 @@
     - type: HardpointAnchorableOnly
       class: Ballistic
       size: Large
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # SNAPDRAGON TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: MissilePodSnapdragon
+  suffix: ShipGun
   name: NT 'Snapdragon' SRM missile system
   description: A small short-range missile pod recovered and fabricated with Abyssal materials and designed according to old NanoTrasen schematics. Fires a blast of guided rockets and uses trace exotic matter in surrounding space to manufacture it's own ammunition.
   components:
@@ -1372,31 +1330,20 @@
       drawdepth: Mobs
       layers:
         - state: regent
-    - type: Damageable
-      damageContainer: Inorganic
+    - type: Machine
+      board: MissilePodSnapdragonCircuitboard
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
             damage: 1600
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 1600
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
     - type: ProjectileIFF
     - type: Gun
       projectileSpeed: 95
@@ -1421,46 +1368,44 @@
     - type: HardpointAnchorableOnly
       class: Missile
       size: Small
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board
 
 # KOMODO TURRET
 
 - type: entity
   parent: BaseTurretShipgun
   id: BaseWeaponTurretKomodo
+  suffix: ShipGun
   name: NT 400c 'Komodo' chemical blaster
   description: A small laser pulser of antiquated NanoTrasen design, commonly found mounted on droneships or found as scrap in the Abyss. Uses ancient, outdated chemical mixes to create accelerated laser pulses, which are then flung as projectiles. Luckily for you, this one seems to be sourcing it's material from inert dark matter in the void around it.
   components:
-    - type: ContainerContainer
-      containers:
-        ballistic-ammo: !type:Container
     - type: Sprite
       sprite: _Crescent/Objects/Autoturrets/komodo.rsi
       drawdepth: Mobs
       layers:
         - state: komodo
+    - type: Machine
+      board: BaseWeaponTurretKomodoCircuitboard
     - type: Destructible
       thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 800
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
             damage: 500
           # TODO: Construction graph
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
+            - !type:ChangeConstructionNodeBehavior
+              node: machineFrame
             - !type:PlaySoundBehavior
               sound:
                 collection: MetalGlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                SheetSteel1:
-                  min: 3
-                  max: 5
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
     - type: Gun
       projectileSpeed: 95
       fireRate: 3
@@ -1484,3 +1429,9 @@
     - type: HardpointAnchorableOnly
       class: Energy
       size: Small
+    - type: Construction
+      graph: Machine
+      node: machine
+      containers:
+      - machine_parts
+      - machine_board


### PR DESCRIPTION
Shipguns have machine boards, allowing them to be repaired after being destroyed. Build recipe for each gun currently 1 MatterBin as a placeholder.

Shipguns don't spawn with ammo anymore to prevent duping, made the pillum accept ammunition again and removed steel spawning from turrets being destroyed to prevent duping aswell. Also added the ShipGun prefix to all turrets so that they can be easily found. I feel so skibidi :D
▼・ᴗ・▼

Video was taken before I removed the steel dropping, courtesy of Ghost581

https://github.com/user-attachments/assets/c6244663-9612-4d60-8f4b-1aae0487165b

