### PR TITLE
Boombox + Fix man at arms and knights backpacks

### DIFF
--- a/Resources/Prototypes/_Crescent/Loadouts/items.yml
+++ b/Resources/Prototypes/_Crescent/Loadouts/items.yml
@@ -1,0 +1,6 @@
+- type: loadout
+  id: LoadoutItemsBoombox
+  category: Items
+  cost: 6
+  items:
+    - Boombox

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/knight.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/knight.yml
@@ -58,6 +58,7 @@
     ears: ClothingHeadsetEmpire
     jumpsuit: ClothingUniformJumpsuitImperialCombat
     shoes: ClothingShoesBootsImperialJackboots
+    back: ClothingBackpackDSMFilledSoldier
     head: ClothingHeadHelmetImperialKnightCommanderHelmet
     outerClothing: ClothingOuterArmorImperialArmorPrestige
     gloves: ClothingHandsGlovesImperialLonggloves

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/levyman.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/levyman.yml
@@ -52,6 +52,7 @@
     id: LevymanPDA
     ears: ClothingHeadsetEmpire
     shoes: ClothingShoesBootsImperialJackboots
+    back: ClothingBackpackDSMFilledSoldier
     head: ClothingHeadHelmetImperialTrooperHelmet
     jumpsuit: ClothingUniformJumpsuitImperialCombat
     outerClothing: ClothingOuterArmorImperialTrooperArmor


### PR DESCRIPTION

# Description

Adds boombox to loadout at the cost of 6 points in the item tab. Fix man at arms and knight roles of the DSM not starting with default backpacks.

# Changelog

:cl:
- add: Boombox to the loadouts tab
- fix: Backpacks for DSM man at arms and knights

