### PR TITLE
timelocks both antiquarian and lord admiral

### DIFF
--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/advocatus.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/advocatus.yml
@@ -14,11 +14,11 @@
     - !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
+    - !type:CharacterOverallTimeRequirement
+      min: 36000
     - !type:CharacterSpeciesRequirement
       species:
         - Human
-    - !type:CharacterOverallTimeRequirement
-      min: 36000
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/governor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/governor.yml
@@ -14,6 +14,8 @@
     - !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
+    - !type:CharacterOverallTimeRequirement
+      min: 36000
     - !type:CharacterSpeciesRequirement
       species:
         - Human

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/FourFamilies/antiquarian.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/FourFamilies/antiquarian.yml
@@ -13,6 +13,8 @@
   requirements:
     - !type:FactionRequirement
       factionID: "TAP"
+    - !type:CharacterOverallTimeRequirement
+      min: 36000
     - !type:CharacterSpeciesRequirement
       species:
         - Human

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/FourFamilies/prophet.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/FourFamilies/prophet.yml
@@ -14,6 +14,8 @@
     - !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "TAP"
+    - !type:CharacterOverallTimeRequirement
+      min: 36000
     - !type:CharacterSpeciesRequirement
       species:
         - Moth

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_commandant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_commandant.yml
@@ -12,10 +12,10 @@
   canBeAntag: false
   requirements:
     - !type:CharacterWhitelistRequirement
-    - !type:CharacterOverallTimeRequirement
-      min: 35000
     - !type:FactionRequirement
       factionID: "NCWL"
+    - !type:CharacterOverallTimeRequirement
+      min: 35000
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:


### PR DESCRIPTION
added due to whitelists being broken and the antiquarian requiring mechanical knowledge to play correctly

TAP prophet also gets timelocked due to being FL