### PR TITLE
Adds weapons to the liberty vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
@@ -8,21 +8,28 @@
     MagazineBoxLightRifleBig: 3
     MagazineBoxLightRiflePractice: 3
     MagazineBoxLightRifleRubber: 3
+    WeaponRifleDSMMuster: 3
 
     MagazineBoxMagnum: 3
     MagazineBoxMagnumPractice: 3
     MagazineBoxMagnumRubber: 3
+    WeaponRevolverPirate: 3
 
     # DeltaV - .38 special ammo - Add various .38 special ammo to ammovend
     MagazineBoxSpecial: 3
     MagazineBoxSpecialPractice: 3
     MagazineBoxSpecialRubber: 3
+    WeaponRevolverK38Master: 3
     # End of modified code
 
     MagazineBoxPistol: 3
     MagazineBoxPistolPractice: 3
     MagazineBoxPistolRubber: 3
+    WeaponSubMachineGunBeetle: 3
 
     MagazineBoxRifle: 3
     MagazineBoxRiflePractice: 3
     MagazineBoxRifleRubber: 3
+    WeaponSniperNCWLNovomosin: 3
+
+    WeaponLaserGun: 3


### PR DESCRIPTION
# Description

Adds low tier weapons for each ammo type in the liberty vend(except caseless, nothing uses that) to allow for a well organized militia, does not include magazines.

---

# Changelog

:cl:
- add: Adds the novo-mosin to the liberty vend
- add: Adds the Muster to the liberty vend
- add: Adds the pirate revolver to the liberty vend
- add: Adds the K38 revolver to the liberty vend
- add: Adds the Beetle to the liberty vend
- add: Adds the Retro laser gun to the liberty vend