### PR TITLE
2 new psionic traits (4/5) 

### DIFF
--- a/Resources/Prototypes/Traits/Psionics/feats.yml
+++ b/Resources/Prototypes/Traits/Psionics/feats.yml
@@ -9,6 +9,8 @@
           traits:
             - LatentPsychic
             - PsychoHistorian
+            - Biomancer
+            - Pyromancer
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement
@@ -37,6 +39,8 @@
           traits:
             - LatentPsychic
             - PsychoHistorian
+            - Biomancer
+            - Pyromancer
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement


### PR DESCRIPTION
# Description
This commit adds the "Biomancer" and "Pyromancer" trait into the requirement to select high potential and power overwhelming, so you can actually use those with the new psionic traits. (see what this is for in https://github.com/Sector-Crescent/Hullrot/pull/758)

