### PR TITLE
Timelocks for SHI and Downsizing

### DIFF
--- a/Resources/Prototypes/_Crescent/Maps/Stations/tatsumoto.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Stations/tatsumoto.yml
@@ -31,4 +31,4 @@
             HighsecSHI: [ 2, 2 ]
             CorpsecSHI: [ 6, 6 ]
             MedtechSHI: [ 4, 4 ]
-            EmployeeSHI: [ 15, 15 ]
+            EmployeeSHI: [ 8, 8 ]

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
@@ -13,7 +13,7 @@
   requirements:
     - !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
-      min: 14400
+      min: 18000
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/employee.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/employee.yml
@@ -11,11 +11,13 @@
   supervisors: job-supervisors-shi
   canBeAntag: false
   requirements:
-    - !type:FactionRequirement
+      - !type:CharacterOverallTimeRequirement
+       min: 10800
+      - !type:FactionRequirement
         factionID: "SHI"
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
+      - !type:CharacterTraitRequirement
+       inverted: true
+       traits:
         - Muted
         - WheelchairBound
   special:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/medtech.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/medtech.yml
@@ -11,13 +11,15 @@
   supervisors: job-supervisors-shi
   canBeAntag: false
   requirements:
-    - !type:FactionRequirement
-      factionID: "SHI"
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Blindness
-        - WheelchairBound
+          - !type:CharacterOverallTimeRequirement
+           min: 10800 
+          - !type:FactionRequirement
+           factionID: "SHI"
+          - !type:CharacterTraitRequirement
+           inverted: true
+           traits:
+          - Blindness
+          - WheelchairBound
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/security.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/security.yml
@@ -12,7 +12,7 @@
   canBeAntag: false
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 7200
+      min: 16000
     - !type:FactionRequirement
       factionID: "SHI"
     - !type:CharacterTraitRequirement


### PR DESCRIPTION


# Description

Makes SHI timelocked for completely new players. Requiring 3 hours of play time (Or just an average lenght round) on any other role/faction before playing. Also tweaks the requirements for more important roles to need a tiny bit more time invested into the game.

The main reason behind the PR is the atrocious player quality in SHI flooding in from new players liking the *ideea* of SHI, whilst having no ideea on the most basic things in the said game. Couple that with the fact Tatsumoto is extremely half baked, extremely understaffed with actually experienced players. You have the most dogshit first player experience AND the most dogshit leading experience - since unlike the big three factions, DSM and NCWL have an enormous amount of players ready to take up the initiative to teach - TFSC in general is smaller and thus easier to manage for the single "main players" on them.  SHI has three experienced people at best of times, and it won't change anytime soon unless a miracle happens.

The downsizing of salarymen is also direct response to the limited leadership. Its extremely mentally draining for the people in leadership roles to control the already insane amount of people flooding in, and it's very heavy hitting to see people logging off in the middle of hallways because they literally  joined 5 minutes after the briefing was over and the mining convoy is off.

It's worse to have an incompetent crew than it is to be up against a competent enemy. - Shinohara Heavy Industries.

---

# Changelog

:cl: 
- add: Added timelock for Salarymen and Medtechs. Making the whole faction unavailable for players that only joined in.
- tweak: The amount of time more important roles require.
- fix: Fixed fun!
- remove: Removed 7 slots of Salarymen
