### PR TITLE
Doubles the component price of ships and halves the print time of the…

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -225,108 +225,108 @@
   result: ShipVoucherVanguard
   completetime: 1
   materials:
-    StarshipEngineComponents: 1500
-    ShipComponents: 1500
-    ShipHull: 2500
+    StarshipEngineComponents: 3000
+    ShipComponents: 3000
+    ShipHull: 5000
 
 - type: latheRecipe
   id: ZorniyLPC
   result: ShipVoucherZorniy
   completetime: 1
   materials:
-    StarshipEngineComponents: 1500
-    ShipComponents: 1500
-    ShipHull: 2500
+    StarshipEngineComponents: 3000
+    ShipComponents: 3000
+    ShipHull: 5000
 
 - type: latheRecipe
   id: LodkaLPC
   result: ShipVoucherLodka
   completetime: 1
   materials:
-    StarshipEngineComponents: 1500
-    ShipComponents: 1500
-    ShipHull: 2500
+    StarshipEngineComponents: 3000
+    ShipComponents: 3000
+    ShipHull: 5000
 
 - type: latheRecipe
   id: MolotLPC
   result: ShipVoucherMolot
   completetime: 1
   materials:
-    StarshipEngineComponents: 2000
-    ShipComponents: 2500
-    ShipHull: 3000
+    StarshipEngineComponents: 4000
+    ShipComponents: 5000
+    ShipHull: 6000
 
 - type: latheRecipe
   id: KrechetLPC
   result: ShipVoucherKrechet
   completetime: 1
   materials:
-    StarshipEngineComponents: 2000
-    ShipComponents: 2000
-    ShipHull: 2000
+    StarshipEngineComponents: 4000
+    ShipComponents: 4000
+    ShipHull: 4000
 
 - type: latheRecipe
   id: IvarodLPC
   result: ShipVoucherIvarod
   completetime: 1
   materials:
-    StarshipEngineComponents: 4000
-    ShipComponents: 4000
-    ShipHull: 6000
+    StarshipEngineComponents: 8000
+    ShipComponents: 8000
+    ShipHull: 12000
 
 - type: latheRecipe
   id: VanguardMarkTwoLPC
   result: ShipVoucherVanguardMarkTwo
   completetime: 1
   materials:
-    StarshipEngineComponents: 2000
-    ShipComponents: 2000
-    ShipHull: 2500
+    StarshipEngineComponents: 4000
+    ShipComponents: 4000
+    ShipHull: 5000
 
 - type: latheRecipe
   id: HindLPC
   result: ShipVoucherHind
   completetime: 1
   materials:
-    StarshipEngineComponents: 5000
-    ShipComponents: 5000
-    ShipHull: 6000
+    StarshipEngineComponents: 10000
+    ShipComponents: 10000
+    ShipHull: 12000
 
 - type: latheRecipe
   id: GargutLPC
   result: ShipVoucherGargut
   completetime: 1
   materials:
-    StarshipEngineComponents: 7000
-    ShipComponents: 8000
-    ShipHull: 12000
+    StarshipEngineComponents: 14000
+    ShipComponents: 16000
+    ShipHull: 24000
 
 - type: latheRecipe
   id: SternLPC
   result: ShipVoucherStern
   completetime: 1
   materials:
-    StarshipEngineComponents: 12500
-    ShipComponents: 10000
-    ShipHull: 17500
+    StarshipEngineComponents: 25000
+    ShipComponents: 20000
+    ShipHull: 35000
 
 - type: latheRecipe
   id: SunderLPC
   result: ShipVoucherSunder
   completetime: 1
   materials:
-    StarshipEngineComponents: 7000
-    ShipComponents: 8000
-    ShipHull: 8000
+    StarshipEngineComponents: 14000
+    ShipComponents: 16000
+    ShipHull: 16000
 
 - type: latheRecipe
   id: BogatyrLPC
   result: ShipVoucherBogatyr
   completetime: 1
   materials:
-    StarshipEngineComponents: 6000
-    ShipComponents: 6000
-    ShipHull: 8000
+    StarshipEngineComponents: 12000
+    ShipComponents: 12000
+    ShipHull: 16000
 
 - type: latheRecipe
   id: LancerFlatpack

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -474,51 +474,51 @@
   result: ShipVoucherLaelaps
   completetime: 1
   materials:
-    StarshipEngineComponents: 6250
-    ShipComponents: 4750
-    ShipHull: 9000
+    StarshipEngineComponents: 12500
+    ShipComponents: 9500
+    ShipHull: 18000
 
 - type: latheRecipe
   id: SunesisLPC
   result: ShipVoucherSunesis
   completetime: 1
   materials:
-    StarshipEngineComponents: 6250
-    ShipComponents: 4750
-    ShipHull: 9000
+    StarshipEngineComponents: 25000
+    ShipComponents: 19000
+    ShipHull: 36000
 
 - type: latheRecipe
   id: SuzerainLPC
   result: ShipVoucherSuzerain
   completetime: 1
   materials:
-    StarshipEngineComponents: 12500
-    ShipComponents: 9000
-    ShipHull: 16500
+    StarshipEngineComponents: 25000
+    ShipComponents: 18000
+    ShipHull: 33000
 
 - type: latheRecipe
   id: TriumphantLPC
   result: ShipVoucherTriumphant
   completetime: 1
   materials:
-    StarshipEngineComponents: 8250
-    ShipComponents: 6750
-    ShipHull: 10500
+    StarshipEngineComponents: 16500
+    ShipComponents: 13500
+    ShipHull: 21000
 
 - type: latheRecipe
   id: IbisLPC
   result: ShipVoucherIbis
   completetime: 1
   materials:
-    StarshipEngineComponents: 3250
-    ShipComponents: 1750
-    ShipHull: 4000
+    StarshipEngineComponents: 6500
+    ShipComponents: 3500
+    ShipHull: 8000
 
 - type: latheRecipe
   id: CovetorLPC
   result: ShipVoucherCovetor
   completetime: 1
   materials:
-    StarshipEngineComponents: 3000
-    ShipComponents: 2750
-    ShipHull: 6000
+    StarshipEngineComponents: 6000
+    ShipComponents: 5500
+    ShipHull: 12000

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/shipcomponents.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/shipcomponents.yml
@@ -2,7 +2,7 @@
 - type: latheRecipe
   id: ShipHull
   result: StarshipHull1
-  completetime: 0.25
+  completetime: 0.5
   materials:
     Steel: 250
     Plasma: 175
@@ -10,7 +10,7 @@
 - type: latheRecipe
   id: ShipElectronics
   result: StarshipElectronics1
-  completetime: 0.25
+  completetime: 0.5
   materials:
     Steel: 200
     Gold: 175
@@ -19,7 +19,7 @@
 - type: latheRecipe
   id: ShipEngine
   result: StarshipEngineComponents1
-  completetime: 0.25
+  completetime: 0.5
   materials:
     Steel: 175
     Gold: 130


### PR DESCRIPTION
# Description

Doubles the ship component price of both faction produced LPCs and doubles the print speed of these components. Currently from my personal testing a single mining trip that tooks an hour nets enough material to produce a very very big ammount of ships. With the current problem of printing money by mass selling produced ships (Up to and over 2 mil for one hour of mining by a single pilot on a single ship. Allthough this ammount really depends on the ammount of plasma one would gather.) this change will nerf this way to generate basically free money. I dont believe it will decrease the ammount of ships the big factions can use in combat (only 3 sterns for hour of mining instead of 6 :/ ). I also doubled the speed at which the ship components are produced so that it wont make the speed of actually making the ships feel any different.

---

# TODO
- [x] Mald at people coping its gonna become slave work.
---
# Changelog

:cl:
- tweak: 2x every ship LPC recipe costs
- tweak: 0,5x ship component print time

