### PR TITLE
Removing the mood contest from psionic dampening/amplification.

### DIFF
--- a/Content.Shared/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -97,8 +97,7 @@ namespace Content.Shared.Abilities.Psionics
         }
 
         /// <summary>
-        ///     Returns the CurrentAmplification of a given Entity, multiplied by the result of that Entity's MoodContest.
-        ///     Higher mood means more Amplification, Lower mood means less Amplification.
+        ///     Returns the CurrentAmplification of a given Entity.
         /// </summary>
         public float ModifiedAmplification(EntityUid uid)
         {
@@ -109,17 +108,15 @@ namespace Content.Shared.Abilities.Psionics
         }
 
         /// <summary>
-        ///     Returns the CurrentAmplification of a given Entity, multiplied by the result of that Entity's MoodContest.
-        ///     Higher mood means more Amplification, Lower mood means less Amplification.
+        ///     Returns the CurrentAmplification of a given Entity.
         /// </summary>
         public float ModifiedAmplification(EntityUid uid, PsionicComponent component)
         {
-            return component.CurrentAmplification * _contests.MoodContest(uid, true);
+            return component.CurrentAmplification;
         }
 
         /// <summary>
-        ///     Returns the CurrentDampening of a given Entity, multiplied by the result of that Entity's MoodContest.
-        ///     Lower mood means more Dampening, higher mood means less Dampening.
+        ///     Returns the CurrentDampening of a given Entity.
         /// </summary>
         public float ModifiedDampening(EntityUid uid)
         {
@@ -130,11 +127,10 @@ namespace Content.Shared.Abilities.Psionics
         }
 
         /// <summary>
-        ///     Returns the CurrentDampening of a given Entity, multiplied by the result of that Entity's MoodContest.
-        ///     Lower mood means more Dampening, higher mood means less Dampening.
+        ///     Returns the CurrentDampening of a given Entity.
         /// </summary>
         public float ModifiedDampening(EntityUid uid, PsionicComponent component) =>
-         component.CurrentDampening / _contests.MoodContest(uid, true);
+         component.CurrentDampening;
     }
 
     public sealed class PsionicPowerUsedEvent : HandledEntityEventArgs


### PR DESCRIPTION
mood contest is fucking with the stats, as it is (presumably) set to 0 due to how hullrot handles mood.

This PR removes the mood contest within the calc for amplification/dampening (lines 117 and 137). This removal shouldn't fuck with anything else on the account that mood in hullrot is effectively disabled, which may have caused the contest to be set to 0, thus resulting in the amplification/dampening being set as 0.

Everything in this current file is done, but I may have to look through the other files to find other mood contests that have to be removed, or just force the mood contest as "1".
