### PR TITLE
Surgery duffel fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -20,7 +20,6 @@
   - type: EncryptionKey
     channels:
     - Common
-    - Traffic
     defaultChannel: Common
   - type: Sprite
     layers:


### PR DESCRIPTION
# Description

Adds bone gel to advanced surgical duffel bags so you can fix their rib cage after you sawed it open to reach their organs

:cl:
- add: Adds bone gel to surgical duffel bags
