### PR TITLE
Exhumer MKII prototype fix (i fixed spelling error)

### DIFF
--- a/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/exhumermk2.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/exhumermk2.yml
@@ -19,7 +19,7 @@
   mapPath: /Maps/_Crescent/Shuttles/Civilian/exhumermk2.yml
   minPlayers: 0
   stations:
-    Exhumerkmk2:
+    Exhumermk2:
       stationProto: StandardCrescentExpeditionVessel
       components:
         - type: VesselIcon


### PR DESCRIPTION
fixes a line from being Exhumerkmk2 (wrong way to spell) to Exhumermk2 (right way)

:cl:
- fix: Exhumer MKII prototype fix

