### PR TITLE
scrap-fix

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Materials/craftcomponents.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Materials/craftcomponents.yml
@@ -14,6 +14,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: basicelectronics
+  - type: Currency
+    price:
+      ScrapSAW: 0.1
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -149,6 +152,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: basicmechanic
+  - type: Currency
+    price:
+      ScrapSAW: 0.1
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -287,6 +293,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: laserlocus
+  - type: Currency
+    price:
+      ScrapSAW: 0.3
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -334,6 +343,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: gascycler
+  - type: Currency
+    price:
+      ScrapSAW: 0.3
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -379,6 +391,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: tubeloaderrobotics
+  - type: Currency
+    price:
+      ScrapSAW: 0.3
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -424,6 +439,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: weaklaserlocus
+  - type: Currency
+    price:
+      ScrapSAW: 0.1
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -469,6 +487,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: hardlightgenerator
+  - type: Currency
+    price:
+      ScrapSAW: 0.3
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -514,6 +535,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: hardsuitelectronics
+  - type: Currency
+    price:
+      ScrapSAW: 0.1
   - type: Material
   - type: PhysicalComposition
     materialComposition:
@@ -559,6 +583,9 @@
     sprite: _Crescent/Objects/Materials/materials.rsi
     layers:
     - state: plastitaniumfibrealloy
+  - type: Currency
+    price:
+      ScrapSAW: 0.3
   - type: Material
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/_Crescent/Entities/Materials/scrap.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Materials/scrap.yml
@@ -448,6 +448,9 @@
   - type: Sprite
     sprite: _Crescent/Objects/Materials/ore.rsi
     state: garbage
+  - type: Currency
+    price:
+      ScrapSAW: 0.1
   - type: Material
   - type: PhysicalComposition
     materialComposition:


### PR DESCRIPTION
what this pr does: a lot of scrap from salvage fields had previously did not give any saw scrap vend points because the currency prototype wasn't made for them. This pr adds the prototype 

changelog: all industry components that can be found and salvaged off scrap fields now can give scrap points, with the low types of componets giving 0.1 points while more advanced giving 0.3 (both per one)

https://github.com/user-attachments/assets/7fdf9933-d06a-4a6e-8d12-546ffca99449

