### PR TITLE
SHI Shipyard Changes

### DIFF
--- a/Resources/Prototypes/_Crescent/Maps/Ships/SHI/bison.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SHI/bison.yml
@@ -2,7 +2,7 @@
   id: Bison
   name: SHI Bison
   description: A heavy blockade runner, the Bison primarily serves as a backliner for the CorpSec team, and as a smuggler vehicle for prospective freight-runners.
-  price: 75000
+  price: 61000
   category: Medium
   group: None
   path: /Maps/_Crescent/Shuttles/SHI/bison.yml

--- a/Resources/Prototypes/_Crescent/Maps/Ships/SHI/buffalo.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SHI/buffalo.yml
@@ -2,7 +2,7 @@
   id: buffalo
   name: SHI Buffalo
   description: The SHI Buffalo is a cost-effective hauling ship designed for two technicians, one foreman, and an anti-boarding corpsec officer.
-  price: 60000
+  price: 40000
   category: Medium
   group: None
   path: /Maps/_Crescent/Shuttles/SHI/buffalo.yml

--- a/Resources/Prototypes/_Crescent/Maps/Ships/SHI/gazpachov.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SHI/gazpachov.yml
@@ -2,7 +2,7 @@
   id: gazpachov
   name: SHI Gazpachov
   description: The SHI Gazpachov is a cost-effective mining ship designed for 2 miners and one foreman.
-  price: 70000
+  price: 52000
   category: Small
   group: Civilian
   path: /Maps/_Crescent/Shuttles/SHI/gazpachov.yml

--- a/Resources/Prototypes/_Crescent/Maps/Ships/SHI/musinyane.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SHI/musinyane.yml
@@ -2,7 +2,7 @@
   id: Musinyane
   name: SHI Musinyane
   description: A CorpSec patrol corvette.
-  price: 100000
+  price: 75000
   category: Medium
   group: None
   path: /Maps/_Crescent/Shuttles/SHI/musinyane.yml

--- a/Resources/Prototypes/_Crescent/Maps/Ships/SHI/nazaar.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SHI/nazaar.yml
@@ -2,7 +2,7 @@
   id: Nazaar
   name: CSEC Nazaar
   description: A CorpSec patrol gunboat.
-  price: 25000
+  price: 27500
   category: Small
   group: None
   path: /Maps/_Crescent/Shuttles/SHI/nazaar.yml

--- a/Resources/Prototypes/_Crescent/Maps/Ships/SHI/probe.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/SHI/probe.yml
@@ -2,7 +2,7 @@
   id: Probe
   name: SHI Probe
   description: The SHI Probe is a cost-effective research ship designed for short-term deployment.
-  price: 52000
+  price: 20000
   category: Small
   group: None
   path: /Maps/_Crescent/Shuttles/SHI/probe.yml

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -80,7 +80,6 @@
     speechSounds: Pai
   - type: ShipyardListing
     shuttles:
-    - gazpachov
     - Exhumer
     - Homesteader
     - Hammerhead


### PR DESCRIPTION
# Description

Makes SHI ships overall cheaper (with the exception of nazaar which was priced at 25000 despite appraising for 27000/Flea being unchanged because its main price comes from its utility. Being incentivized to be sold to players directly for a higher price). 

Probe: 52k > 20k (Absolute dogshit to whoever priced it)
Musinyane:100k> 75k
Buffalo: 60k> 40k
Bison: 75k > 61k
Gazpachov: 70k > 52k

Also removes Gazpachov from the civillian shipyard. The best mining ship ingame should be available only through its manufacturer. Not to mention SHI itself doesn't have a civillian shipyard so it naturally needs to be as cheap as possible.

---
:cl:

- tweak: Lowered prices closer to the baselines (But not under the appraisegrid sell price).
- fix: Fixed nazaar selling for more than you bought it for.
- remove: Removed Gazpachov from general market.
