### PR TITLE
Update grenade types in belt storage fills

### DIFF
--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
@@ -12,11 +12,11 @@
     - 0,0,7,1
   - type: StorageFill
     contents:
-      - id: ExGrenade
+      - id: RGD55M13Handgrenade
         amount: 4
-      - id: SyndieMiniBomb
+      - id: ZaryiaFlashbangHandgrenade
         amount: 2
-      - id: EmpGrenade
+      - id: M18SmokeHandgrenade
         amount: 2
   - type: StaticPrice
     price: 250
@@ -55,11 +55,11 @@
     - 0,0,7,1
   - type: StorageFill
     contents:
-      - id: ExGrenade
+      - id: NCSPRGD5Handgrenade
         amount: 4
-      - id: SyndieMiniBomb
+      - id: STFSCRGD2BSmokeHandgrenade
         amount: 2
-      - id: EmpGrenade
+      - id: M14IncendiaryHandgrenade
         amount: 2
   - type: StaticPrice
     price: 250


### PR DESCRIPTION
Replaces existing grenade IDs in belt.yml with new types for both storage fill entries, updating the contents of them.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description
Updates Grenade belt fills to  have the faction grenades in them
<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.

Currently  the only belts  that exist for them is the NCWL rig and the GSC RIG

both have there faction Frag grenade and smoke grenade

-  TFC has an Incendiary grenade instead of EMP
- NCWL has flashbang instead of EMP
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
