### PR TITLE
Add 230mm HE shells to the shell fabricator

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Factory/factory.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Factory/factory.yml
@@ -20,6 +20,7 @@
       - GargoyleCasing
       - LancerCasing
       - IdnaTorpedoManufacturing
+      - 230mmCasing
 
 - type: entity
   id: Factory120Weld

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Factory/munitions.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Factory/munitions.yml
@@ -107,7 +107,7 @@
 
 - type: factoryRecipe
   id: IdnaTorpedoManufacturing
-  name : Manufacture IDNA Torpedo
+  name: Manufacture IDNA Torpedo
   inputs:
     Plasma: 5
     Steel: 5
@@ -116,6 +116,7 @@
 
 - type: factoryRecipe
   id: 230mmCasing
+  name: Manufacture 230mm Heavy Mortar Shell
   inputs:
     Tungsten: 5
   outputs:

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Factory/munitions.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Factory/munitions.yml
@@ -114,6 +114,12 @@
   outputs:
     IdnaTorpedo: 1
 
+- type: factoryRecipe
+  id: 230mmCasing
+  inputs:
+    Tungsten: 5
+  outputs:
+    HeavyMortarCartridge: 1
 
 
 


### PR DESCRIPTION
Adds 230mm high-explosive heavy mortar shells to the shell fabricator for 5 Tungsten-Carbidge.
Input can be changed to whatever on request, I wanted to cover a blind spot in munitions production since 230mms ROCK.

<img width="850" height="516" alt="image" src="https://github.com/user-attachments/assets/5c5901fc-f65f-4494-bb49-c80c171fa12e" />
