### PR TITLE
2 new psionic traits (2/5)

### DIFF
--- a/Resources/Prototypes/Psionics/PsionicPowerPool.yml
+++ b/Resources/Prototypes/Psionics/PsionicPowerPool.yml
@@ -36,3 +36,14 @@
     TelekineticPulsePower: 0.75
     PyrokineticFlare: 0.5
     NoosphericZapPower: 0.25
+
+    - type: weightedRandom
+  id: BiomancerPowerPool # Handles bio-energy, focusing on medical applications.
+  weights:
+    PsionicRegenerationPower: 0.5
+    HealingWordPower: 2 #this leads to revivify
+
+    - type: weightedRandom
+  id: PyromancerPowerPool # Only pyrokinetic flare, which leads to other upgrades.
+  weights:
+    PyrokineticFlare: 1 # Leads to summon imp and pyrokenisis


### PR DESCRIPTION


<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

includes two more powerpool types, which works hand in hand with the new psionic traits. (see what this is for in 1/5 https://github.com/Sector-Crescent/Hullrot/pull/758)
