### PR TITLE
My hi-vis vest does not and should not take up my entire bag, 

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
@@ -151,7 +151,7 @@
 #clothes
 
 - type: entity
-  parent: ClothingOuterBaseLarge
+  parent: ClothingOuterBase
   id: ClothingOuterShinoharaVest
   name: corporate hi-vis vest
   description: A hi-vis vest made for Shinohara workers.


### PR DESCRIPTION
I am not carrying a heavy extravagant space suit, I am wearing high-visibility clothing, that way, whatever pirate or shipbreaker that finds me will be able to at least identify my credentials and hopefully return me to my family, or god forbid; Shinohara to be cloned, and my balance to be deducted 40 KCr for cloning fees. Oh, right, I don't got a family, not anymore at least. Their organs are within maybe fifty or so people, all of whom are likely high on drugs in beautiful floating cities, or being harvested by another privateer-shipbreaker-fucker. I don't know, I don't care, I really don't. Sorry, was I trauma-dumping?

# Description

I want my Shinohara hi-vis vest to not be 4x4. I use a satchel, so the 4x4 slot is very important for me. It is quite ridiculous that I have to either throw my vest onto the floor (which also blocks the room for some reason, it's a _vest_) or just throw it away whenever I'm not using a hardsuit. I want to wear a cool sweater when I'm off duty and wear my vest when I am on duty, and the hardsuit when I'm going on EVA. Thus, I've taken it to myself to reparent the Shinohara hi-vis vest to `ClothingOuterBase` rather than `ClothingOuterBaseLarge`. This sets it's size to Normal (2x2) and removes the collision box when its on the ground. I believe this PR will affect the game and codebase positively, allowing for SHI players to roleplay their wage-slave character out.. I personally don't see any alternatives to this, other than completely removing the SHI vest, but I like the SHI vest so I didn't remove it. This benefits me and other SHI players because we get to express our characters better and it looks cooler.
# TODO

- [x] Reparent SHI to `ClothingOuterBase`
- [x] Make the corporate vest actually high visibility

<details><summary><h1>Media</h1></summary>
<p>

<img width="423" height="323" alt="image" src="https://github.com/user-attachments/assets/d046389a-965d-45d8-9bed-46fbdc796392" />

</p>
</details>

---

# Changelog

:cl: rain
- add: Corporate hi-vis vests now only take 2x2 slots rather than 4x4 slots in backpacks.
- add: Corporate hi-vis vests now glow in the dark. They're high visibility for a reason.