### PR TITLE
Sacrificial Alter buff

### DIFF
--- a/Content.Server/Chapel/SacrificialAltarSystem.cs
+++ b/Content.Server/Chapel/SacrificialAltarSystem.cs
@@ -50,7 +50,7 @@ public sealed class SacrificialAltarSystem : SharedSacrificialAltarSystem
         // lower glimmer by a random amount
         _glimmer.DeltaGlimmerInput(ent.Comp.GlimmerReduction * psionic.CurrentAmplification);
 
-        if (ent.Comp.RewardPool is not null && _random.Prob(ent.Comp.BaseItemChance * psionic.CurrentDampening))
+        if (ent.Comp.RewardPool is not null)
         {
             var proto = _proto.Index(_random.Pick(ent.Comp.RewardPool));
             Spawn(proto.ToString(), Transform(ent).Coordinates);
@@ -87,14 +87,6 @@ public sealed class SacrificialAltarSystem : SharedSacrificialAltarSystem
         if (!HasComp<HumanoidAppearanceComponent>(user))
         {
             _popup.PopupEntity(Loc.GetString("altar-failure-reason-user-humanoid"), ent, user, PopupType.SmallCaution);
-            return;
-        }
-
-        // prevent psichecking SSD people...
-        // notably there is no check in OnDoAfter so you can't alt f4 to survive being sacrificed
-        if (!HasComp<ActorComponent>(target) || _mind.GetMind(target) == null)
-        {
-            _popup.PopupEntity(Loc.GetString("altar-failure-reason-target-catatonic", ("target", target)), ent, user, PopupType.SmallCaution);
             return;
         }
 


### PR DESCRIPTION
This should buff the alter by guaranteeing a psychic to drop items on sacrifice, as well as allowing SSD'd psychics to be sacrificed.

The PR is very simple, it takes out the percentage chance of rewards dropping on sacrifice, guaranteeing rewards on drop (that is if the reward pool is not null), and the check to stop the sacrificing of SSD'd people to stop.

The removals should not change anything outside of the alter buffs. 
sacrifice loot drops should no longer be RNG, making outing yourself as a psychic a lot more riskier, as it adds an extra dynamic, where if you can't prove your worth to the faction/associate/raider who has your life in their hands, they may just throw you on an alter for what you drop when sacrificed. It can even help expand the lore a bit by giving a gameplay reason WHY psychics are generally shunned (like the house of questions lore, as it now becomes a place where only psychics that are the best of the best live, as the rest become _Quite literally_ tools for the house to use). 
The SSD check is removed in this PR as well, mostly for the fact that someone may just alt F4, /ghost, or take a ghost role BEFORE being sacrificed to stop it from happening (the // in pre-commit lines 93-94 mention how SSDing doesn't stop the sacrifice, but the check does stop anyone who SSD'd before being sacrificed). This will probably be extremely frustrating if exploited, so the SSD check must go to prevent this from happening.

# TODO
- [x] remove random probability condition on line 53
- [x] remove SSD check from sacrificing (might be reverted, depends on the balancing)
- [ ] make sacrifice attempts on non-psychics more punishing or give an actual penalty (this is even mentioned in the todo at pre-commit line 101)
- [ ] ensure that ent.comp.rewardpool does not run out (outside of the scope of this PR, as it requires an overhaul of the sacrifice loot pool)