### PR TITLE
PTA charger rifle available to be bought at the pang tai trader

### DIFF
--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/PangTai/infantry.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/PangTai/infantry.yml
@@ -208,6 +208,16 @@
   category: cargoproduct-category-name-military
   group: pangtai
 
+- type: cargoProduct
+  id: ChargeRiflePangTai
+  icon:
+    sprite: _Crescent/Objects/Weapons/Guns/charge_rifle.rsi
+    state: base
+  product: CratePangtaiChargeRifle
+  cost: 35000
+  category: cargoproduct-category-name-military
+  group: pangtai
+
 
 #- type: cargoProduct
 #  id: KevlarPangTai

--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Crates/infantry.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Crates/infantry.yml
@@ -33,7 +33,7 @@
       - id: WeaponPistolHKUSP
         amount: 2
       - id: WeaponSubMachineGunSabre
-        amount: 2     
+        amount: 2
 
 #pangtai
 
@@ -48,7 +48,26 @@
       - id: WeaponRifleTakemura
         amount: 1
       - id: MagazineRifle
-        amount: 2    
+        amount: 2
+
+- type: entity
+  id: CratePangtaiChargeRifle
+  parent: WeaponCaseRifle
+  name: pang tai arms "XCR-6 Charge rifle" case
+  description: A experimental rifle developed by Pang Tai Arms. Extremly rare.
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponSpecialChargeRifle
+        amount: 1
+      - id: Magazine6x24mmShock
+        amount: 1
+      - id: Magazine6x24mmIncendiary
+        amount: 1
+      - id: Magazine6x24mmIon
+        amount: 1
+      - id: Magazine6x24mmConcentrated
+        amount: 1
 
 - type: entity
   id: CratePangtaiHalyad
@@ -61,7 +80,7 @@
       - id: WeaponRifleHalyadMarksman
         amount: 1
       - id: MagazineHeavyRifle
-        amount: 2    
+        amount: 2
 
 - type: entity
   id: CratePangtaiCheshyre
@@ -74,7 +93,7 @@
       - id: WeaponSubMachineGunCheshyre
         amount: 1
       - id: MagazinePistolSubMachineGunHeavy
-        amount: 2    
+        amount: 2
 
 - type: entity
   id: CratePangtaiRongyu
@@ -87,7 +106,7 @@
       - id: WeaponPistolRongyu
         amount: 1
       - id: MagazinePistol6mm
-        amount: 2  
+        amount: 2
 
 - type: entity
   id: CratePangtaiViper
@@ -100,7 +119,7 @@
       - id: WeaponPistolViper
         amount: 1
       - id: MagazinePistol
-        amount: 2  
+        amount: 2
 
 - type: entity
   id: CratePangtaiDrozd
@@ -113,7 +132,7 @@
       - id: WeaponSubMachineGunDrozd
         amount: 1
       - id: MagazineMagnumSub
-        amount: 2  
+        amount: 2
 
 - type: entity
   id: CratePangtaiVektor
@@ -126,7 +145,7 @@
       - id: WeaponSubMachineGunPTAVektor
         amount: 1
       - id: MagazinePistol6mmSmg
-        amount: 2  
+        amount: 2
 
 - type: entity
   id: CratePangtaiPozhar
@@ -139,7 +158,7 @@
       - id: WeaponShotgunBulldog
         amount: 1
       - id: MagazineShotgun
-        amount: 2  
+        amount: 2
 
 - type: entity
   id: CratePangtaiTwinshot
@@ -152,7 +171,7 @@
       - id: WeaponShotgunPTATwinshot
         amount: 1
       - id: BoxLethalshot
-        amount: 2 
+        amount: 2
 
 - type: entity
   id: CratePangtaiKarabin
@@ -165,7 +184,7 @@
       - id: WeaponShotgunKS23
         amount: 1
       - id: BoxLethalshot4g
-        amount: 2 
+        amount: 2
 
 - type: entity
   id: CratePangtaiLancer
@@ -266,13 +285,13 @@
       - id: ClothingUniformJumpsuitMilitaryColorGrey
         amount: 1
       - id: ClothingShoesBootsJack
-        amount: 1  
+        amount: 1
       - id: ClothingHandsGlovesFingerless
-        amount: 1  
+        amount: 1
       - id: ClothingHeadHatPangtaiCorvidHelmet
-        amount: 1 
+        amount: 1
       - id: ClothingOuterArmorPangTaiVest
-        amount: 1 
+        amount: 1
 
 - type: entity
   id: CratePangtaiHighArmor
@@ -285,13 +304,13 @@
       - id: ClothingUniformJumpsuitMilitaryColorGrey
         amount: 1
       - id: ClothingShoesBootsJack
-        amount: 1  
+        amount: 1
       - id: ClothingHandsGlovesFingerless
-        amount: 1  
+        amount: 1
       - id: ClothingHeadHatPangtaiKorundHelmet
-        amount: 1 
+        amount: 1
       - id: ClothingOuterArmorPangTaiKorund
-        amount: 1 
+        amount: 1
 
 - type: entity
   id: CratePangtaiHardsuitArmor
@@ -304,11 +323,11 @@
       - id: ClothingUniformJumpsuitMilitaryColorGrey
         amount: 1
       - id: ClothingShoesBootsJack
-        amount: 1  
+        amount: 1
       - id: ClothingHandsGlovesFingerless
-        amount: 1  
+        amount: 1
       - id: ClothingOuterHardsuitPangTai
-        amount: 1 
+        amount: 1
 
 #shinohara
 
@@ -323,7 +342,7 @@
       - id: WeaponRifleGoro
         amount: 1
       - id: MagazineRifle
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaHristov
@@ -336,7 +355,7 @@
       - id: WeaponSniperHristov
         amount: 1
       - id: MagazineAntiMateriel
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaLecter
@@ -349,7 +368,7 @@
       - id: WeaponRifleLecter
         amount: 1
       - id: MagazineRifle
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaHound
@@ -362,7 +381,7 @@
       - id: WeaponRifleHoundMarksman
         amount: 1
       - id: MagazineLightRifle
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaMP49
@@ -375,7 +394,7 @@
       - id: WeaponSubMachineGunMP49
         amount: 1
       - id: MagazinePistolSubMachineGun
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaM211s
@@ -388,7 +407,7 @@
       - id: WeaponSubMachineGunSabre
         amount: 1
       - id: MagazinePistol6mmSmg
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaHimehabu
@@ -401,7 +420,7 @@
       - id: WeaponPistolHimehabu
         amount: 1
       - id: MagazinePistol
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaHiPo
@@ -414,7 +433,7 @@
       - id: WeaponPistolMk58
         amount: 1
       - id: MagazinePistol6mm
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaShinobi
@@ -427,7 +446,7 @@
       - id: WeaponPistolSmartpistol
         amount: 1
       - id: MagazinePistolSmartgun
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaSAW
@@ -451,7 +470,7 @@
       - id: WeaponRifleBarghest
         amount: 1
       - id: MagazineHeavyRifle
-        amount: 2   
+        amount: 2
 
 - type: entity
   id: CrateShinoharaMilkor
@@ -463,7 +482,7 @@
     contents:
       - id: WeaponLauncherMilkor
         amount: 1
- 
+
 - type: entity
   id: CrateShinoharaHardsuit
   parent: CrateSecgear
@@ -486,9 +505,9 @@
       - id: ClothingUniformJumpsuitMilitaryColorGrey
         amount: 1
       - id: ClothingShoesBootsJack
-        amount: 1  
+        amount: 1
       - id: ClothingHandsGlovesFingerless
-        amount: 1  
+        amount: 1
       - id: ClothingHeadHatShinoharaHelmet
         amount: 1
       - id: ClothingOuterArmorShinoharaArmorHighsec
@@ -505,9 +524,9 @@
       - id: ClothingUniformJumpsuitMilitaryColorGrey
         amount: 1
       - id: ClothingShoesBootsJack
-        amount: 1  
+        amount: 1
       - id: ClothingHandsGlovesFingerless
-        amount: 1  
+        amount: 1
       - id: ClothingHeadHatShinoharaNonevaHelm
         amount: 1
       - id: ClothingOuterArmorShinoharaArmorBulwark

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/donator.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/donator.yml
@@ -138,7 +138,7 @@
   name: PTA XCR-6 Charge rifle 6x24mm
   parent: BaseWeaponRifle
   id: WeaponSpecialChargeRifle
-  description: A canceled experimental rifle developed by Pang Tai Arms. Only a few exist. This one has the serial number M-18. Chambered in 6×24mm.
+  description: A experimental rifle developed by Pang Tai Arms. Extremly rare. This one has the serial number M-18. Chambered in 6×24mm.
   components:
   - type: Clothing
     sprite: _Crescent/Objects/Weapons/Guns/charge_rifle.rsi


### PR DESCRIPTION

# Description

makes "XCR-6 charge rifle" available to be bought in the Pang Tai trader, it makes sense lore wise and the donator asked to be available to the common folk, (he owes me 200k in game too). The rifle is available at 35k and comes with diverse ammunition
---
<details><summary><h1>Media</h1></summary>
<p>

<img width="598" height="586" alt="2025-9-21_10 46 48" src="https://github.com/user-attachments/assets/d573aab4-ba4e-4e27-a821-d74f07f35579" />

</p>
</details>

---

# Changelog

:cl:
- tweak: XCR-6 charge rifle description
- adds: XCR-6 charge rifle to the Pang Tai trading console