### PR TITLE
ICM Birdie - civilian medevac

### DIFF
--- a/Resources/Maps/_Crescent/Shuttles/Civilian/birdie.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/birdie.yml
@@ -1,0 +1,2918 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 260.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 10/03/2025 11:57:52
+  entityCount: 259
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  4: Space
+  2: FloorHullReinforced
+  5: FloorSteel
+  1: FloorTechMaint2
+  3: Lattice
+  0: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Shuttle MV-529
+    - type: Transform
+      pos: -7.009388,-12.512201
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAAAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAMAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAFAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAFAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAMAAAAAAAACAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAA==
+          version: 7
+        -1,1:
+          ind: -1,1
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAADAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        0,1:
+          ind: 0,1
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAwAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      baseMaxLinearVelocity: 30
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelEndN
+          decals:
+            247: 1,19
+            248: 1,19
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelInnerNe
+          decals:
+            495: 0,5
+            496: 0,5
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelInnerNw
+          decals:
+            493: 2,5
+            494: 2,5
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelInnerSe
+          decals:
+            499: 0,9
+            500: 0,9
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelInnerSw
+          decals:
+            497: 2,9
+            498: 2,9
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineE
+          decals:
+            221: 1,14
+            222: 1,14
+            223: 1,13
+            224: 1,13
+            225: 1,12
+            226: 1,12
+            227: 1,11
+            228: 1,11
+            229: 1,15
+            230: 1,15
+            231: 1,16
+            232: 1,16
+            233: 1,17
+            234: 1,17
+            235: 1,18
+            236: 1,18
+            249: 1,10
+            250: 1,10
+            477: 0,8
+            478: 0,8
+            479: 0,7
+            480: 0,7
+            481: 0,6
+            482: 0,6
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineN
+          decals:
+            483: 1,5
+            484: 1,5
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineS
+          decals:
+            491: 1,9
+            492: 1,9
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#52B4E996'
+            id: BrickTileSteelLineS
+          decals:
+            511: 2,5
+            512: 2,5
+            513: 2,6
+            514: 2,6
+            515: 2,7
+            516: 2,7
+            517: 2,8
+            518: 2,8
+            519: 2,9
+            520: 2,9
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineW
+          decals:
+            213: 1,11
+            214: 1,11
+            215: 1,12
+            216: 1,12
+            217: 1,13
+            218: 1,13
+            219: 1,14
+            220: 1,14
+            237: 1,18
+            238: 1,18
+            239: 1,17
+            240: 1,17
+            241: 1,16
+            242: 1,16
+            243: 1,15
+            244: 1,15
+            245: 1,10
+            246: 1,10
+            485: 2,6
+            486: 2,6
+            487: 2,7
+            488: 2,7
+            489: 2,8
+            490: 2,8
+            501: 0,5
+            502: 0,5
+            503: 0,6
+            504: 0,6
+            505: 0,7
+            506: 0,7
+            507: 0,8
+            508: 0,8
+            509: 0,9
+            510: 0,9
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: IhejrikaCenter
+          decals:
+            476: 1,7
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: IhejrikaLeft
+          decals:
+            475: 1,6
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: IhejrikaRight
+          decals:
+            474: 1,8
+        - node:
+            zIndex: 1
+            id: LatticeCornerNE
+          decals:
+            13: 4,6
+            29: 4,8
+            37: 4,7
+            61: 4,6
+            69: 4,7
+            77: 4,8
+            102: 4,6
+            110: 4,7
+            118: 4,8
+            148: 0,19
+            165: -1,18
+            190: -3,12
+            206: -2,4
+            263: 4,6
+            271: 4,7
+            279: 4,8
+            305: -3,12
+            311: -2,4
+            320: -1,18
+            328: 0,19
+            344: 2,19
+            372: 4,6
+            380: 4,7
+            388: 4,8
+            411: -3,12
+            417: -2,4
+            426: -1,18
+            434: 0,19
+            450: 2,19
+            533: 4,6
+            541: 4,7
+            549: 4,8
+            580: -3,12
+            586: -2,4
+            595: -1,18
+            603: 0,19
+            619: 2,19
+            647: 4,6
+            655: 4,7
+            663: 4,8
+            694: -3,12
+            700: -2,4
+            709: -1,18
+            717: 0,19
+            733: 2,19
+            761: 4,6
+            769: 4,7
+            777: 4,8
+            808: -3,12
+            814: -2,4
+            823: -1,18
+            831: 0,19
+            847: 2,19
+        - node:
+            zIndex: 1
+            id: LatticeCornerNW
+          decals:
+            8: 5,6
+            16: 4,6
+            24: 5,7
+            32: 4,8
+            40: 4,7
+            45: 4,5
+            56: 4,5
+            64: 4,6
+            72: 4,7
+            80: 4,8
+            86: 5,6
+            91: 5,7
+            105: 4,6
+            113: 4,7
+            121: 4,8
+            127: 5,6
+            132: 5,7
+            151: 0,19
+            173: 3,18
+            187: 5,12
+            198: 4,4
+            203: 4,5
+            253: 4,4
+            258: 4,5
+            266: 4,6
+            274: 4,7
+            282: 4,8
+            288: 5,6
+            293: 5,7
+            299: 5,12
+            331: 0,19
+            347: 2,19
+            355: 3,18
+            362: 4,4
+            367: 4,5
+            375: 4,6
+            383: 4,7
+            391: 4,8
+            394: 5,6
+            399: 5,7
+            405: 5,12
+            437: 0,19
+            453: 2,19
+            461: 3,18
+            473: 4,9
+            523: 4,4
+            528: 4,5
+            536: 4,6
+            544: 4,7
+            552: 4,8
+            557: 4,9
+            563: 5,6
+            568: 5,7
+            574: 5,12
+            606: 0,19
+            622: 2,19
+            630: 3,18
+            637: 4,4
+            642: 4,5
+            650: 4,6
+            658: 4,7
+            666: 4,8
+            671: 4,9
+            677: 5,6
+            682: 5,7
+            688: 5,12
+            720: 0,19
+            736: 2,19
+            744: 3,18
+            751: 4,4
+            756: 4,5
+            764: 4,6
+            772: 4,7
+            780: 4,8
+            785: 4,9
+            791: 5,6
+            796: 5,7
+            802: 5,12
+            834: 0,19
+            850: 2,19
+            858: 3,18
+        - node:
+            zIndex: 1
+            id: LatticeCornerSE
+          decals:
+            11: 4,6
+            27: 4,8
+            35: 4,7
+            48: -2,10
+            59: 4,6
+            67: 4,7
+            75: 4,8
+            97: -2,10
+            100: 4,6
+            108: 4,7
+            116: 4,8
+            138: -1,19
+            141: 1,20
+            146: 0,19
+            154: 0,20
+            163: -1,18
+            168: -2,10
+            193: -3,14
+            261: 4,6
+            269: 4,7
+            277: 4,8
+            308: -3,14
+            314: -2,10
+            318: -1,18
+            323: -1,19
+            326: 0,19
+            334: 0,20
+            337: 1,20
+            342: 2,19
+            370: 4,6
+            378: 4,7
+            386: 4,8
+            414: -3,14
+            420: -2,10
+            424: -1,18
+            429: -1,19
+            432: 0,19
+            440: 0,20
+            443: 1,20
+            448: 2,19
+            531: 4,6
+            539: 4,7
+            547: 4,8
+            583: -3,14
+            589: -2,10
+            593: -1,18
+            598: -1,19
+            601: 0,19
+            609: 0,20
+            612: 1,20
+            617: 2,19
+            645: 4,6
+            653: 4,7
+            661: 4,8
+            697: -3,14
+            703: -2,10
+            707: -1,18
+            712: -1,19
+            715: 0,19
+            723: 0,20
+            726: 1,20
+            731: 2,19
+            759: 4,6
+            767: 4,7
+            775: 4,8
+            811: -3,14
+            817: -2,10
+            821: -1,18
+            826: -1,19
+            829: 0,19
+            837: 0,20
+            840: 1,20
+            845: 2,19
+        - node:
+            zIndex: 1
+            id: LatticeCornerSW
+          decals:
+            15: 4,6
+            19: 5,8
+            23: 5,7
+            31: 4,8
+            39: 4,7
+            44: 4,5
+            51: 4,9
+            55: 4,5
+            63: 4,6
+            71: 4,7
+            79: 4,8
+            83: 4,9
+            90: 5,7
+            94: 5,8
+            104: 4,6
+            112: 4,7
+            120: 4,8
+            124: 4,9
+            131: 5,7
+            135: 5,8
+            143: 1,20
+            150: 0,19
+            157: 2,20
+            160: 3,19
+            172: 3,18
+            184: 5,14
+            202: 4,5
+            257: 4,5
+            265: 4,6
+            273: 4,7
+            281: 4,8
+            285: 4,9
+            292: 5,7
+            296: 5,8
+            302: 5,14
+            330: 0,19
+            339: 1,20
+            346: 2,19
+            350: 2,20
+            354: 3,18
+            358: 3,19
+            366: 4,5
+            374: 4,6
+            382: 4,7
+            390: 4,8
+            398: 5,7
+            402: 5,8
+            408: 5,14
+            436: 0,19
+            445: 1,20
+            452: 2,19
+            456: 2,20
+            460: 3,18
+            464: 3,19
+            468: 4,10
+            472: 4,9
+            527: 4,5
+            535: 4,6
+            543: 4,7
+            551: 4,8
+            556: 4,9
+            560: 4,10
+            567: 5,7
+            571: 5,8
+            577: 5,14
+            605: 0,19
+            614: 1,20
+            621: 2,19
+            625: 2,20
+            629: 3,18
+            633: 3,19
+            641: 4,5
+            649: 4,6
+            657: 4,7
+            665: 4,8
+            670: 4,9
+            674: 4,10
+            681: 5,7
+            685: 5,8
+            691: 5,14
+            719: 0,19
+            728: 1,20
+            735: 2,19
+            739: 2,20
+            743: 3,18
+            747: 3,19
+            755: 4,5
+            763: 4,6
+            771: 4,7
+            779: 4,8
+            784: 4,9
+            788: 4,10
+            795: 5,7
+            799: 5,8
+            805: 5,14
+            833: 0,19
+            842: 1,20
+            849: 2,19
+            853: 2,20
+            857: 3,18
+            861: 3,19
+        - node:
+            id: LatticeEdgeE
+          decals:
+            10: 4,6
+            26: 4,8
+            34: 4,7
+            47: -2,10
+            58: 4,6
+            66: 4,7
+            74: 4,8
+            96: -2,10
+            99: 4,6
+            107: 4,7
+            115: 4,8
+            137: -1,19
+            140: 1,20
+            145: 0,19
+            153: 0,20
+            162: -1,18
+            167: -2,10
+            188: -3,12
+            192: -3,14
+            194: -2,16
+            204: -2,4
+            260: 4,6
+            268: 4,7
+            276: 4,8
+            303: -3,12
+            307: -3,14
+            309: -2,4
+            313: -2,10
+            315: -2,16
+            317: -1,18
+            322: -1,19
+            325: 0,19
+            333: 0,20
+            336: 1,20
+            341: 2,19
+            369: 4,6
+            377: 4,7
+            385: 4,8
+            409: -3,12
+            413: -3,14
+            415: -2,4
+            419: -2,10
+            421: -2,16
+            423: -1,18
+            428: -1,19
+            431: 0,19
+            439: 0,20
+            442: 1,20
+            447: 2,19
+            530: 4,6
+            538: 4,7
+            546: 4,8
+            578: -3,12
+            582: -3,14
+            584: -2,4
+            588: -2,10
+            590: -2,16
+            592: -1,18
+            597: -1,19
+            600: 0,19
+            608: 0,20
+            611: 1,20
+            616: 2,19
+            644: 4,6
+            652: 4,7
+            660: 4,8
+            692: -3,12
+            696: -3,14
+            698: -2,4
+            702: -2,10
+            704: -2,16
+            706: -1,18
+            711: -1,19
+            714: 0,19
+            722: 0,20
+            725: 1,20
+            730: 2,19
+            758: 4,6
+            766: 4,7
+            774: 4,8
+            806: -3,12
+            810: -3,14
+            812: -2,4
+            816: -2,10
+            818: -2,16
+            820: -1,18
+            825: -1,19
+            828: 0,19
+            836: 0,20
+            839: 1,20
+            844: 2,19
+        - node:
+            id: LatticeEdgeN
+          decals:
+            6: 5,6
+            12: 4,6
+            21: 5,7
+            28: 4,8
+            36: 4,7
+            42: 4,5
+            53: 4,5
+            60: 4,6
+            68: 4,7
+            76: 4,8
+            84: 5,6
+            88: 5,7
+            101: 4,6
+            109: 4,7
+            117: 4,8
+            125: 5,6
+            129: 5,7
+            147: 0,19
+            164: -1,18
+            170: 3,18
+            185: 5,12
+            189: -3,12
+            196: 4,4
+            200: 4,5
+            205: -2,4
+            251: 4,4
+            255: 4,5
+            262: 4,6
+            270: 4,7
+            278: 4,8
+            286: 5,6
+            290: 5,7
+            297: 5,12
+            304: -3,12
+            310: -2,4
+            319: -1,18
+            327: 0,19
+            343: 2,19
+            352: 3,18
+            360: 4,4
+            364: 4,5
+            371: 4,6
+            379: 4,7
+            387: 4,8
+            392: 5,6
+            396: 5,7
+            403: 5,12
+            410: -3,12
+            416: -2,4
+            425: -1,18
+            433: 0,19
+            449: 2,19
+            458: 3,18
+            470: 4,9
+            521: 4,4
+            525: 4,5
+            532: 4,6
+            540: 4,7
+            548: 4,8
+            554: 4,9
+            561: 5,6
+            565: 5,7
+            572: 5,12
+            579: -3,12
+            585: -2,4
+            594: -1,18
+            602: 0,19
+            618: 2,19
+            627: 3,18
+            635: 4,4
+            639: 4,5
+            646: 4,6
+            654: 4,7
+            662: 4,8
+            668: 4,9
+            675: 5,6
+            679: 5,7
+            686: 5,12
+            693: -3,12
+            699: -2,4
+            708: -1,18
+            716: 0,19
+            732: 2,19
+            741: 3,18
+            749: 4,4
+            753: 4,5
+            760: 4,6
+            768: 4,7
+            776: 4,8
+            782: 4,9
+            789: 5,6
+            793: 5,7
+            800: 5,12
+            807: -3,12
+            813: -2,4
+            822: -1,18
+            830: 0,19
+            846: 2,19
+            855: 3,18
+        - node:
+            id: LatticeEdgeS
+          decals:
+            9: 4,6
+            17: 5,8
+            20: 5,7
+            25: 4,8
+            33: 4,7
+            41: 4,5
+            46: -2,10
+            49: 4,9
+            52: 4,5
+            57: 4,6
+            65: 4,7
+            73: 4,8
+            81: 4,9
+            87: 5,7
+            92: 5,8
+            95: -2,10
+            98: 4,6
+            106: 4,7
+            114: 4,8
+            122: 4,9
+            128: 5,7
+            133: 5,8
+            136: -1,19
+            139: 1,20
+            144: 0,19
+            152: 0,20
+            155: 2,20
+            158: 3,19
+            161: -1,18
+            166: -2,10
+            169: 3,18
+            182: 5,14
+            191: -3,14
+            199: 4,5
+            254: 4,5
+            259: 4,6
+            267: 4,7
+            275: 4,8
+            283: 4,9
+            289: 5,7
+            294: 5,8
+            300: 5,14
+            306: -3,14
+            312: -2,10
+            316: -1,18
+            321: -1,19
+            324: 0,19
+            332: 0,20
+            335: 1,20
+            340: 2,19
+            348: 2,20
+            351: 3,18
+            356: 3,19
+            363: 4,5
+            368: 4,6
+            376: 4,7
+            384: 4,8
+            395: 5,7
+            400: 5,8
+            406: 5,14
+            412: -3,14
+            418: -2,10
+            422: -1,18
+            427: -1,19
+            430: 0,19
+            438: 0,20
+            441: 1,20
+            446: 2,19
+            454: 2,20
+            457: 3,18
+            462: 3,19
+            466: 4,10
+            469: 4,9
+            524: 4,5
+            529: 4,6
+            537: 4,7
+            545: 4,8
+            553: 4,9
+            558: 4,10
+            564: 5,7
+            569: 5,8
+            575: 5,14
+            581: -3,14
+            587: -2,10
+            591: -1,18
+            596: -1,19
+            599: 0,19
+            607: 0,20
+            610: 1,20
+            615: 2,19
+            623: 2,20
+            626: 3,18
+            631: 3,19
+            638: 4,5
+            643: 4,6
+            651: 4,7
+            659: 4,8
+            667: 4,9
+            672: 4,10
+            678: 5,7
+            683: 5,8
+            689: 5,14
+            695: -3,14
+            701: -2,10
+            705: -1,18
+            710: -1,19
+            713: 0,19
+            721: 0,20
+            724: 1,20
+            729: 2,19
+            737: 2,20
+            740: 3,18
+            745: 3,19
+            752: 4,5
+            757: 4,6
+            765: 4,7
+            773: 4,8
+            781: 4,9
+            786: 4,10
+            792: 5,7
+            797: 5,8
+            803: 5,14
+            809: -3,14
+            815: -2,10
+            819: -1,18
+            824: -1,19
+            827: 0,19
+            835: 0,20
+            838: 1,20
+            843: 2,19
+            851: 2,20
+            854: 3,18
+            859: 3,19
+        - node:
+            id: LatticeEdgeW
+          decals:
+            7: 5,6
+            14: 4,6
+            18: 5,8
+            22: 5,7
+            30: 4,8
+            38: 4,7
+            43: 4,5
+            50: 4,9
+            54: 4,5
+            62: 4,6
+            70: 4,7
+            78: 4,8
+            82: 4,9
+            85: 5,6
+            89: 5,7
+            93: 5,8
+            103: 4,6
+            111: 4,7
+            119: 4,8
+            123: 4,9
+            126: 5,6
+            130: 5,7
+            134: 5,8
+            142: 1,20
+            149: 0,19
+            156: 2,20
+            159: 3,19
+            171: 3,18
+            183: 5,14
+            186: 5,12
+            195: 4,16
+            197: 4,4
+            201: 4,5
+            252: 4,4
+            256: 4,5
+            264: 4,6
+            272: 4,7
+            280: 4,8
+            284: 4,9
+            287: 5,6
+            291: 5,7
+            295: 5,8
+            298: 5,12
+            301: 5,14
+            329: 0,19
+            338: 1,20
+            345: 2,19
+            349: 2,20
+            353: 3,18
+            357: 3,19
+            359: 4,16
+            361: 4,4
+            365: 4,5
+            373: 4,6
+            381: 4,7
+            389: 4,8
+            393: 5,6
+            397: 5,7
+            401: 5,8
+            404: 5,12
+            407: 5,14
+            435: 0,19
+            444: 1,20
+            451: 2,19
+            455: 2,20
+            459: 3,18
+            463: 3,19
+            465: 4,16
+            467: 4,10
+            471: 4,9
+            522: 4,4
+            526: 4,5
+            534: 4,6
+            542: 4,7
+            550: 4,8
+            555: 4,9
+            559: 4,10
+            562: 5,6
+            566: 5,7
+            570: 5,8
+            573: 5,12
+            576: 5,14
+            604: 0,19
+            613: 1,20
+            620: 2,19
+            624: 2,20
+            628: 3,18
+            632: 3,19
+            634: 4,16
+            636: 4,4
+            640: 4,5
+            648: 4,6
+            656: 4,7
+            664: 4,8
+            669: 4,9
+            673: 4,10
+            676: 5,6
+            680: 5,7
+            684: 5,8
+            687: 5,12
+            690: 5,14
+            718: 0,19
+            727: 1,20
+            734: 2,19
+            738: 2,20
+            742: 3,18
+            746: 3,19
+            748: 4,16
+            750: 4,4
+            754: 4,5
+            762: 4,6
+            770: 4,7
+            778: 4,8
+            783: 4,9
+            787: 4,10
+            790: 5,6
+            794: 5,7
+            798: 5,8
+            801: 5,12
+            804: 5,14
+            832: 0,19
+            841: 1,20
+            848: 2,19
+            852: 2,20
+            856: 3,18
+            860: 3,19
+            862: 4,16
+        - node:
+            color: '#FFFFFFFF'
+            id: TechE
+          decals:
+            208: 2,12
+        - node:
+            color: '#FFFFFFFF'
+            id: TechNE
+          decals:
+            207: 2,13
+        - node:
+            color: '#FFFFFFFF'
+            id: TechNW
+          decals:
+            212: 0,13
+        - node:
+            color: '#FFFFFFFF'
+            id: TechSE
+          decals:
+            209: 2,11
+        - node:
+            color: '#FFFFFFFF'
+            id: TechSW
+          decals:
+            210: 0,11
+        - node:
+            color: '#FFFFFFFF'
+            id: TechW
+          decals:
+            211: 0,12
+        - node:
+            color: '#EFB34196'
+            id: WarnLineE
+          decals:
+            3: 3,8
+            4: 3,7
+            5: 3,6
+        - node:
+            color: '#EFB34196'
+            id: WarnLineN
+          decals:
+            178: 2,4
+            179: 2,4
+            180: 0,4
+            181: 0,4
+        - node:
+            color: '#EFB34196'
+            id: WarnLineS
+          decals:
+            0: 3,8
+            1: 3,7
+            2: 3,6
+        - node:
+            color: '#EFB34196'
+            id: WarnLineW
+          decals:
+            174: 2,4
+            175: 2,4
+            176: 0,4
+            177: 0,4
+    - type: RadiationGridResistance
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,1:
+            0: 30581
+          -1,1:
+            0: 34944
+            2: 4
+          0,2:
+            0: 29303
+          -1,2:
+            0: 136
+            2: 1024
+          0,3:
+            0: 8823
+            1: 32768
+          0,4:
+            0: 10103
+            2: 55296
+          -1,3:
+            1: 33796
+            2: 514
+          1,1:
+            2: 13073
+          1,2:
+            2: 275
+          1,3:
+            1: 257
+            2: 514
+          -1,4:
+            2: 34820
+          0,5:
+            2: 7
+          1,4:
+            2: 1
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: IFF
+      relations: {}
+      color: '#F6CE9C9C'
+      flags: IsPlayerShuttle
+    - type: ShuttleDeed
+      shuttleName: Shuttle MV-529
+      shuttleUid: 1
+- proto: ActionToggleInternals
+  entities:
+  - uid: 109
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 107
+    - type: InstantAction
+      container: 107
+  - uid: 111
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 110
+    - type: InstantAction
+      container: 110
+  - uid: 114
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 112
+    - type: InstantAction
+      container: 112
+- proto: ActionToggleJetpack
+  entities:
+  - uid: 108
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 107
+    - type: InstantAction
+      container: 107
+  - uid: 113
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      parent: 112
+    - type: InstantAction
+      container: 112
+- proto: AirCanister
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      anchored: True
+      pos: 2.5,12.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: Airlock
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 1
+- proto: AirlockMedical
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+- proto: AirlockShuttle
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -0.5,19.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: Boombox
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 2.4947367,18.734543
+      parent: 1
+- proto: BoriaticGeneratorHerculesShuttle
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+- proto: BoxBodyBag
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.72789574,7.3535576
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,18.5
+      parent: 1
+- proto: ClothingOuterHardsuitVoidParamed
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      parent: 106
+    - type: ContainerContainer
+      containers:
+        toggleable-clothing: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        actions: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 113
+          - 114
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: This decreases your speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        - message: >-
+            It provides the following protection:
+
+            - [color=yellow]Heat[/color] damage reduced by [color=lightblue]10%[/color].
+
+            - [color=yellow]Radiation[/color] damage reduced by [color=lightblue]25%[/color].
+
+            - [color=yellow]Caustic[/color] damage reduced by [color=lightblue]50%[/color].
+
+            - [color=aqua]Stamina[/color] damage reduced by [color=lightblue]25%[/color].
+          priority: 0
+          component: Armor
+        title: null
+    - type: GasTank
+      toggleActionEntity: 114
+    - type: Jetpack
+      toggleActionEntity: 113
+    - type: Physics
+      canCollide: False
+    - type: ActionsContainer
+    - type: InsideEntityStorage
+- proto: ComputerTabletopAdvancedRadar
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,17.5
+      parent: 1
+- proto: ComputerTabletopShuttle
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 1.5,19.5
+      parent: 1
+    - type: NamedModules
+      buttonNames:
+      - Toggle Shutters
+      - Module B
+      - Module C
+      - Module D
+      - Module E
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        disk_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        id_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: DeviceLinkSource
+      linkedPorts:
+        196:
+        - - Group1
+          - Toggle
+        191:
+        - - Group1
+          - Toggle
+        192:
+        - - Group1
+          - Toggle
+        193:
+        - - Group1
+          - Toggle
+        197:
+        - - Group1
+          - Toggle
+        194:
+        - - Group1
+          - Toggle
+        195:
+        - - Group1
+          - Toggle
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+- proto: FaxMachineShip
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+- proto: Firelock
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,20.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+- proto: HandheldHealthAnalyzer
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.46011734,7.8847046
+      parent: 1
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: JetpackMiniFilled
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      parent: 106
+    - type: GasTank
+      toggleActionEntity: 109
+    - type: Jetpack
+      toggleActionEntity: 108
+    - type: Physics
+      canCollide: False
+    - type: ActionsContainer
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 108
+          - 109
+    - type: InsideEntityStorage
+- proto: MedicalBed
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.7915764,8.165918
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.6684389,8.572205
+      parent: 1
+- proto: NFHolopadShip
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 1
+- proto: OxygenTankFilled
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      parent: 106
+    - type: GasTank
+      toggleActionEntity: 111
+    - type: Physics
+      canCollide: False
+    - type: ActionsContainer
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 111
+    - type: InsideEntityStorage
+- proto: PaperBin20
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 2.4295874,17.6775
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,5.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+- proto: ReinforcedWindow
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,20.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+- proto: RollerBed
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -0.7429142,6.6007776
+      parent: 1
+- proto: RubberStampApproved
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 2.4009867,18.172043
+      parent: 1
+- proto: RubberStampDenied
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 2.6353617,18.125168
+      parent: 1
+- proto: ShuttersNormal
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 198
+  - uid: 189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 198
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 198
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,19.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,20.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 1.5,20.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,19.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+  - uid: 195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,18.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,20.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 116
+- proto: SignalButton
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        190:
+        - - Pressed
+          - Toggle
+        189:
+        - - Pressed
+          - Toggle
+        188:
+        - - Pressed
+          - Toggle
+- proto: SubstationBasic
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+- proto: SuitStorageBase
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 112
+          - 110
+          - 107
+- proto: TableGlass
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 2.5,18.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5486355,12.298908
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,17.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+- proto: WallShuttleDiagonalCurved
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -0.5,19.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+...

--- a/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/birdie.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/birdie.yml
@@ -1,0 +1,30 @@
+# Author Info
+# Discord: speedycss
+
+- type: vessel
+  id: Birdie
+  name: ICM Birdie
+  description: A civilian ferry shuttle, refitted with medical supplies to act as a nimble medevac carrier.
+  price: 32000
+  category: Small
+  group: Civilian
+  path: /Maps/_Crescent/Shuttles/Civilian/birdie.yml
+
+- type: gameMap
+  id: Birdie
+  mapName: 'ICM Birdie'
+  mapPath: /Maps/_Crescent/Shuttles/Civilian/birdie.yml
+  minPlayers: 0
+  stations:
+    Birdie:
+      stationProto: StandardCrescentExpeditionVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'ICM Birdie {1}'
+          nameGenerator:
+           !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: VesselDesignation
+          designation: vessel-designation-expeditions
+        - type: VesselDescription
+          description: Perfect for trauma response.

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -89,6 +89,7 @@
     - Paracelsus
     - Qian
     - Pear
+    - Birdie
     - Termite
     - Manatee
 # Hardcoded consoles


### PR DESCRIPTION
# Description

Adds the ICM Birdie, a lightweight civilian ferry shuttle refitted with medical supplies. Cheaper, faster, and smaller than the Paracelsus. It's good for snatching up bodies, saving people, and getting away during a ship fight. Just remember to charge your patients for saving them once you get back to Gliess.

The medical area has a good amount of space for cargo (or spacer boarding parties), so it's versatile. The cockpit comes equipped with a radar console. There isn't too much to say about it, it's just a nice little medical ship.

---

# TODO

- [x] Make the ICM Birdie


---
<details><summary><h1>Media</h1></summary>
<p>

<img width="1257" height="698" alt="birdie3" src="https://github.com/user-attachments/assets/4da96219-ce02-41a3-87fd-cdf4ebb32bb0" />

</p>
</details>

---

# Changelog

:cl:
- add: Added the ICM Birdie - a civilian medevac shuttle

