### PR TITLE
Hayes trade machines seperated from Gliess' + Jackal warp point fix

### DIFF
--- a/Resources/Maps/_Crescent/Stations/gliess.yml
+++ b/Resources/Maps/_Crescent/Stations/gliess.yml
@@ -20155,21 +20155,17 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -4.5,12.5
       parent: 1
-- proto: InterdyneCargoChute
+- proto: GliessSantoCargoChute
   entities:
   - uid: 1997
     components:
-    - type: MetaData
-      name: gliess santo cargo turn-in chute
     - type: Transform
       pos: -6.5,18.5
       parent: 1
-- proto: InterdyneCargoDispenser
+- proto: GliessSantoCargoDispenser
   entities:
   - uid: 1998
     components:
-    - type: MetaData
-      name: gliess santo dispensary
     - type: Transform
       pos: -6.5,21.5
       parent: 1

--- a/Resources/Maps/_Crescent/Stations/hayes.yml
+++ b/Resources/Maps/_Crescent/Stations/hayes.yml
@@ -8415,7 +8415,7 @@ entities:
     - type: DeviceLinkSink
       links:
       - 599
-- proto: MachineFrame
+- proto: InterdyneCargoDispenser
   entities:
   - uid: 807
     components:

--- a/Resources/Maps/_Crescent/Stations/jackal.yml
+++ b/Resources/Maps/_Crescent/Stations/jackal.yml
@@ -23423,6 +23423,8 @@ entities:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
+    - type: WarpPoint
+      location: GSC Grinning Jackal
 - proto: WeaponPistolBlastpopGray
   entities:
   - uid: 3532

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Hayes/gases.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Hayes/gases.yml
@@ -18,3 +18,12 @@
   category: cargoproduct-category-name-atmospherics
   group: hayes
 
+- type: cargoProduct
+  id: AtmosphericsLiquidHayes
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: blue
+  product: LiquidOxygenCanister
+  cost: 2000
+  category: cargoproduct-category-name-atmospherics
+  group: hayes

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Hayes/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Hayes/medical.yml
@@ -49,22 +49,22 @@
   group: hayes
 
 - type: cargoProduct
+  id: EmergencyBruteKitHayes
+  icon:
+    sprite: Objects/Specific/Medical/firstaidkits.rsi
+    state: brutekit
+  product: CrateEmergencyBruteKit
+  cost: 2000
+  category: cargoproduct-category-name-medical
+  group: hayes
+
+- type: cargoProduct
   id: EmergencyBurnKitHayes
   icon:
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: burnkit
   product: CrateEmergencyBurnKit
   cost: 1500
-  category: cargoproduct-category-name-medical
-  group: hayes
-
-- type: cargoProduct
-  id: EmergencyToxinKitHayes
-  icon:
-    sprite: Objects/Specific/Medical/firstaidkits.rsi
-    state: toxinkit
-  product: CrateEmergencyToxinKit
-  cost: 1000
   category: cargoproduct-category-name-medical
   group: hayes
 
@@ -79,12 +79,12 @@
   group: hayes
 
 - type: cargoProduct
-  id: EmergencyBruteKitHayes
+  id: EmergencyToxinKitHayes
   icon:
     sprite: Objects/Specific/Medical/firstaidkits.rsi
-    state: brutekit
-  product: CrateEmergencyBruteKit
-  cost: 2000
+    state: toxinkit
+  product: CrateEmergencyToxinKit
+  cost: 1000
   category: cargoproduct-category-name-medical
   group: hayes
 

--- a/Resources/Prototypes/_Crescent/Catalog/VendingMachines/Inventories/cargodispensaries.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/VendingMachines/Inventories/cargodispensaries.yml
@@ -20,13 +20,18 @@
     TradeGoodAmmo: 9999
     TradeGoodRice: 9999
 
-
 - type: vendingMachineInventory
-  id: InterdyneDispensary
+  id: GliessSantoDispensary
   startingInventory:
     TradeGoodCybernetics: 9999
     TradeGoodAntibiotics: 9999
     TradeGoodAlcohol: 9999
+
+- type: vendingMachineInventory
+  id: InterdyneDispensary
+  startingInventory:
+    TradeGoodAntibiotics: 9999
+    TradeGoodCybernetics: 9999
 
 - type: vendingMachineInventory
   id: SawDispensary

--- a/Resources/Prototypes/_Crescent/Entities/Structures/dispensers.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/dispensers.yml
@@ -377,8 +377,8 @@
 
 - type: entity
   parent: BaseDispenser
-  id: InterdyneCargoChute
-  name: hayes cargo turn-in chute
+  id: GliessSantoCargoChute
+  name: gliess santo cargo turn-in chute
   description: A machine with piping systems that lead deep into the bowels of the station, accepting trade goods for deeds.
   components:
   - type: Anchorable
@@ -401,6 +401,42 @@
       TradeGoodWine: TradeDeedHigh
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedHigh
+      TradeGoodOldParts: TradeDeedHigh
+  - type: Sprite
+    sprite: _Crescent/Structures/cargochute.rsi
+    layers:
+    - state: "icon"
+  - type: PointLight
+    radius: 1.5
+    energy: 1.6
+    color: "#9dc5c9"
+
+- type: entity
+  parent: BaseDispenser
+  id: InterdyneCargoChute
+  name: hayes cargo turn-in chute
+  description: A machine with piping systems that lead deep into the bowels of the station, accepting trade goods for deeds.
+  components:
+  - type: Anchorable
+    flags:
+    - None
+  - type: Dispenser
+    defaultItem: TradeDeedStub
+    inventory:
+      TradeGoodAmmo: TradeDeedNormal
+      TradeGoodAlcohol: TradeDeedHigh
+      TradeGoodGunparts: TradeDeedLow
+      TradeGoodScrap: TradeDeedLow
+      TradeGoodRice: TradeDeedNormal
+      TradeGoodFlour: TradeDeedLow
+      TradeGoodSugar: TradeDeedLow
+      TradeGoodFabrics: TradeDeedVeryHigh
+      TradeGoodMiltech: TradeDeedExotic
+      TradeGoodAlloys: TradeDeedVeryHigh
+      TradeGoodPlasma: TradeDeedHigh
+      TradeGoodWine: TradeDeedHigh
+      TradeGoodNanoTrasen: TradeDeedHigh
+      TradeGoodOldCyber: TradeDeedExotic
       TradeGoodOldParts: TradeDeedHigh
   - type: Sprite
     sprite: _Crescent/Structures/cargochute.rsi

--- a/Resources/Prototypes/_Crescent/Entities/Structures/vending_machines.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/vending_machines.yml
@@ -238,6 +238,35 @@
 
 - type: entity
   parent: [BaseStructureUnanchorable, VendingMachine]
+  id: GliessSantoCargoDispenser
+  name: gliess santo dispensary
+  description: Excess goods are sold here to licensed traders.
+  components:
+  - type: VendingMachine
+    pack: GliessSantoDispensary
+    offState: off
+    brokenState: broken
+    normalState: normal-unshaded
+  - type: Advertise
+    pack: AmmoVendAds
+  - type: SpeakOnUIClosed
+    pack: GenericVendGoodbyes
+  - type: Speech
+  - type: Sprite
+    sprite: _Crescent/Structures/cargovendor.rsi
+    layers:
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.Base"]
+    - state: "off"
+      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
+      shader: unshaded
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: MarketModifier
+    mod: 1
+
+- type: entity
+  parent: [BaseStructureUnanchorable, VendingMachine]
   id: InterdyneCargoDispenser
   name: hayes dispensary
   description: Excess goods are sold here to licensed traders.


### PR DESCRIPTION
Hayes got its own set of trade good needs seperate from Gliess. Hayes can export cybernetic and antibiotic goods now.

Grinning Jackal's warp point is also now named.
swaps around some of Hayes' commissary items aswell in the .yml for more organization and adds in liquid oxygen