### PR TITLE
enable re-spawning as same character, bodies no longer pop off limbs like legos from rot, rot timer increased to 30 minutes instead of 10

### DIFF
--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class PerishableComponent : Component
     /// How long it takes after death to start rotting.
     /// </summary>
     [DataField]
-    public TimeSpan RotAfter = TimeSpan.FromMinutes(10);
+    public TimeSpan RotAfter = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// How much rotting has occured

--- a/Content.Shared/Atmos/Rotting/RottingComponent.cs
+++ b/Content.Shared/Atmos/Rotting/RottingComponent.cs
@@ -45,7 +45,6 @@ public sealed partial class RottingComponent : Component
     {
         DamageDict = new()
         {
-            { "Blunt", 0.06 },
             { "Cellular", 0.06 }
         }
     };

--- a/Content.Shared/CCVar/CCVars.Admin.Rules.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.Rules.cs
@@ -8,7 +8,7 @@ public sealed partial class CCVars
     ///     Time that players have to wait before rules can be accepted.
     /// </summary>
     public static readonly CVarDef<float> RulesWaitTime =
-        CVarDef.Create("rules.time", 45f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("rules.time", 30f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     ///     Don't show rules to localhost/loopback interface.

--- a/Content.Shared/CCVar/CCVars.Cloning.cs
+++ b/Content.Shared/CCVar/CCVars.Cloning.cs
@@ -20,7 +20,7 @@ public sealed partial class CCVars
     ///     Controls whether or not Metempsychosis will potentially give people a sex change.
     /// </summary>
     public static readonly CVarDef<bool> CloningPreserveSex =
-        CVarDef.Create("cloning.preserve_sex", false, CVar.SERVERONLY);
+        CVarDef.Create("cloning.preserve_sex", true, CVar.SERVERONLY);
 
     /// <summary>
     ///     Controls whether or not Metempsychosis preserves Pronouns when reincarnating people.
@@ -38,13 +38,13 @@ public sealed partial class CCVars
     ///     Controls whether or not Metempsychosis preserves height.
     /// </summary>
     public static readonly CVarDef<bool> CloningPreserveHeight =
-        CVarDef.Create("cloning.preserve_height", false, CVar.SERVERONLY);
+        CVarDef.Create("cloning.preserve_height", true, CVar.SERVERONLY);
 
     /// <summary>
     ///     Controls whether or not Metempsychosis preserves width.
     /// </summary>
     public static readonly CVarDef<bool> CloningPreserveWidth =
-        CVarDef.Create("cloning.preserve_width", false, CVar.SERVERONLY);
+        CVarDef.Create("cloning.preserve_width", true, CVar.SERVERONLY);
 
     /// <summary>
     ///     Controls whether or not Metempsychosis preserves Names. EG: Are you actually a new person?

--- a/Content.Shared/CCVar/CCVars.GhostRespawn.cs
+++ b/Content.Shared/CCVar/CCVars.GhostRespawn.cs
@@ -19,5 +19,5 @@ public sealed partial class CCVars
     // This is checked at latejoin-time to determine whether you can join as the same character.
     //
     public static readonly CVarDef<bool> GhostAllowSameCharacter =
-        CVarDef.Create("ghost.allow_same_character", false, CVar.SERVERONLY);
+        CVarDef.Create("ghost.allow_same_character", true, CVar.SERVERONLY);
 }


### PR DESCRIPTION
metempsychosis cloning cvars edited incase we ever use it to not be RNG
also makes accepting rules on first time joining faster by 15 seconds