### PR TITLE
2 new psionic traits (3/5) 

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Psionics/castingTypes.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Psionics/castingTypes.yml
@@ -8,3 +8,7 @@
       id: PsionicInsulation
     - type: trait
       id: PsychoHistorian
+      - type: trait
+      id: Biomancer
+      - type: trait
+      id: Pyromancer


### PR DESCRIPTION
# Description

Adds Biomancer and Pyromancer into "TraitsCasterType", which prevents people from picking multiple caster type traits. (see what this is for in https://github.com/Sector-Crescent/Hullrot/pull/758)