### PR TITLE
Turns most explosions (slope,total,max) on shipguns up by 15x

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Shipguns/Guns/turrets.yml
@@ -433,7 +433,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 1000
+            damage: 500
           # TODO: Construction graph
           behaviors:
             - !type:ChangeConstructionNodeBehavior
@@ -447,7 +447,7 @@
     - type: Gun
       fireOnDropChance: 0
       projectileSpeed: 95
-      fireRate: 8
+      fireRate: 4
       selectedMode: FullAuto
       availableModes:
         - FullAuto


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Under .2's request. blame him and ask him to clarify since explosions are split into three parts.


---


# Changelog
:cl:
- tweak: Changes most explosives on shipguns to 15x the orignal value