### PR TITLE
Headset fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -20,6 +20,7 @@
   - type: EncryptionKey
     channels:
     - Common
+    - Traffic
     defaultChannel: Common
   - type: Sprite
     layers:


### PR DESCRIPTION
# Description

Gives all headsets shortband by default as was intended

:cl:
- fix: Allows all headsets to use shortband by default

