### PR TITLE
2 new psionic traits (1/5)

### DIFF
--- a/Resources/Prototypes/Traits/Psionics/casterTypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterTypes.yml
@@ -79,3 +79,57 @@
           inverted: true
           species:
             - IPC
+
+- type: trait
+  id: Biomancer
+  category: Psionics
+  points: -2
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          powerPool: BiomancerPowerPool
+    - !type:TraitAddPsionics
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+
+- type: trait
+  id: Pyromancer
+  category: Psionics
+  points: -2
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          powerPool: PyromancerPowerPool
+    - !type:TraitAddPsionics
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC


### PR DESCRIPTION
added the "Biomancer" and "Pyromancer" trait (also I fucked up on how forking works so I have to list all 5 of my commits on separate PRs, which is why this is listed as 1/5).

# Description

This PR specifically adds the "Biomancer" and "Pyromancer" trait into the game, but the other PRs included define the new power pools, as well as making sure they work as intended (only being able to pick one psionic trait and making sure they work with power overwhelming and high potential, as well as including descriptions for the new traits).

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Created "Pyromancer" and "Biomancer" power pools (in 2/5)
- [x] Added "Pyromancer" and "Biomancer" (1/5)
- [x]  Ensure that "Pyromancer" and "Biomancer" properly work as psionic traits (3/5,4/5)
- [x] Add trait description for "Pyromancer" and "Biomancer" (5/5)