### PR TITLE
Pang Tai and SHI trader fix

### DIFF
--- a/Resources/Prototypes/_Crescent/Maps/base.yml
+++ b/Resources/Prototypes/_Crescent/Maps/base.yml
@@ -18,6 +18,7 @@
   parent:
     - BaseStation
     - BaseStationShuttles
+    - BaseStationCargo
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform


### PR DESCRIPTION

# Description

Fix the cargo consoles of both traders not showing anything.

---



<details><summary><h1>Media</h1></summary>
<p>

<img width="1483" height="591" alt="2025-9-13_12 00 41" src="https://github.com/user-attachments/assets/7bd28d6e-d59b-4c4e-83c6-970cd6e00ee4" />


</p>
</details>

---

# Changelog
:cl:
- fix: PTA Gu Tian and SHI Kitamura cargo consoles are able to sell their goods again.
