### PR TITLE
Draugr armor rework

### DIFF
--- a/.run/Content Server+Client.run.xml
+++ b/.run/Content Server+Client.run.xml
@@ -1,7 +1,5 @@
 ﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Content Server+Client" type="CompoundRunConfigurationType">
-    <toRun name="Content.Client" type="DotNetProject" />
-    <toRun name="Content.Server" type="DotNetProject" />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Content Server+Client.run.xml
+++ b/.run/Content Server+Client.run.xml
@@ -1,5 +1,7 @@
 ﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Content Server+Client" type="CompoundRunConfigurationType">
+    <toRun name="Content.Client" type="DotNetProject" />
+    <toRun name="Content.Server" type="DotNetProject" />
     <method v="2" />
   </configuration>
 </component>

--- a/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
+++ b/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
@@ -85,6 +85,7 @@ research-technology-imperial-srmimitation = Sixth Fireteam Imitation
 research-technology-imperial-bomblauncher = M320 Launcher
 research-technology-imperial-triumphant = Imperial Cruiser
 research-technology-imperial-padparadscha = Imperial Siege Battlecruiser
+research-technology-imperial-basicmechguns = Basic Exoplate Weaponry
 
 #NCWL
 research-technology-communard-clothes = Communard Clothes

--- a/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
+++ b/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
@@ -85,7 +85,6 @@ research-technology-imperial-srmimitation = Sixth Fireteam Imitation
 research-technology-imperial-bomblauncher = M320 Launcher
 research-technology-imperial-triumphant = Imperial Cruiser
 research-technology-imperial-padparadscha = Imperial Siege Battlecruiser
-research-technology-imperial-basicmechguns = Basic Exoplate Weaponry
 
 #NCWL
 research-technology-communard-clothes = Communard Clothes

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -470,3 +470,29 @@
     StarshipEngineComponents: 3000
     ShipComponents: 2750
     ShipHull: 6000
+
+- type: latheRecipe
+  id: WeaponMechLightRifleImperial
+  result: WeaponMechCombatLightRifle
+  completetime: 2
+  materials:
+    Steel: 2500
+    BallisticCycler: 1000
+    BasicMechatronics: 1000
+
+- type: latheRecipe
+  id: WeaponMechAutoshotgunImperial
+  result: WeaponMechCombatAutoshotgun
+  completetime: 2
+  materials:
+    Steel: 3000
+    BallisticCycler: 1000
+    BasicMechatronics: 1000
+
+- type: latheRecipe
+  id: WeaponMechSwordImperial
+  result: WeaponMechSword
+  completetime: 2
+  materials:
+    Steel: 3000
+    BasicMechatronics: 1000

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -470,29 +470,3 @@
     StarshipEngineComponents: 3000
     ShipComponents: 2750
     ShipHull: 6000
-
-- type: latheRecipe
-  id: WeaponMechLightRifleImperial
-  result: WeaponMechCombatLightRifle
-  completetime: 2
-  materials:
-    Steel: 2500
-    BallisticCycler: 1000
-    BasicMechatronics: 1000
-
-- type: latheRecipe
-  id: WeaponMechAutoshotgunImperial
-  result: WeaponMechCombatAutoshotgun
-  completetime: 2
-  materials:
-    Steel: 3000
-    BallisticCycler: 1000
-    BasicMechatronics: 1000
-
-- type: latheRecipe
-  id: WeaponMechSwordImperial
-  result: WeaponMechSword
-  completetime: 2
-  materials:
-    Steel: 3000
-    BasicMechatronics: 1000

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -527,6 +527,9 @@
       - LaelapsLPC
       - PaladinFlatpack
       - WandererFlatpack
+      - WeaponMechSwordImperial
+      - WeaponMechAutoshotgunImperial
+      - WeaponMechLightRifleImperial
       - WeaponRifleDSMLegionnaire
       - WeaponSubMachineGunC20rImperial
       - WeaponPistolNeoVolker

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -527,6 +527,9 @@
       - LaelapsLPC
       - PaladinFlatpack
       - WandererFlatpack
+      - WeaponMechLightRifleImperial
+      - WeaponMechAutoshotgunImperial
+      - WeaponMechSwordImperial
       - WeaponRifleDSMLegionnaire
       - WeaponSubMachineGunC20rImperial
       - WeaponPistolNeoVolker

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -527,9 +527,6 @@
       - LaelapsLPC
       - PaladinFlatpack
       - WandererFlatpack
-      - WeaponMechLightRifleImperial
-      - WeaponMechAutoshotgunImperial
-      - WeaponMechSwordImperial
       - WeaponRifleDSMLegionnaire
       - WeaponSubMachineGunC20rImperial
       - WeaponPistolNeoVolker

--- a/Resources/Prototypes/_Crescent/Research/imperial.yml
+++ b/Resources/Prototypes/_Crescent/Research/imperial.yml
@@ -249,17 +249,3 @@
   cost: 12000
   recipeUnlocks:
   - PadparadschaLPC
-
-- type: technology
-  id: ImperialBasicMechGuns
-  name: research-technology-imperial-basicmechguns
-  icon:
-    sprite: _Crescent/Objects/Specific/mechaweapons.rsi
-    state: rifle
-  discipline: Imperial
-  tier: 1
-  cost: 8500
-  recipeUnlocks:
-  - WeaponMechAutoshotgunImperial
-  - WeaponMechLightRifleImperial
-  - WeaponMechSwordImperial

--- a/Resources/Prototypes/_Crescent/Research/imperial.yml
+++ b/Resources/Prototypes/_Crescent/Research/imperial.yml
@@ -249,3 +249,17 @@
   cost: 12000
   recipeUnlocks:
   - PadparadschaLPC
+
+- type: technology
+  id: ImperialBasicMechGuns
+  name: research-technology-imperial-basicmechguns
+  icon:
+    sprite: _Crescent/Objects/Specific/mechaweapons.rsi
+    state: rifle
+  discipline: Imperial
+  tier: 1
+  cost: 8500
+  recipeUnlocks:
+  - WeaponMechAutoshotgunImperial
+  - WeaponMechLightRifleImperial
+  - WeaponMechSwordImperial

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ritter.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ritter.yml
@@ -54,3 +54,5 @@
     head: ClothingHeadHelmetImperialRitter
     outerClothing: ClothingOuterCoatImperialRitter
     gloves: ClothingHandsGlovesImperialLonggloves
+  inhand:
+  - WandererFlatpack


### PR DESCRIPTION
Draugr Armor Buff and rework. Weaker to blunt (HAMMER) and completely weak to any caustic. Splash sulfuric on them and they scream and die. Or flash uranium at them and they die. Slash has not been touched

Buffs armor health from 750 to 1000 (Likely a 2 bullet increase. maybe 3)
Buffs pierce resist by 5 (to 50)
Buffs heat resist by 5 (to 25 (allows for accidental friendly fire with halberd))
Nerfs caustic resist by 20 (to 5)
Nerfs blunt resist by 5 (Use hammer or blunt object to kill)
Increases speed by 5% (10% from 15% speed malus)

This is only done because draugrs rely on melee combat. This entire buff is to make them more capable of reaching melee combat and relying on their armor. Rather than sitting in a corner and just jumping people like a hoodlum.