### PR TITLE
fix and add tracking implanters

### DIFF
--- a/Resources/Maps/_Crescent/Stations/kalsuzerai.yml
+++ b/Resources/Maps/_Crescent/Stations/kalsuzerai.yml
@@ -39766,7 +39766,7 @@ entities:
     - type: Transform
       pos: 29.400703,-38.65979
       parent: 1
-- proto: TrackingImplanterDSMCiv
+- proto: VitalsTrackingImplanterDSMCivilian
   entities:
   - uid: 6914
     components:
@@ -39818,7 +39818,7 @@ entities:
     - type: Transform
       pos: -6.265203,-28.644875
       parent: 1
-- proto: TrackingImplanterDSMSec
+- proto: VitalsTrackingImplanterDSMCommand
   entities:
   - uid: 6907
     components:

--- a/Resources/Maps/_Crescent/Stations/novabalreska.yml
+++ b/Resources/Maps/_Crescent/Stations/novabalreska.yml
@@ -108201,7 +108201,7 @@ entities:
     - type: Transform
       pos: 28.455208,-26.365143
       parent: 1
-- proto: TrackingImplanterNCWL
+- proto: VitalsTrackingImplanterNCWL
   entities:
   - uid: 3663
     components:

--- a/Resources/Maps/_Crescent/Stations/novabalreska_old.yml
+++ b/Resources/Maps/_Crescent/Stations/novabalreska_old.yml
@@ -96074,7 +96074,7 @@ entities:
     - type: Transform
       pos: 28.455208,-26.365143
       parent: 1
-- proto: TrackingImplanterNCWL
+- proto: VitalsTrackingImplanterNCWL
   entities:
   - uid: 3660
     components:

--- a/Resources/Maps/_Crescent/Stations/vladzena.yml
+++ b/Resources/Maps/_Crescent/Stations/vladzena.yml
@@ -36701,7 +36701,7 @@ entities:
     - type: Transform
       pos: 22.619436,-28.454348
       parent: 1
-- proto: TrackingImplanterNCWL
+- proto: VitalsTrackingImplanterNCWL
   entities:
   - uid: 1367
     components:

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -100,6 +100,7 @@
     - type: TriggerOnMobstateChange
       mobState:
       - Critical
+      - Dead
     - type: Rattle
       radioChannel: "Security"
 

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Commie/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Commie/medical.yml
@@ -67,3 +67,23 @@
   cost: 750
   category: cargoproduct-category-name-medical
   group: commie
+
+- type: cargoProduct
+  id: VitalsTrackingNCWLSuppliescommie
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingNCWL
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: commie
+
+- type: cargoProduct
+  id: VitalsTrackingIPMSuppliescommie
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 1000
+  category: cargoproduct-category-name-medical
+  group: commie

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Freeport/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Freeport/medical.yml
@@ -127,3 +127,13 @@
   cost: 6000
   category: cargoproduct-category-name-medical
   group: ship
+
+- type: cargoProduct
+  id: VitalsTrackingIPMSuppliesFreeport
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 750
+  category: cargoproduct-category-name-medical
+  group: freeport

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Gliess/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Gliess/medical.yml
@@ -17,3 +17,33 @@
   cost: 3000
   category: cargoproduct-category-name-medical
   group: gliess
+
+- type: cargoProduct
+  id: VitalsTrackingSuppliesGliess
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingBasic
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: gliess
+
+- type: cargoProduct
+  id: VitalsTrackingCMMSuppliesGliess
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingCMM
+  cost: 750
+  category: cargoproduct-category-name-medical
+  group: gliess
+
+- type: cargoProduct
+  id: VitalsTrackingIPMSuppliesGliess
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 1000
+  category: cargoproduct-category-name-medical
+  group: gliess

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Hayes/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Hayes/medical.yml
@@ -117,3 +117,23 @@
   cost: 700
   category: cargoproduct-category-name-medical
   group: hayes
+
+- type: cargoProduct
+  id: VitalsTrackingBasicSuppliesHayes
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingBasic
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: hayes
+
+- type: cargoProduct
+  id: VitalsTrackingIPMSuppliesHayes
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: hayes

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/PangTai/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/PangTai/medical.yml
@@ -67,3 +67,13 @@
   cost: 750
   category: cargoproduct-category-name-medical
   group: pangtai
+
+- type: cargoProduct
+  id: VitalsTrackingIPMSuppliesPang
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: pangtai

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Shinohara/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Shinohara/medical.yml
@@ -67,3 +67,23 @@
   cost: 750
   category: cargoproduct-category-name-medical
   group: shinohara
+
+- type: cargoProduct
+  id: VitalsTrackingShinoharaSuppliesShi
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingShinohara
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: shinohara
+
+- type: cargoProduct
+  id: VitalsTrackingInterdyneSuppliesShi
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 1000
+  category: cargoproduct-category-name-medical
+  group: shinohara

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Surezai/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Surezai/medical.yml
@@ -67,3 +67,33 @@
   cost: 750
   category: cargoproduct-category-name-medical
   group: surezai
+
+- type: cargoProduct
+  id: VitalsTrackingCommandSuppliesSurezai
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingDSMCommand
+  cost: 750
+  category: cargoproduct-category-name-medical
+  group: surezai
+
+- type: cargoProduct
+  id: VitalsTrackingCivilianSuppliesSurezai
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingDSMCivilian
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: surezai
+
+- type: cargoProduct
+  id: VitalsTrackingInterdyneSuppliesSurezai
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingIPM
+  cost: 1000
+  category: cargoproduct-category-name-medical
+  group: surezai

--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Crates/medical.yml
@@ -41,3 +41,103 @@
     contents:
       - id: MechaniteCanister5
         amount: 3
+
+# vitals tracking implanters
+- type: entity
+  id: CrateVitalsTrackingBasic
+  parent: CrateMedical
+  name: basic vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: MedicalTrackingImplanter
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingIPM
+  parent: CrateMedical
+  name: interdyne vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterInterdyne
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingCMM
+  parent: CrateMedical
+  name: colonial minutemen vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterCMM
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingShinohara
+  parent: CrateMedical
+  name: shinohara vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterShinohara
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingDSMCommand
+  parent: CrateMedical
+  name: mandate command vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterDSMCommand
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingDSMCivilian
+  parent: CrateMedical
+  name: mandate civilian vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterDSMCivilian
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingNCWL
+  parent: CrateMedical
+  name: workers league vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterNCWL
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingClarizian
+  parent: CrateMedical
+  name: clarizian vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterCRN
+        amount: 6
+
+- type: entity
+  id: CrateVitalsTrackingATH
+  parent: CrateMedical
+  name: 43rd battlegroup vitals tracking crate
+  description: A crate containing six vitals tracking implanters.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VitalsTrackingImplanterATH
+        amount: 6

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/trackingimplanters.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/trackingimplanters.yml
@@ -1,0 +1,171 @@
+# Base vitals implant
+- type: entity
+  parent: TrackingImplant
+  id: MedicalTrackingImplant
+  name: vitals tracker (Basic)
+  description: This implant has a vitals tracking device for the local broadband frequency.
+  components:
+    - type: Rattle
+      radioChannel: "Common"
+
+# Hullrot vital tracking implants
+# IPM
+- type: entity
+  parent: TrackingImplant
+  id: TrackingImplantInterdyne
+  name: vitals tracker (IPM)
+  description: This implant has a vitals tracking device for the Interdyne Pharmaceuticals frequency.
+  components:
+    - type: Rattle
+      radioChannel: "Interdyne"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterInterdyne
+  name: interdyne vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantInterdyne
+
+# CMM
+- type: entity
+  parent: TrackingImplant
+  id: TrackingImplantCMM
+  name: vitals tracker (CMM)
+  description: This implant has a vitals tracking device for the Colonial Minutemen frequency.
+  components:
+    - type: Rattle
+      radioChannel: "Nfsd"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterCMM
+  name: colonial minutemen vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantCMM
+
+# SHI
+- type: entity
+  parent: TrackingImplant
+  id: TrackingImplantShinohara
+  name: vitals tracker (SHI)
+  description: This implant has a vitals tracking device for the Shinohara Industries frequency.
+  components:
+    - type: Rattle
+      radioChannel: "SHI"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterShinohara
+  name: shinohara vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantShinohara
+
+# DSM
+- type: entity
+  parent: TrackingImplant
+  id: TrackingImplantDSMCommand
+  name : vitals tracker (DSM-Comm)
+  description: This implant has a vitals tracking device for the Divine Mandate's command frequency.
+  components:
+  - type: Rattle
+    radioChannel: "Imperial"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterDSMCommand
+  name: imperial command vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantDSMCommand
+
+- type: entity
+  parent: TrackingImplant
+  name : vitals tracker (DSM-Civ)
+  id: TrackingImplantDSMCivilian
+  description: This implant has a vitals tracking device for the Divine Mandate's civilian frequency.
+  components:
+  - type: Rattle
+    radioChannel: "EmpireCiv"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterDSMCivilian
+  name: imperial civilian vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantDSMCivilian
+
+# NCWL
+- type: entity
+  parent: TrackingImplant
+  name : vitals tracker (NCWL)
+  id: TrackingImplantNCWL
+  description: This implant has a vitals tracking device for the Workers League frequency.
+  components:
+  - type: Rattle
+    radioChannel: "NCWL"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterNCWL
+  name: communard vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantNCWL
+
+# CRN
+- type: entity
+  parent: TrackingImplant
+  name : vitals tracker (CRN)
+  id: TrackingImplantCRN
+  description: This implant has a vitals tracking device for the Clarizian expeditionary frequency.
+  components:
+  - type: Rattle
+    radioChannel: "Clarizian"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterCRN
+  name: clarizian vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantCRN
+
+# ATH
+- type: entity
+  parent: TrackingImplant
+  name : vitals tracker (ATH)
+  id: TrackingImplantATH
+  description: This implant has a vitals tracking device for the Solarian 43rd Battlegroup frequency.
+  components:
+  - type: Rattle
+    radioChannel: "Authority"
+
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: VitalsTrackingImplanterATH
+  name: authoritat vitals tracking implanter
+  components:
+    - type: Implanter
+      implant: TrackingImplantATH
+
+# NAP - uncomment when NAP has comms
+#- type: entity
+#  parent: TrackingImplant
+#  name : tracking implant (NAP)
+#  id: TrackingImplantNAP
+#  description: This implant has a vitals tracking device for the New American Protectorate vanguard frequency.
+#  components:
+#  - type: Rattle
+#    radioChannel: "NAP"
+
+#- type: entity
+#  parent: BaseImplantOnlyImplanter
+#  id: VitalsTrackingImplanterNAP
+#  name: protectorate vitals tracking implanter
+#  components:
+#    - type: Implanter
+#      implant: TrackingImplantNAP

--- a/Resources/Prototypes/_Crescent/PortedShit.yml
+++ b/Resources/Prototypes/_Crescent/PortedShit.yml
@@ -539,50 +539,6 @@
     energyConsumption: 500000
     disableDuration: 30
 
-- type: entity
-  parent: BaseSubdermalImplant
-  id: MedicalTrackingImplant
-  name: tracking implant (IPM)
-  description: This implant has a tracking device monitor for the Interdyne Pharmaceuticals radio channel.
-  components:
-    - type: SubdermalImplant
-      whitelist:
-        components:
-        - MobState
-    - type: TriggerOnMobstateChange
-      mobState:
-      - Critical
-      - Dead
-    - type: Rattle
-      radioChannel: "Interdyne"
-
-- type: entity
-  parent: TrackingImplant
-  id: TrackingImplantDSMSec
-  name : tracking implant (DSM-Sec)
-  description: This implant has a tracking device monitor for the Divine Mandate Security radio channel
-  components:
-  - type: Rattle
-    radioChannel: "Imperial"
-
-- type: entity
-  parent: TrackingImplant
-  name : tracking implant (DSM-Civ)
-  id: TrackingImplantDSMCiv
-  description: This implant has a tracking device monitor for the Divine Mandate Civilian radio channel
-  components:
-  - type: Rattle
-    radioChannel: "EmpireCiv"
-
-- type: entity
-  parent: TrackingImplant
-  name : tracking implant (NCWL)
-  id: TrackingImplantNCWL
-  description: This implant has a tracking device monitor for the New Crescent Workers League radio channel
-  components:
-  - type: Rattle
-    radioChannel: "NCWL"
-
 - type: noiseChannel
   id: DensityGraveyard
   noiseType: Perlin
@@ -666,27 +622,3 @@
     sprite: _Crescent/Structures/fueltank.rsi
     layers:
       - state: fueltank
-
-- type: entity
-  id: TrackingImplanterDSMSec
-  name: tracking implanter (DSM Sec Death Alarm)
-  parent: BaseImplantOnlyImplanter
-  components:
-    - type: Implanter
-      implant: TrackingImplantDSMSec
-
-- type: entity
-  id: TrackingImplanterDSMCiv
-  name: tracking implanter (DSM Civ Death Alarm)
-  parent: BaseImplantOnlyImplanter
-  components:
-    - type: Implanter
-      implant: TrackingImplantDSMCiv
-
-- type: entity
-  id: TrackingImplanterNCWL
-  name: tracking implanter (NCWL Death Alarm)
-  parent: BaseImplantOnlyImplanter
-  components:
-    - type: Implanter
-      implant: TrackingImplantNCWL


### PR DESCRIPTION
also adds multiple more versions, aswell as one for broadband which can be used by spacers
vitals tracking implanters are buyable from all cargos

also adds a version for NAP in, intended for the event for the 20th.