### PR TITLE
draugr armor rework WITH A BRANCH

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
@@ -16,19 +16,19 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 750
+    armorMaxHealth: 1000
     armorType: Metallic
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 25
+        Blunt: 20
         Slash: 25
-        Piercing: 45
-        Heat: 20
-        Caustic: 25
+        Piercing: 50
+        Heat: 25
+        Caustic: 5
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDraugr
   - type: StaticPrice


### PR DESCRIPTION
FUCK YOU GITHUB.
FUCK. YOU. 

Draugr armor buff to allow them to actually utilize their melee and rely on their armor more. Having reskins of armors isn't good game design and their armor is currently just shitty DSM armor which folds like fucking paper in combat. Not great when you rely on a close-range melee weapon to kill people.

Buffs pierce resist to 50 (from 45)
Buffs armor health by 250 (1000 from 750)
Buffs heat resist to 25 (from 20)
Nerfs blunt resist by 5 (from 25
Nerfs caustic resist by 20 (from 25)
Buffs speed by 5% (10% from 15% speed decrease)

Kill them with hammers or throw acid on them