### PR TITLE
Combat buff to SAW Plasma Cutter

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/donator.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/donator.yml
@@ -535,7 +535,7 @@
     availablePrototypes:
     - Deconstruct
   - type: Gun
-    fireRate: 1
+    fireRate: 2
     projectileSpeed: 30
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
@@ -547,12 +547,12 @@
     startingCharge: 1005
   - type: HitscanBatteryAmmoProvider
     proto: PlasmaCutterBolt
-    fireCost: 250
+    fireCost: 150
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 125
+    autoRechargeRate: 250
     autoRechargePause: true
-    autoRechargePauseTime: 4
+    autoRechargePauseTime: 3
   - type: Item
     size: Normal
     shape:
@@ -564,7 +564,7 @@
   damage:
     types:
       Structural: 60
-      Heat: 35
+      Heat: 25
       Piercing: 15
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi


### PR DESCRIPTION
Underperforms even as a self-defense weapon against Mobs. Plus, this shit can cut a ship hull apart - but not a person?

Adds damage buff, putting it slightly on par with other plasma-based handheld weaponry in Hullrot.
