### PR TITLE
IPCS as Man at Arms and loadout available dueling khopeshes for Man at Arms + 

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/beltGroup.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/beltGroup.yml
@@ -23,6 +23,8 @@
     - type: loadout
       id: LoadoutBeltSheathDSMRapier
     - type: loadout
+      id: LoadoutBeltSheathDSMDuelingKhopesh
+    - type: loadout
       id: LoadoutBeltATHWebbing
     - type: loadout
       id: LoadoutBeltATHPouches

--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
@@ -508,6 +508,16 @@
       - DSMRapier
 
 - type: entity
+  id: ClothingBeltSheathDSMDuelingKhopeshFilled
+  parent: ClothingBeltSheathKhopesh
+  suffix: Filled
+  components:
+  - type: ContainerFill
+    containers:
+      item:
+      - DSMDuelingKhopesh
+
+- type: entity
   id: ClothingBeltSheathNCWLKukriFilled
   parent: ClothingBeltSheathNCWLKukri
   suffix: Filled

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SRM/belts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SRM/belts.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: [ClothingBeltBase, ClothingSlotBase]
   id: ClothingBeltSheathKhopesh
-  name: vibrokhopesh scabbard
-  description: A scabbard meant to hold a Hunter's vibrokhopesh.
+  name: khopesh scabbard
+  description: A scabbard meant to hold a khopesh.
   components:
   - type: Sprite
     sprite: _Crescent/Clothing/SRM/Belt/sheath.rsi

--- a/Resources/Prototypes/_Crescent/Loadouts/Empire/belt.yml
+++ b/Resources/Prototypes/_Crescent/Loadouts/Empire/belt.yml
@@ -41,3 +41,26 @@
         - CourtierDSM
         - TemplarDSM
         - WealthDSM
+
+- type: loadout
+  id: LoadoutBeltSheathDSMDuelingKhopesh
+  category: Belt
+  cost: 0
+  items:
+    - ClothingBeltSheathDSMDuelingKhopeshFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - GovernorDSM
+        - KnightDSM
+        - RitterDSM
+        - LaborDSM
+        - CourtierDSM
+        - TemplarDSM
+        - WealthDSM
+        - LevymanDSM

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/levyman.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/levyman.yml
@@ -17,6 +17,7 @@
       species:
         - Human
         - Oni
+        - IPC
     - !type:CharacterTraitRequirement
       inverted: true
       traits:


### PR DESCRIPTION
# Description

Allows IPC to be Man at Arms in the DSM, would make sense for the imperial remnants to use the clankas in my opinion. Dueling khopesh available in loadouts for man at arms and higher ranks, is a worse machete but a quite larpy weapon, also man at arms don't get a cool side melee like higher ranks (with reason) but i feel like this one is fine.

---


---


<details><summary><h1>Media</h1></summary>
<p>

</p>
</details>

---

# Changelog

:cl:
- add: Added Dueling Khopesh in loadouts for man at arms and higher ranks
- tweak: IPCs can be Man at Arms