### PR TITLE
Temporal stealth suit removal

### DIFF
--- a/Resources/Prototypes/_Crescent/DogtagStore/catalog_GSC.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/catalog_GSC.yml
@@ -229,16 +229,16 @@
 
 #SUITS
 
-- type: listing
-  id: StoreListingGSCEgui
-  name: CDT mk-1 "Egui" tacsuit
-  description: The crown jewel of Cyberdawn's technological prowess. Bargaining it out is going to be costly.
-  icon: { sprite: /Textures/_Crescent/Clothing/Syndicate/OuterClothing/cybersunstealth.rsi, state: icon }
-  productEntity: ClothingOuterHardsuitCybersunStealth
-  cost:
-    PlunderGSC: 50
-  categories:
-  - StoreCategoryGSCSuits
+#- type: listing  Removed until fix for the suit
+#  id: StoreListingGSCEgui
+#  name: CDT mk-1 "Egui" tacsuit
+#  description: The crown jewel of Cyberdawn's technological prowess. Bargaining it out is going to be costly.
+#  icon: { sprite: /Textures/_Crescent/Clothing/Syndicate/OuterClothing/cybersunstealth.rsi, state: icon }
+#  productEntity: ClothingOuterHardsuitCybersunStealth
+#  cost:
+#    PlunderGSC: 50
+#  categories:
+#  - StoreCategoryGSCSuits
 
 - type: listing
   id: StoreListingGSCZhongyao

--- a/Resources/Prototypes/_Crescent/Research/cyberdawn.yml
+++ b/Resources/Prototypes/_Crescent/Research/cyberdawn.yml
@@ -148,17 +148,17 @@
 
 # tier 3
 
-- type: technology
-  id: CyberdawnEgui
-  name: research-technology-cyberdawn-egui
-  icon:
-    sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/cybersunstealth.rsi
-    state: icon
-  discipline: Cyberdawn
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-  - ClothingOuterHardsuitCybersunStealthCyberdawn
+#- type: technology removed until fix
+#  id: CyberdawnEgui
+#  name: research-technology-cyberdawn-egui
+#  icon:
+#    sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/cybersunstealth.rsi
+#    state: icon
+#  discipline: Cyberdawn
+#  tier: 3
+#  cost: 10000
+#  recipeUnlocks:
+#  - ClothingOuterHardsuitCybersunStealthCyberdawn
 
 - type: technology
   id: CyberdawnPsybreaker

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -52,14 +52,14 @@
     size: Huge
   - type: Clothing
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/cybersunstealth.rsi
-    onEquipFunctions:
-      - !type:TraitAddComponent
-        components:
-          - type: BreakStealthOnAttack
-    onUnequipFunctions:
-      - !type:TraitRemoveComponent
-        components:
-          - type: BreakStealthOnAttack
+    #onEquipFunctions:
+    #  - !type:TraitAddComponent
+    #    components:
+   #       - type: BreakStealthOnAttack
+   # onUnequipFunctions:
+    #  - !type:TraitRemoveComponent
+     #   components:
+     #     - type: BreakStealthOnAttack
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
@@ -87,11 +87,11 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
-  - type: ClothingGrantComponent
-    component:
-    - type: StealthOnMove
-      passiveVisibilityRate: -0.75
-      movementVisibilityRate: 0.375
+  #- type: ClothingGrantComponent /component is broken
+  #  component:
+  #  - type: StealthOnMove
+  #    passiveVisibilityRate: -0.75
+  #    movementVisibilityRate: 0.375
   - type: EmitsSoundOnMove
     soundCollection:
       collection: FootstepHardsuitLight


### PR DESCRIPTION
# Description

The CD stealth suit crashes the game, so for now will be unobtainable until a fix is made.

---

# Changelog

:cl:
- remove: Cyberdawn stealth hardsuit
