### PR TITLE
Standardize medical roles

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Devices/pda.yml
@@ -543,6 +543,10 @@
     borderColor: "#ffffff"
   - type: Icon
     state: hunter
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA
@@ -685,6 +689,10 @@
     borderColor: "#535961"
   - type: Icon
     state: pda-bartender
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 #cmm
 
@@ -729,6 +737,10 @@
     borderColor: "#5191e0"
   - type: Icon
     state: cmm
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA
@@ -1043,6 +1055,10 @@
     borderColor: "#535961"
   - type: Icon
     state: pda-bartender
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA
@@ -1127,6 +1143,10 @@
     borderColor: "#535961"
   - type: Icon
     state: pda-bartender
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA
@@ -1185,6 +1205,10 @@
     borderColor: "#535961"
   - type: Icon
     state: pda-bartender
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Devices/pda.yml
@@ -79,6 +79,10 @@
     accentVColor: "#d4d4d4"
   - type: Icon
     state: pda-militiaman
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA
@@ -244,6 +248,10 @@
     accentVColor: "#d4d4d4"
   - type: Icon
     state: pda-syndimedic
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA
@@ -389,6 +397,10 @@
     borderColor: "#6d5f8a"
   - type: Icon
     state: basic
+  - type: HealthAnalyzer
+    scanDelay: 1
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzersanitat.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/APRT/athpanzersanitat.yml
@@ -26,7 +26,7 @@
       - type: BibleUser
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 2
+        speedModifier: 1.75
 
   access:
   - EmergencyShuttleRepealAll

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/ATH/sanitat.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/ATH/sanitat.yml
@@ -25,7 +25,7 @@
         rank: crescent-rank-sanitat
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 2
+        speedModifier: 1.75
       - type: LanguageAdder
         addSpoken:
           - SolBasic

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/surgeon.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/surgeon.yml
@@ -30,7 +30,7 @@
         rank: crescent-rank-smarts
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 2
+        speedModifier: 1.75
       - type: LanguageAdder
         addSpoken:
           - LowImperial

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_doctor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_doctor.yml
@@ -33,6 +33,7 @@
         rank: crescent-rank-ncwl-medi-worker
       - type: CPRTraining
       - type: SurgerySpeedModifier
+        speedModifier: 1.75
       - type: LanguageAdder
         addSpoken:
           - Dockta

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_doctor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_doctor.yml
@@ -31,6 +31,8 @@
     components:
       - type: ChatRank
         rank: crescent-rank-ncwl-medi-worker
+      - type: CPRTraining
+      - type: SurgerySpeedModifier
       - type: LanguageAdder
         addSpoken:
           - Dockta

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/medtech.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/medtech.yml
@@ -23,7 +23,7 @@
     components:
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 1.5
+        speedModifier: 1.75
       - type: ChatRank
         rank: crescent-rank-shi-medtech
       - type: LanguageAdder

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/tender.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/tender.yml
@@ -31,7 +31,7 @@
       - type: BibleUser
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 2
+        speedModifier: 1.75
 
 - type: startingGear
   id: TenderGear

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/ripperdoc.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/ripperdoc.yml
@@ -27,7 +27,7 @@
         rank: crescent-rank-doc
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 2
+        speedModifier: 1.75
       - type: LanguageAdder
         addSpoken:
           - Freespeak

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/traumasec.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/traumasec.yml
@@ -25,6 +25,8 @@
       - type: ChatRank
         rank: crescent-rank-agent
       - type: CPRTraining
+      - type: SurgerySpeedModifier
+        speedModifier: 1.75
       - type: LanguageAdder
         addSpoken:
           - Freespeak

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TSP/combatphysician.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TSP/combatphysician.yml
@@ -25,7 +25,7 @@
         rank: crescent-rank-physician
       - type: CPRTraining
       - type: SurgerySpeedModifier
-        speedModifier: 2
+        speedModifier: 1.75
   access:
   - Command
   - Maintenance


### PR DESCRIPTION
# Description

Several medical roles were missing a medical analyzer in their PDA, a buff to surgery speed, CPR training or all three This PR standardizes all medical roles to have a medical analyzer and sets the surgery speed modifier for all medical roles to 1.75 (the standard for medical doctors on most codebases) with the exception of the ATH Chirurgeon which is 2.5 (same as CMO)

Players can still take the "experienced surgeon" trait to increase their surgery speed modifier to 2.5

# Changelog

:cl: Pockets
- tweak: Set surgery speed modifier to 1.75 for all medical roles except ATH Chirurgeon, which stays at 2.5
- tweak: Add medical analyzer to PDAs for all medical roles which did not already have it
- tweak: Add CPR training to medical roles that did not already have it
