### PR TITLE
Removes Bluespace Crystals from most recipes

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/ousianadustbowl.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/ousianadustbowl.yml
@@ -5,9 +5,6 @@
   - node: start
     edges:
     - to: ousianadustbowl
-      steps:
-      - material: Bluespace
-        amount: 1
       - material: Normality
         amount: 1
       - tag: FoodBowlBig

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -242,7 +242,6 @@
   result: ClothingOuterHardsuitImperialNullweavePsion
   completetime: 2
   materials:
-    Bluespace: 500
     HardsuitElectronics: 500
     Cloth: 500
     Durathread: 500
@@ -253,7 +252,6 @@
   result: ImperialPsionBoundlightStaff
   completetime: 2
   materials:
-    Bluespace: 1000
     Cloth: 250
     Wood: 750
     Silver: 500


### PR DESCRIPTION
on the orders of .2 we are slowly phasing out bluespace crystals, as it stands I haven't bothered to add resource costs onto the edited items primarily because they are not meta in any shape or form and will probably currently get you killed if you use them. Currently the only things left that use Bluespace crystals are glimmer probers and drainers which barely function as it is so it's best to leave them as is.