### PR TITLE
Reverts Species Lock for SHI

### DIFF
--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
@@ -16,10 +16,6 @@
       min: 14400
     - !type:FactionRequirement
       factionID: "SHI"
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Oni
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
@@ -16,9 +16,6 @@
       min: 36000
     - !type:FactionRequirement
       factionID: "SHI"
-    - !type:CharacterSpeciesRequirement
-      species:
-        - Human
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
@@ -16,9 +16,6 @@
       min: 35000
     - !type:FactionRequirement
       factionID: "SHI"
-    - !type:CharacterSpeciesRequirement
-      species:
-        - Human
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/security.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/security.yml
@@ -15,12 +15,6 @@
       min: 7200
     - !type:FactionRequirement
       factionID: "SHI"
-    - !type:CharacterSpeciesRequirement
-      species:
-        - Human
-        - Reptilian
-        - Moth
-        - Arachnid
     - !type:CharacterTraitRequirement
       inverted: true
       traits:


### PR DESCRIPTION
# Description


Reverts previous changes regarding jobs at SHI. 
Sector Manager: Any species - For some reason the only species not allowed to play on the role was Oni. The whitelist requirement and time investment for playing the role means the species won't matter and the filtered players will be able to roleplay up to the standard. Shinohara Industries doesn't condone speciesm nor racism - What truly matters at the end of the day is the profits you can rake in.

Liquidators: Also allowed any species to play, most have more advantages rather than disadvantages. The whitelist and time requirement filters all of the bad actors.

Executive: Same reason as above

Corpsec: Everyone will go to the meatgrinder.

Medtech: Someone already inverted the specieslock for them.

Employees: Everyone will be a wageslave.


# TODO


- [ ] Put a breaching hammer in Liquidator Room to make meelee and breaching in closed spaces feasible.
- [ ] Put Goros in corpsec room replacing 4 of the 6 SMGs. Gives diversity and makes it possible to actually fight people in hardsuits. Will come with 8 mags of 7.62 for each rifle.

These are for separate PRs.

Sorry for shitty formatting this is my first PR and code PR.







