### PR TITLE
Kite MKII update

### DIFF
--- a/Resources/Maps/_Crescent/Shuttles/Civilian/kitemk2.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/kitemk2.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 260.2.0
   forkId: ""
   forkVersion: ""
-  time: 09/19/2025 18:36:00
-  entityCount: 375
+  time: 10/16/2025 07:04:57
+  entityCount: 414
 maps: []
 grids:
 - 1
@@ -47,7 +47,7 @@ entities:
           version: 7
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAIIAAAAAAACCAAAAAAAAPQAAAAAAAD0AAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIIAAAAAAAAJAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAPQAAAAAAAIEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCAAAAAAAABAAAAAAAAAQAAAAAAACCAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAggAAAAAAAD0AAAAAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAAQAAAAAAAAEAAAAAAAAggAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAIIAAAAAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAIIAAAAAAACCAAAAAAAAPQAAAAAAAD0AAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIIAAAAAAAAJAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCAAAAAAAABAAAAAAAAAQAAAAAAACCAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAAggAAAAAAAD0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAAQAAAAAAAAEAAAAAAAAggAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAIIAAAAAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 7
         -1,0:
           ind: -1,0
@@ -55,7 +55,7 @@ entities:
           version: 7
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAD0AAAAAAAA9AAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAD0AAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAAAAAACCAAAAAAAAggAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAIIAAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAAIIAAAAAAAAEAAAAAAAAggAAAAAAAIIAAAAAAAAEAAAAAAAAggAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAD0AAAAAAAA9AAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAAAAAggAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAIIAAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAAIIAAAAAAAAEAAAAAAAAggAAAAAAAIIAAAAAAAAEAAAAAAAAggAAAAAAAA==
           version: 7
     - type: Broadphase
     - type: Physics
@@ -82,757 +82,881 @@ entities:
             color: '#EFB34196'
             id: BoxGreyscale
           decals:
-            88: 0,4
+            76: 0,4
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelCornerNe
           decals:
-            73: 2,-1
-            79: 2,1
+            61: 2,-1
+            67: 2,1
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelCornerNw
           decals:
-            72: 1,-1
-            77: -1,1
+            60: 1,-1
+            65: -1,1
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelCornerSe
           decals:
-            74: 2,-2
-            83: 6,-2
-            85: -3,-2
+            62: 2,-2
+            71: 6,-2
+            73: -3,-2
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelCornerSw
           decals:
-            75: 1,-2
-            81: 4,-2
-            86: -5,-2
+            63: 1,-2
+            74: -5,-2
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelLineE
           decals:
-            84: 6,-1
+            72: 6,-1
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelLineN
           decals:
-            78: 0,1
+            66: 0,1
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelLineS
           decals:
-            82: 5,-2
+            70: 5,-2
         - node:
             color: '#DE3A3A96'
             id: BrickTileSteelLineW
           decals:
-            76: -1,0
-            80: 4,-1
-            87: -5,-1
+            64: -1,0
+            68: 4,-1
+            75: -5,-1
+        - node:
+            cleanable: True
+            color: '#A4610696'
+            id: Dirt
+          decals:
+            792: -4,-1
+            793: -3,-1
         - node:
             color: '#FFFFFFFF'
             id: DirtHeavy
           decals:
-            174: 5,-2
-            175: 2,-1
-            176: 2,-2
-            177: 5,-2
-            178: 5,-1
-            179: 5,0
-            180: 4,1
-            181: 0,1
-            182: -2,2
-            183: -1,1
-            184: -1,0
-            185: -5,-2
-            186: -5,-2
-            187: 0,3
-            188: 0,4
-            189: 2,3
-            190: 0,0
-            191: -1,0
-            416: 6.1524024,0.98047423
-            417: 6.1524024,0.99609923
-            418: -5.0194726,1.0585992
-            419: -5.0194726,1.0585992
-            422: 6,1
-            423: -5,1
-            424: -3,1
-            425: -3,1
-            431: 5,1
-            432: -4,1
-            433: -4,1
-            438: 5,1
-            439: 5,1
-            440: -4,1
+            162: 5,-2
+            163: 2,-1
+            164: 2,-2
+            165: 5,-2
+            166: 5,-1
+            167: 5,0
+            168: 4,1
+            169: 0,1
+            170: -2,2
+            171: -1,1
+            172: -1,0
+            173: -5,-2
+            174: -5,-2
+            175: 0,3
+            176: 0,4
+            177: 2,3
+            178: 0,0
+            179: -1,0
+            372: 6.1524024,0.98047423
+            373: 6.1524024,0.99609923
+            374: -5.0194726,1.0585992
+            375: -5.0194726,1.0585992
+            378: 6,1
+            379: -5,1
+            380: -3,1
+            381: -3,1
+            387: 5,1
+            388: -4,1
+            389: -4,1
+            394: 5,1
+            395: 5,1
+            396: -4,1
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            755: 4,-2
+            756: 4,-2
+            757: 4,-2
+            758: 4,-2
+            759: 4,-2
+            760: 4,-1
+            761: 4,-1
+            762: 1,-3
+            763: 1,-3
+            764: 1,-3
+            765: 6,-2
+            766: 6,-2
+            767: 6,-2
+            768: -3,-1
+            769: -3,-1
+            770: -3,-1
+            771: -4,-1
+            772: -4,-1
+            773: -4,-1
+            774: -4,-1
+            775: -4,-2
+            776: -4,-2
+            777: -4,-2
+            778: -3,-2
+            779: -3,-2
+            780: -3,-2
+            781: -4,-1
+            782: -4,-1
+            783: -3,-1
+            784: -3,-1
+            785: -3,-1
+            786: -3,-1
+            787: -3,-1
+            788: -3,-1
         - node:
             color: '#FFFFFFFF'
             id: DirtHeavyMonotile
           decals:
-            146: 6,0
-            147: 5,-1
-            148: 1,0
-            149: 1,-1
-            150: 2,-2
-            151: -1,0
-            152: -2,0
-            153: -5,0
-            154: -5,1
-            155: -5,-1
-            156: -5,-1
-            157: -5,-2
-            158: 1,3
-            159: 0,3
-            160: 0,4
-            161: 1,4
-            162: 2,3
-            163: 2,3
-            426: 6,1
+            134: 6,0
+            135: 5,-1
+            136: 1,0
+            137: 1,-1
+            138: 2,-2
+            139: -1,0
+            140: -2,0
+            141: -5,0
+            142: -5,1
+            143: -5,-1
+            144: -5,-1
+            145: -5,-2
+            146: 1,3
+            147: 0,3
+            148: 0,4
+            149: 1,4
+            150: 2,3
+            151: 2,3
+            382: 6,1
         - node:
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
-            164: 6,-1
-            165: 4,0
-            166: 3,0
-            167: 3,-2
-            168: 2,-2
-            169: 1,0
-            170: -2,0
-            171: -5,-1
-            172: -6,-1
-            173: -5,-1
-            420: 5.9782863,1.0482366
-            421: 6.1345363,1.0013616
+            152: 6,-1
+            153: 4,0
+            154: 3,0
+            155: 3,-2
+            156: 2,-2
+            157: 1,0
+            158: -2,0
+            159: -5,-1
+            160: -6,-1
+            161: -5,-1
+            376: 5.9782863,1.0482366
+            377: 6.1345363,1.0013616
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            789: -4,-1
+            790: -4,-1
+            791: -4,-1
         - node:
             color: '#FFFFFFFF'
             id: DirtMedium
           decals:
-            104: 0,4
-            105: 0,3
-            106: 2,3
-            107: 2,4
-            108: 2,4
-            109: -1,4
-            110: -1,4
-            111: -1,4
-            112: 0,3
-            113: 1,3
-            114: -1,1
-            115: -2,0
-            116: -1,1
-            117: 2,0
-            118: 2,1
-            119: 2,-1
-            120: 1,-2
-            121: 1,-1
-            122: 2,-2
-            123: 2,-2
-            124: -2,-2
-            125: -1,-2
-            126: -2,-2
-            127: -4,-2
-            128: -5,-1
-            129: -5,0
-            130: -5,1
-            131: -5,1
-            132: -4,0
-            133: -3,0
-            134: -3,1
-            135: 5,0
-            136: 4,1
-            137: 4,0
-            138: 5,-1
-            139: 6,-1
-            140: 4,-2
-            141: 5,-1
-            142: 6,0
-            143: 5,1
-            144: 6,1
-            145: 6,0
-            427: 6,1
-            428: -3,1
-            429: -3,1
-            430: -3,1
-            434: 5,1
-            435: -4,1
-            436: -4,1
-            437: -4,1
+            92: 0,4
+            93: 0,3
+            94: 2,3
+            95: 2,4
+            96: 2,4
+            97: -1,4
+            98: -1,4
+            99: -1,4
+            100: 0,3
+            101: 1,3
+            102: -1,1
+            103: -2,0
+            104: -1,1
+            105: 2,0
+            106: 2,1
+            107: 2,-1
+            108: 1,-2
+            109: 1,-1
+            110: 2,-2
+            111: 2,-2
+            112: -2,-2
+            113: -1,-2
+            114: -2,-2
+            115: -4,-2
+            116: -5,-1
+            117: -5,0
+            118: -5,1
+            119: -5,1
+            120: -4,0
+            121: -3,0
+            122: -3,1
+            123: 5,0
+            124: 4,1
+            125: 4,0
+            126: 5,-1
+            127: 6,-1
+            129: 5,-1
+            130: 6,0
+            131: 5,1
+            132: 6,1
+            133: 6,0
+            383: 6,1
+            384: -3,1
+            385: -3,1
+            386: -3,1
+            390: 5,1
+            391: -4,1
+            392: -4,1
+            393: -4,1
         - node:
             color: '#FFFFFFFF'
             id: FloorTechMaintDirectionalEdge
           decals:
-            103: -1,-1
+            91: -1,-1
         - node:
             zIndex: 1
             id: LatticeCornerNE
           decals:
-            9: -4,-4
-            15: -4,-4
-            18: -4,-4
-            55: -3,3
-            235: -3,3
-            247: -4,-4
-            291: -3,3
-            303: -4,-4
-            347: -3,3
-            359: -4,-4
-            397: -3,3
-            409: -4,-4
-            446: -8,-3
-            493: -3,3
-            505: -8,-3
-            508: -4,-4
-            555: -3,3
-            567: -8,-3
-            570: -4,-4
-            617: -3,3
-            629: -8,-3
-            632: -4,-4
-            705: -3,3
-            745: -4,-4
-            751: -8,-3
+            5: -4,-4
+            11: -4,-4
+            14: -4,-4
+            43: -3,3
+            215: -3,3
+            227: -4,-4
+            263: -3,3
+            275: -4,-4
+            311: -3,3
+            323: -4,-4
+            353: -3,3
+            365: -4,-4
+            441: -3,3
+            456: -4,-4
+            495: -3,3
+            510: -4,-4
+            549: -3,3
+            564: -4,-4
+            581: -3,3
+            616: -4,-4
+            673: -3,3
+            688: -4,-4
+            727: -3,3
+            742: -4,-4
+            748: -7,-3
         - node:
             zIndex: 1
             id: LatticeCornerNW
           decals:
-            6: 5,-4
-            12: 5,-4
-            21: 5,-4
-            61: 4,3
-            210: 4,3
-            223: 5,-4
-            266: 4,3
-            279: 5,-4
-            322: 4,3
-            335: 5,-4
-            378: 4,3
-            388: 5,-4
-            443: 9,-3
-            465: 4,3
-            478: 5,-4
-            481: 9,-3
-            527: 4,3
-            540: 5,-4
-            543: 9,-3
-            589: 4,3
-            602: 5,-4
-            605: 9,-3
-            737: 4,3
-            742: 5,-4
-            757: 9,-3
+            2: 5,-4
+            8: 5,-4
+            17: 5,-4
+            49: 4,3
+            190: 4,3
+            203: 5,-4
+            238: 4,3
+            251: 5,-4
+            286: 4,3
+            299: 5,-4
+            334: 4,3
+            344: 5,-4
+            413: 4,3
+            426: 5,-4
+            467: 4,3
+            480: 5,-4
+            521: 4,3
+            534: 5,-4
+            608: 4,3
+            613: 5,-4
+            645: 4,3
+            658: 5,-4
+            699: 4,3
+            712: 5,-4
+            754: 8,-3
         - node:
             zIndex: 1
             id: LatticeCornerSE
           decals:
-            24: -3,4
-            27: -7,0
-            33: -1,6
-            53: -3,3
-            68: -6,2
-            71: -2,5
-            226: -7,0
-            229: -6,2
-            233: -3,3
-            238: -3,4
-            241: -2,5
-            244: -1,6
-            282: -7,0
-            285: -6,2
-            289: -3,3
-            294: -3,4
-            297: -2,5
-            300: -1,6
-            338: -7,0
-            341: -6,2
-            345: -3,3
-            350: -3,4
-            353: -2,5
-            356: -1,6
-            391: -7,0
-            395: -3,3
-            400: -3,4
-            403: -2,5
-            406: -1,6
-            415: -6,2
-            484: -7,0
-            487: -6,2
-            491: -3,3
-            496: -3,4
-            499: -2,5
-            502: -1,6
-            546: -7,0
-            549: -6,2
-            553: -3,3
-            558: -3,4
-            561: -2,5
-            564: -1,6
-            608: -7,0
-            611: -6,2
-            615: -3,3
-            620: -3,4
-            623: -2,5
-            626: -1,6
-            682: -3,4
-            685: -2,5
-            703: -3,3
-            709: -6,2
-            748: -7,0
-            763: -1,6
+            20: -3,4
+            23: -7,0
+            29: -1,6
+            41: -3,3
+            56: -6,2
+            59: -2,5
+            206: -7,0
+            209: -6,2
+            213: -3,3
+            218: -3,4
+            221: -2,5
+            224: -1,6
+            254: -7,0
+            257: -6,2
+            261: -3,3
+            266: -3,4
+            269: -2,5
+            272: -1,6
+            302: -7,0
+            305: -6,2
+            309: -3,3
+            314: -3,4
+            317: -2,5
+            320: -1,6
+            347: -7,0
+            351: -3,3
+            356: -3,4
+            359: -2,5
+            362: -1,6
+            371: -6,2
+            432: -7,0
+            435: -6,2
+            439: -3,3
+            444: -3,4
+            447: -2,5
+            450: -1,6
+            486: -7,0
+            489: -6,2
+            493: -3,3
+            498: -3,4
+            501: -2,5
+            504: -1,6
+            540: -7,0
+            543: -6,2
+            547: -3,3
+            552: -3,4
+            555: -2,5
+            558: -1,6
+            567: -3,4
+            570: -2,5
+            579: -3,3
+            585: -6,2
+            619: -7,0
+            634: -1,6
+            664: -7,0
+            667: -6,2
+            671: -3,3
+            676: -3,4
+            679: -2,5
+            682: -1,6
+            718: -7,0
+            721: -6,2
+            725: -3,3
+            730: -3,4
+            733: -2,5
+            736: -1,6
         - node:
             zIndex: 1
             id: LatticeCornerSW
           decals:
-            30: 8,0
-            36: 2,6
-            39: 4,4
-            42: 3,5
-            60: 4,3
-            65: 7,2
-            194: 2,6
-            205: 3,5
-            209: 4,3
-            213: 4,4
-            217: 7,2
-            220: 8,0
-            250: 2,6
-            261: 3,5
-            265: 4,3
-            269: 4,4
-            273: 7,2
-            276: 8,0
-            306: 2,6
-            317: 3,5
-            321: 4,3
-            325: 4,4
-            329: 7,2
-            332: 8,0
-            362: 2,6
-            373: 3,5
-            377: 4,3
-            381: 4,4
-            385: 8,0
-            412: 7,2
-            449: 2,6
-            460: 3,5
-            464: 4,3
-            468: 4,4
-            472: 7,2
-            475: 8,0
-            511: 2,6
-            522: 3,5
-            526: 4,3
-            530: 4,4
-            534: 7,2
-            537: 8,0
-            573: 2,6
-            584: 3,5
-            588: 4,3
-            592: 4,4
-            596: 7,2
-            599: 8,0
-            718: 7,2
-            729: 3,5
-            732: 4,4
-            736: 4,3
-            754: 8,0
-            760: 2,6
+            26: 8,0
+            32: 2,6
+            35: 4,4
+            38: 3,5
+            48: 4,3
+            53: 7,2
+            182: 2,6
+            185: 3,5
+            189: 4,3
+            193: 4,4
+            197: 7,2
+            200: 8,0
+            230: 2,6
+            233: 3,5
+            237: 4,3
+            241: 4,4
+            245: 7,2
+            248: 8,0
+            278: 2,6
+            281: 3,5
+            285: 4,3
+            289: 4,4
+            293: 7,2
+            296: 8,0
+            326: 2,6
+            329: 3,5
+            333: 4,3
+            337: 4,4
+            341: 8,0
+            368: 7,2
+            405: 2,6
+            408: 3,5
+            412: 4,3
+            416: 4,4
+            420: 7,2
+            423: 8,0
+            459: 2,6
+            462: 3,5
+            466: 4,3
+            470: 4,4
+            474: 7,2
+            477: 8,0
+            513: 2,6
+            516: 3,5
+            520: 4,3
+            524: 4,4
+            528: 7,2
+            531: 8,0
+            589: 7,2
+            600: 3,5
+            603: 4,4
+            607: 4,3
+            625: 8,0
+            631: 2,6
+            637: 2,6
+            640: 3,5
+            644: 4,3
+            648: 4,4
+            652: 7,2
+            655: 8,0
+            691: 2,6
+            694: 3,5
+            698: 4,3
+            702: 4,4
+            706: 7,2
+            709: 8,0
         - node:
             id: LatticeEdgeE
           decals:
-            7: -4,-4
-            13: -4,-4
-            16: -4,-4
-            23: -3,4
-            26: -7,0
-            32: -1,6
-            52: -3,3
-            67: -6,2
-            70: -2,5
-            225: -7,0
-            228: -6,2
-            232: -3,3
-            237: -3,4
-            240: -2,5
-            243: -1,6
-            245: -4,-4
-            281: -7,0
-            284: -6,2
-            288: -3,3
-            293: -3,4
-            296: -2,5
-            299: -1,6
-            301: -4,-4
-            337: -7,0
-            340: -6,2
-            344: -3,3
-            349: -3,4
-            352: -2,5
-            355: -1,6
-            357: -4,-4
-            390: -7,0
-            394: -3,3
-            399: -3,4
-            402: -2,5
-            405: -1,6
-            407: -4,-4
-            414: -6,2
-            444: -8,-3
-            483: -7,0
-            486: -6,2
-            490: -3,3
-            495: -3,4
-            498: -2,5
-            501: -1,6
-            503: -8,-3
-            506: -4,-4
-            545: -7,0
-            548: -6,2
-            552: -3,3
-            557: -3,4
-            560: -2,5
-            563: -1,6
-            565: -8,-3
-            568: -4,-4
-            607: -7,0
-            610: -6,2
-            614: -3,3
-            619: -3,4
-            622: -2,5
-            625: -1,6
-            627: -8,-3
-            630: -4,-4
-            681: -3,4
-            684: -2,5
-            702: -3,3
-            708: -6,2
-            743: -4,-4
-            747: -7,0
-            749: -8,-3
-            762: -1,6
+            3: -4,-4
+            9: -4,-4
+            12: -4,-4
+            19: -3,4
+            22: -7,0
+            28: -1,6
+            40: -3,3
+            55: -6,2
+            58: -2,5
+            205: -7,0
+            208: -6,2
+            212: -3,3
+            217: -3,4
+            220: -2,5
+            223: -1,6
+            225: -4,-4
+            253: -7,0
+            256: -6,2
+            260: -3,3
+            265: -3,4
+            268: -2,5
+            271: -1,6
+            273: -4,-4
+            301: -7,0
+            304: -6,2
+            308: -3,3
+            313: -3,4
+            316: -2,5
+            319: -1,6
+            321: -4,-4
+            346: -7,0
+            350: -3,3
+            355: -3,4
+            358: -2,5
+            361: -1,6
+            363: -4,-4
+            370: -6,2
+            431: -7,0
+            434: -6,2
+            438: -3,3
+            443: -3,4
+            446: -2,5
+            449: -1,6
+            454: -4,-4
+            485: -7,0
+            488: -6,2
+            492: -3,3
+            497: -3,4
+            500: -2,5
+            503: -1,6
+            508: -4,-4
+            539: -7,0
+            542: -6,2
+            546: -3,3
+            551: -3,4
+            554: -2,5
+            557: -1,6
+            562: -4,-4
+            566: -3,4
+            569: -2,5
+            578: -3,3
+            584: -6,2
+            614: -4,-4
+            618: -7,0
+            633: -1,6
+            663: -7,0
+            666: -6,2
+            670: -3,3
+            675: -3,4
+            678: -2,5
+            681: -1,6
+            686: -4,-4
+            717: -7,0
+            720: -6,2
+            724: -3,3
+            729: -3,4
+            732: -2,5
+            735: -1,6
+            740: -4,-4
+            746: -7,-3
         - node:
             id: LatticeEdgeN
           decals:
-            4: 5,-4
-            8: -4,-4
-            10: 5,-4
-            14: -4,-4
-            17: -4,-4
-            19: 5,-4
-            54: -3,3
-            58: 4,3
-            207: 4,3
-            221: 5,-4
-            234: -3,3
-            246: -4,-4
-            263: 4,3
-            277: 5,-4
-            290: -3,3
-            302: -4,-4
-            319: 4,3
-            333: 5,-4
-            346: -3,3
-            358: -4,-4
-            375: 4,3
-            386: 5,-4
-            396: -3,3
-            408: -4,-4
-            441: 9,-3
-            445: -8,-3
-            462: 4,3
-            476: 5,-4
-            479: 9,-3
-            492: -3,3
-            504: -8,-3
-            507: -4,-4
-            524: 4,3
-            538: 5,-4
-            541: 9,-3
-            554: -3,3
-            566: -8,-3
-            569: -4,-4
-            586: 4,3
-            600: 5,-4
-            603: 9,-3
-            616: -3,3
-            628: -8,-3
-            631: -4,-4
-            704: -3,3
-            734: 4,3
-            740: 5,-4
-            744: -4,-4
-            750: -8,-3
-            755: 9,-3
+            0: 5,-4
+            4: -4,-4
+            6: 5,-4
+            10: -4,-4
+            13: -4,-4
+            15: 5,-4
+            42: -3,3
+            46: 4,3
+            187: 4,3
+            201: 5,-4
+            214: -3,3
+            226: -4,-4
+            235: 4,3
+            249: 5,-4
+            262: -3,3
+            274: -4,-4
+            283: 4,3
+            297: 5,-4
+            310: -3,3
+            322: -4,-4
+            331: 4,3
+            342: 5,-4
+            352: -3,3
+            364: -4,-4
+            410: 4,3
+            424: 5,-4
+            440: -3,3
+            455: -4,-4
+            464: 4,3
+            478: 5,-4
+            494: -3,3
+            509: -4,-4
+            518: 4,3
+            532: 5,-4
+            548: -3,3
+            563: -4,-4
+            580: -3,3
+            605: 4,3
+            611: 5,-4
+            615: -4,-4
+            642: 4,3
+            656: 5,-4
+            672: -3,3
+            687: -4,-4
+            696: 4,3
+            710: 5,-4
+            726: -3,3
+            741: -4,-4
+            747: -7,-3
+            752: 8,-3
         - node:
             id: LatticeEdgeS
           decals:
-            22: -3,4
-            25: -7,0
-            28: 8,0
-            31: -1,6
-            34: 2,6
-            37: 4,4
-            40: 3,5
-            51: -3,3
-            56: -5,3
-            57: 4,3
-            62: 6,3
-            63: 7,2
-            66: -6,2
-            69: -2,5
-            192: 2,6
-            203: 3,5
-            206: 4,3
-            211: 4,4
-            214: 6,3
-            215: 7,2
-            218: 8,0
-            224: -7,0
-            227: -6,2
-            230: -5,3
-            231: -3,3
-            236: -3,4
-            239: -2,5
-            242: -1,6
-            248: 2,6
-            259: 3,5
-            262: 4,3
-            267: 4,4
-            270: 6,3
-            271: 7,2
-            274: 8,0
-            280: -7,0
-            283: -6,2
-            286: -5,3
-            287: -3,3
-            292: -3,4
-            295: -2,5
-            298: -1,6
-            304: 2,6
-            315: 3,5
-            318: 4,3
-            323: 4,4
-            326: 6,3
-            327: 7,2
-            330: 8,0
-            336: -7,0
-            339: -6,2
-            342: -5,3
-            343: -3,3
-            348: -3,4
-            351: -2,5
-            354: -1,6
-            360: 2,6
-            371: 3,5
-            374: 4,3
-            379: 4,4
-            382: 6,3
-            383: 8,0
-            389: -7,0
-            392: -5,3
-            393: -3,3
-            398: -3,4
-            401: -2,5
-            404: -1,6
-            410: 7,2
-            413: -6,2
-            447: 2,6
-            458: 3,5
-            461: 4,3
-            466: 4,4
-            469: 6,3
-            470: 7,2
-            473: 8,0
-            482: -7,0
-            485: -6,2
-            488: -5,3
-            489: -3,3
-            494: -3,4
-            497: -2,5
-            500: -1,6
-            509: 2,6
-            520: 3,5
-            523: 4,3
-            528: 4,4
-            531: 6,3
-            532: 7,2
-            535: 8,0
-            544: -7,0
-            547: -6,2
-            550: -5,3
-            551: -3,3
-            556: -3,4
-            559: -2,5
-            562: -1,6
-            571: 2,6
-            582: 3,5
-            585: 4,3
-            590: 4,4
-            593: 6,3
-            594: 7,2
-            597: 8,0
-            606: -7,0
-            609: -6,2
-            612: -5,3
-            613: -3,3
-            618: -3,4
-            621: -2,5
-            624: -1,6
-            680: -3,4
-            683: -2,5
-            701: -3,3
-            706: -5,3
-            707: -6,2
-            715: 6,3
-            716: 7,2
-            727: 3,5
-            730: 4,4
-            733: 4,3
-            746: -7,0
-            752: 8,0
-            758: 2,6
-            761: -1,6
+            18: -3,4
+            21: -7,0
+            24: 8,0
+            27: -1,6
+            30: 2,6
+            33: 4,4
+            36: 3,5
+            39: -3,3
+            44: -5,3
+            45: 4,3
+            50: 6,3
+            51: 7,2
+            54: -6,2
+            57: -2,5
+            180: 2,6
+            183: 3,5
+            186: 4,3
+            191: 4,4
+            194: 6,3
+            195: 7,2
+            198: 8,0
+            204: -7,0
+            207: -6,2
+            210: -5,3
+            211: -3,3
+            216: -3,4
+            219: -2,5
+            222: -1,6
+            228: 2,6
+            231: 3,5
+            234: 4,3
+            239: 4,4
+            242: 6,3
+            243: 7,2
+            246: 8,0
+            252: -7,0
+            255: -6,2
+            258: -5,3
+            259: -3,3
+            264: -3,4
+            267: -2,5
+            270: -1,6
+            276: 2,6
+            279: 3,5
+            282: 4,3
+            287: 4,4
+            290: 6,3
+            291: 7,2
+            294: 8,0
+            300: -7,0
+            303: -6,2
+            306: -5,3
+            307: -3,3
+            312: -3,4
+            315: -2,5
+            318: -1,6
+            324: 2,6
+            327: 3,5
+            330: 4,3
+            335: 4,4
+            338: 6,3
+            339: 8,0
+            345: -7,0
+            348: -5,3
+            349: -3,3
+            354: -3,4
+            357: -2,5
+            360: -1,6
+            366: 7,2
+            369: -6,2
+            403: 2,6
+            406: 3,5
+            409: 4,3
+            414: 4,4
+            417: 6,3
+            418: 7,2
+            421: 8,0
+            430: -7,0
+            433: -6,2
+            436: -5,3
+            437: -3,3
+            442: -3,4
+            445: -2,5
+            448: -1,6
+            457: 2,6
+            460: 3,5
+            463: 4,3
+            468: 4,4
+            471: 6,3
+            472: 7,2
+            475: 8,0
+            484: -7,0
+            487: -6,2
+            490: -5,3
+            491: -3,3
+            496: -3,4
+            499: -2,5
+            502: -1,6
+            511: 2,6
+            514: 3,5
+            517: 4,3
+            522: 4,4
+            525: 6,3
+            526: 7,2
+            529: 8,0
+            538: -7,0
+            541: -6,2
+            544: -5,3
+            545: -3,3
+            550: -3,4
+            553: -2,5
+            556: -1,6
+            565: -3,4
+            568: -2,5
+            577: -3,3
+            582: -5,3
+            583: -6,2
+            586: 6,3
+            587: 7,2
+            598: 3,5
+            601: 4,4
+            604: 4,3
+            617: -7,0
+            623: 8,0
+            629: 2,6
+            632: -1,6
+            635: 2,6
+            638: 3,5
+            641: 4,3
+            646: 4,4
+            649: 6,3
+            650: 7,2
+            653: 8,0
+            662: -7,0
+            665: -6,2
+            668: -5,3
+            669: -3,3
+            674: -3,4
+            677: -2,5
+            680: -1,6
+            689: 2,6
+            692: 3,5
+            695: 4,3
+            700: 4,4
+            703: 6,3
+            704: 7,2
+            707: 8,0
+            716: -7,0
+            719: -6,2
+            722: -5,3
+            723: -3,3
+            728: -3,4
+            731: -2,5
+            734: -1,6
         - node:
             id: LatticeEdgeW
           decals:
-            5: 5,-4
-            11: 5,-4
-            20: 5,-4
-            29: 8,0
-            35: 2,6
-            38: 4,4
-            41: 3,5
-            59: 4,3
-            64: 7,2
-            193: 2,6
-            204: 3,5
-            208: 4,3
-            212: 4,4
-            216: 7,2
-            219: 8,0
-            222: 5,-4
-            249: 2,6
-            260: 3,5
-            264: 4,3
-            268: 4,4
-            272: 7,2
-            275: 8,0
-            278: 5,-4
-            305: 2,6
-            316: 3,5
-            320: 4,3
-            324: 4,4
-            328: 7,2
-            331: 8,0
-            334: 5,-4
-            361: 2,6
-            372: 3,5
-            376: 4,3
-            380: 4,4
-            384: 8,0
-            387: 5,-4
-            411: 7,2
-            442: 9,-3
-            448: 2,6
-            459: 3,5
-            463: 4,3
-            467: 4,4
-            471: 7,2
-            474: 8,0
-            477: 5,-4
-            480: 9,-3
-            510: 2,6
-            521: 3,5
-            525: 4,3
-            529: 4,4
-            533: 7,2
-            536: 8,0
-            539: 5,-4
-            542: 9,-3
-            572: 2,6
-            583: 3,5
-            587: 4,3
-            591: 4,4
-            595: 7,2
-            598: 8,0
-            601: 5,-4
-            604: 9,-3
-            717: 7,2
-            728: 3,5
-            731: 4,4
-            735: 4,3
-            741: 5,-4
-            753: 8,0
-            756: 9,-3
-            759: 2,6
+            1: 5,-4
+            7: 5,-4
+            16: 5,-4
+            25: 8,0
+            31: 2,6
+            34: 4,4
+            37: 3,5
+            47: 4,3
+            52: 7,2
+            181: 2,6
+            184: 3,5
+            188: 4,3
+            192: 4,4
+            196: 7,2
+            199: 8,0
+            202: 5,-4
+            229: 2,6
+            232: 3,5
+            236: 4,3
+            240: 4,4
+            244: 7,2
+            247: 8,0
+            250: 5,-4
+            277: 2,6
+            280: 3,5
+            284: 4,3
+            288: 4,4
+            292: 7,2
+            295: 8,0
+            298: 5,-4
+            325: 2,6
+            328: 3,5
+            332: 4,3
+            336: 4,4
+            340: 8,0
+            343: 5,-4
+            367: 7,2
+            404: 2,6
+            407: 3,5
+            411: 4,3
+            415: 4,4
+            419: 7,2
+            422: 8,0
+            425: 5,-4
+            458: 2,6
+            461: 3,5
+            465: 4,3
+            469: 4,4
+            473: 7,2
+            476: 8,0
+            479: 5,-4
+            512: 2,6
+            515: 3,5
+            519: 4,3
+            523: 4,4
+            527: 7,2
+            530: 8,0
+            533: 5,-4
+            588: 7,2
+            599: 3,5
+            602: 4,4
+            606: 4,3
+            612: 5,-4
+            624: 8,0
+            630: 2,6
+            636: 2,6
+            639: 3,5
+            643: 4,3
+            647: 4,4
+            651: 7,2
+            654: 8,0
+            657: 5,-4
+            690: 2,6
+            693: 3,5
+            697: 4,3
+            701: 4,4
+            705: 7,2
+            708: 8,0
+            711: 5,-4
+            753: 8,-3
         - node:
             color: '#FFFFFFFF'
             id: TechE
           decals:
-            89: 0,-3
-            90: 0,-2
-            91: 0,-1
-            100: 1,1
+            77: 0,-3
+            78: 0,-2
+            79: 0,-1
+            88: 1,1
         - node:
             color: '#FFFFFFFF'
             id: TechN
           decals:
-            98: 1,0
-            99: 2,0
+            86: 1,0
+            87: 2,0
         - node:
             color: '#FFFFFFFF'
             id: TechNW
           decals:
-            95: 0,0
+            83: 0,0
         - node:
             color: '#FFFFFFFF'
             id: TechS
           decals:
-            96: 1,0
-            97: 2,0
-            102: -1,-1
+            84: 1,0
+            85: 2,0
+            90: -1,-1
         - node:
             color: '#FFFFFFFF'
             id: TechW
           decals:
-            92: 0,-3
-            93: 0,-2
-            94: 0,-1
-            101: 1,1
+            80: 0,-3
+            81: 0,-2
+            82: 0,-1
+            89: 1,1
         - node:
             color: '#EFB34196'
             id: WarnLineE
           decals:
-            697: 3,0
-            698: -2,-1
-            719: -3,2
-            720: -5,2
-            721: 4,2
-            722: 6,2
+            573: 3,0
+            574: -2,-1
+            590: -3,2
+            591: -5,2
+            592: 4,2
+            593: 6,2
         - node:
             color: '#EFB34196'
             id: WarnLineN
           decals:
-            696: 1,2
-            739: 0,-4
+            572: 1,2
+            610: 0,-4
         - node:
             color: '#EFB34196'
             id: WarnLineS
           decals:
-            699: 3,0
-            700: -2,-1
-            723: 6,2
-            724: 4,2
-            725: -3,2
-            726: -5,2
+            575: 3,0
+            576: -2,-1
+            594: 6,2
+            595: 4,2
+            596: -3,2
+            597: -5,2
         - node:
             color: '#EFB34196'
             id: WarnLineW
           decals:
-            695: 1,2
-            738: 0,-4
+            571: 1,2
+            609: 0,-4
     - type: GridAtmosphere
       version: 2
       data:
@@ -864,8 +988,8 @@ entities:
           2,0:
             2: 1
           2,-1:
-            1: 4608
-            2: 32
+            1: 4352
+            2: 16
           -1,-1:
             0: 51200
             1: 13062
@@ -874,8 +998,8 @@ entities:
             2: 33794
             1: 136
           -2,-1:
-            1: 43264
-            2: 16
+            1: 43520
+            2: 32
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -941,7 +1065,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 233
+      - 237
     - type: Physics
       canCollide: False
   - uid: 3
@@ -952,7 +1076,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 233
+      - 237
     - type: Physics
       canCollide: False
   - uid: 4
@@ -963,7 +1087,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 233
+      - 237
     - type: Physics
       canCollide: False
   - uid: 5
@@ -974,7 +1098,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 233
+      - 237
     - type: Physics
       canCollide: False
 - proto: AirAlarm
@@ -986,8 +1110,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 262
-      - 259
+      - 266
+      - 263
   - uid: 7
     components:
     - type: Transform
@@ -995,8 +1119,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 261
-      - 263
+      - 265
+      - 267
 - proto: AirCanister
   entities:
   - uid: 8
@@ -1031,7 +1155,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -333.89612
+      secondsUntilStateChange: -1033.1837
       state: Opening
   - uid: 12
     components:
@@ -1043,7 +1167,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -334.79614
+      secondsUntilStateChange: -1034.0837
       state: Opening
 - proto: AtmosDeviceFanTiny
   entities:
@@ -1325,95 +1449,95 @@ entities:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 372
+  - uid: 69
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      pos: -6.5,-1.5
       parent: 1
-  - uid: 373
+  - uid: 307
     components:
     - type: Transform
-      pos: -7.5,-2.5
+      pos: -6.5,-2.5
       parent: 1
-  - uid: 374
+  - uid: 347
     components:
     - type: Transform
-      pos: 9.5,-2.5
+      pos: 8.5,-2.5
       parent: 1
-  - uid: 375
+  - uid: 348
     components:
     - type: Transform
-      pos: 9.5,-1.5
+      pos: 8.5,-1.5
       parent: 1
 - proto: BarricadeBlock
   entities:
-  - uid: 68
+  - uid: 72
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
 - proto: BaseAPC
   entities:
-  - uid: 69
+  - uid: 73
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 70
+  - uid: 74
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 71
+  - uid: 75
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 72
+  - uid: 76
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 73
+  - uid: 77
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 293
-  - uid: 74
+      - 297
+  - uid: 78
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 293
-  - uid: 75
+      - 297
+  - uid: 79
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 292
-  - uid: 76
+      - 296
+  - uid: 80
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 292
+      - 296
 - proto: BoriaticGeneratorHerculesShuttle
   entities:
-  - uid: 77
+  - uid: 81
     components:
     - type: Transform
       pos: 4.5,-1.5
@@ -1424,403 +1548,523 @@ entities:
       bodyType: Static
 - proto: BoxMRE
   entities:
-  - uid: 79
+  - uid: 83
     components:
     - type: Transform
-      parent: 78
+      parent: 82
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 82
+  - uid: 86
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 83
+  - uid: 87
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 84
+  - uid: 68
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: 7.5,-2.5
       parent: 1
-  - uid: 85
+  - uid: 70
     components:
     - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
+      pos: -5.5,-2.5
       parent: 1
   - uid: 88
     components:
     - type: Transform
-      pos: 1.5,-2.5
+      pos: -2.5,-2.5
       parent: 1
   - uid: 89
     components:
     - type: Transform
-      pos: 4.5,-3.5
+      pos: 6.5,1.5
       parent: 1
   - uid: 90
     components:
     - type: Transform
-      pos: 3.5,-3.5
+      pos: 5.5,1.5
       parent: 1
   - uid: 91
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: 1.5,-3.5
       parent: 1
   - uid: 92
     components:
     - type: Transform
-      pos: 1.5,-3.5
+      pos: 1.5,-2.5
       parent: 1
   - uid: 93
     components:
     - type: Transform
-      pos: 0.5,-3.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 94
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: 3.5,-3.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 96
     components:
     - type: Transform
-      pos: -2.5,-3.5
+      pos: 1.5,-3.5
       parent: 1
   - uid: 97
     components:
     - type: Transform
-      pos: -4.5,1.5
+      pos: 0.5,-3.5
       parent: 1
   - uid: 98
     components:
     - type: Transform
-      pos: 4.5,-0.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 99
     components:
     - type: Transform
-      pos: 8.5,-0.5
+      pos: -1.5,-3.5
       parent: 1
   - uid: 100
     components:
     - type: Transform
-      pos: 5.5,-0.5
+      pos: -2.5,-3.5
       parent: 1
   - uid: 101
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: -4.5,1.5
       parent: 1
   - uid: 102
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: 4.5,-0.5
       parent: 1
   - uid: 103
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: 8.5,-0.5
       parent: 1
   - uid: 104
     components:
     - type: Transform
-      pos: -6.5,-2.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 105
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 106
     components:
     - type: Transform
-      pos: 1.5,2.5
+      pos: -1.5,-0.5
       parent: 1
   - uid: 107
     components:
     - type: Transform
-      pos: 7.5,-0.5
+      pos: -2.5,-0.5
       parent: 1
   - uid: 108
     components:
     - type: Transform
-      pos: 0.5,-0.5
+      pos: -6.5,-2.5
       parent: 1
   - uid: 109
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 110
     components:
     - type: Transform
-      pos: -0.5,-1.5
+      pos: 1.5,2.5
       parent: 1
   - uid: 111
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 7.5,-0.5
       parent: 1
   - uid: 112
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 113
     components:
     - type: Transform
-      pos: 1.5,6.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 114
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: -0.5,-1.5
       parent: 1
   - uid: 115
     components:
     - type: Transform
-      pos: 1.5,-2.5
+      pos: 2.5,0.5
       parent: 1
   - uid: 116
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: 1.5,4.5
       parent: 1
   - uid: 117
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: 1.5,6.5
       parent: 1
   - uid: 118
     components:
     - type: Transform
-      pos: 8.5,-1.5
+      pos: 1.5,-1.5
       parent: 1
   - uid: 119
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: 1.5,-2.5
       parent: 1
   - uid: 120
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 121
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: 6.5,2.5
       parent: 1
   - uid: 122
     components:
     - type: Transform
-      pos: -3.5,0.5
+      pos: 8.5,-1.5
       parent: 1
   - uid: 123
     components:
     - type: Transform
-      pos: 0.5,2.5
+      pos: -1.5,-2.5
       parent: 1
   - uid: 124
     components:
     - type: Transform
-      pos: 4.5,0.5
+      pos: 4.5,-1.5
       parent: 1
   - uid: 125
     components:
     - type: Transform
-      pos: -2.5,2.5
+      pos: -0.5,-2.5
       parent: 1
   - uid: 126
     components:
     - type: Transform
-      pos: -2.5,1.5
+      pos: -3.5,0.5
       parent: 1
   - uid: 127
     components:
     - type: Transform
-      pos: 1.5,-0.5
+      pos: 0.5,2.5
       parent: 1
   - uid: 128
     components:
     - type: Transform
-      pos: -3.5,1.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 129
     components:
     - type: Transform
-      pos: -6.5,-0.5
+      pos: -2.5,2.5
       parent: 1
   - uid: 130
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      pos: -2.5,1.5
       parent: 1
   - uid: 131
     components:
     - type: Transform
-      pos: 8.5,-2.5
+      pos: 1.5,-0.5
       parent: 1
   - uid: 132
     components:
     - type: Transform
-      pos: 6.5,-0.5
+      pos: -3.5,1.5
       parent: 1
   - uid: 133
     components:
     - type: Transform
-      pos: -4.5,2.5
+      pos: -6.5,-0.5
       parent: 1
   - uid: 134
     components:
     - type: Transform
-      pos: 1.5,1.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 135
     components:
     - type: Transform
-      pos: 3.5,-3.5
+      pos: 8.5,-2.5
       parent: 1
   - uid: 136
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: 6.5,-0.5
       parent: 1
   - uid: 137
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: -4.5,2.5
       parent: 1
   - uid: 138
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: 1.5,1.5
       parent: 1
   - uid: 139
     components:
     - type: Transform
-      pos: 4.5,1.5
+      pos: 3.5,-3.5
       parent: 1
   - uid: 140
     components:
     - type: Transform
-      pos: 1.5,5.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 141
     components:
     - type: Transform
-      pos: 5.5,0.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 142
     components:
     - type: Transform
-      pos: -4.5,-0.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 143
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 144
     components:
     - type: Transform
-      pos: 0.5,6.5
+      pos: 1.5,5.5
       parent: 1
   - uid: 145
     components:
     - type: Transform
-      pos: 4.5,-3.5
+      pos: 5.5,0.5
       parent: 1
   - uid: 146
     components:
     - type: Transform
-      pos: 4.5,-2.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 147
     components:
     - type: Transform
-      pos: 4.5,2.5
+      pos: -5.5,-0.5
       parent: 1
-- proto: CableHV
-  entities:
   - uid: 148
     components:
     - type: Transform
-      pos: 0.5,-0.5
+      pos: 0.5,6.5
       parent: 1
   - uid: 149
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 150
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 4.5,-2.5
       parent: 1
   - uid: 151
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: 4.5,2.5
       parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+- proto: CableHV
+  entities:
   - uid: 152
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 153
     components:
     - type: Transform
-      pos: 4.5,-0.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 154
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 2.5,0.5
       parent: 1
   - uid: 155
     components:
     - type: Transform
-      pos: 1.5,1.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 156
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: -0.5,3.5
       parent: 1
   - uid: 157
     components:
     - type: Transform
-      pos: 4.5,0.5
+      pos: 4.5,-0.5
       parent: 1
   - uid: 158
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: 4.5,-1.5
       parent: 1
   - uid: 159
     components:
@@ -1830,341 +2074,361 @@ entities:
   - uid: 160
     components:
     - type: Transform
-      pos: 1.5,2.5
+      pos: 0.5,3.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: 1.5,1.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: 1.5,2.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
-      pos: -2.5,-1.5
+      pos: 0.5,0.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
-      pos: -0.5,-1.5
+      pos: -1.5,-0.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
-      pos: 2.5,-1.5
+      pos: -2.5,-0.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: -2.5,-1.5
       parent: 1
   - uid: 171
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 175
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 172
+  - uid: 176
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 173
+  - uid: 177
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 174
+  - uid: 178
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 175
+  - uid: 179
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 176
+  - uid: 180
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 177
+  - uid: 181
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 178
+  - uid: 182
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 179
+  - uid: 183
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 180
+  - uid: 184
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 181
+  - uid: 185
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 182
+  - uid: 186
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 183
+  - uid: 187
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 184
+  - uid: 188
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 185
+  - uid: 189
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 186
+  - uid: 190
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 189
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 190
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
   - uid: 191
     components:
     - type: Transform
-      pos: 1.5,-0.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 192
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: 1.5,2.5
       parent: 1
   - uid: 193
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: 2.5,-1.5
       parent: 1
   - uid: 194
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: 2.5,0.5
       parent: 1
   - uid: 195
     components:
     - type: Transform
-      pos: 0.5,2.5
+      pos: 1.5,-0.5
       parent: 1
   - uid: 196
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: 0.5,3.5
       parent: 1
   - uid: 197
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 198
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 199
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: 0.5,2.5
       parent: 1
   - uid: 200
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 201
     components:
     - type: Transform
-      pos: -2.5,-1.5
+      pos: -0.5,3.5
       parent: 1
-- proto: CardHandBase
-  entities:
   - uid: 202
     components:
     - type: Transform
-      pos: 6.5085692,-1.3131516
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+- proto: CardDeckSyndicate
+  entities:
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 2.4473362,-1.3242924
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 203
+  - uid: 207
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 204
+  - uid: 208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 205
+  - uid: 209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 206
+  - uid: 210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 207
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,0.5
-      parent: 1
-  - uid: 208
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
-  - uid: 209
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 1
-  - uid: 210
-    components:
-    - type: Transform
-      pos: 4.5,-3.5
-      parent: 1
-  - uid: 211
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
       parent: 1
   - uid: 212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
+      pos: -2.5,-3.5
       parent: 1
   - uid: 213
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,0.5
+      pos: -1.5,-3.5
       parent: 1
   - uid: 214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 215
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,0.5
+      pos: 3.5,-3.5
       parent: 1
   - uid: 216
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,0.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,4.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-0.5
+      pos: 0.5,0.5
       parent: 1
   - uid: 219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
       parent: 1
   - uid: 220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-1.5
+      pos: 2.5,0.5
       parent: 1
   - uid: 221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 222
+  - uid: 226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 1
-  - uid: 223
+  - uid: 227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2172,33 +2436,28 @@ entities:
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 224
+  - uid: 228
     components:
     - type: Transform
-      pos: 6.5424137,-0.43815154
-      parent: 1
-  - uid: 225
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5736637,-1.3444016
+      rot: -1.5707963267948966 rad
+      pos: 2.6192112,-0.46491748
       parent: 1
 - proto: CigaretteSpent
   entities:
-  - uid: 226
+  - uid: 230
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.2364664,4.296259
       parent: 1
-  - uid: 227
+  - uid: 231
     components:
     - type: Transform
       pos: 2.3927164,4.108759
       parent: 1
 - proto: ClosetWall
   entities:
-  - uid: 78
+  - uid: 82
     components:
     - type: Transform
       pos: 0.5,5.5
@@ -2209,10 +2468,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 81
-          - 79
-          - 80
-  - uid: 228
+          - 84
+          - 83
+          - 85
+  - uid: 232
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2224,25 +2483,34 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 230
-          - 229
+          - 233
+          - 234
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 231
+  - uid: 235
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
+- proto: ClothingOuterHardsuitSpatio
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      parent: 302
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: ComputerFrame
   entities:
-  - uid: 232
+  - uid: 236
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
 - proto: ComputerTabletopShuttle
   entities:
-  - uid: 233
+  - uid: 237
     components:
     - type: Transform
       pos: -0.5,1.5
@@ -2290,23 +2558,30 @@ entities:
       - Toggle Hardpoints
       - Fire Hardpoints
       - Module E
+- proto: DrinkBeerBottleFull
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 2.8535862,-1.1055424
+      parent: 1
 - proto: DrinkHotCoffee
   entities:
-  - uid: 234
+  - uid: 238
     components:
     - type: Transform
       pos: 2.6895914,4.186884
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 235
+  - uid: 239
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 236
+  - uid: 240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2314,7 +2589,7 @@ entities:
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 237
+  - uid: 241
     components:
     - type: Transform
       pos: -2.5,3.5
@@ -2323,14 +2598,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 238
+  - uid: 242
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 239
+  - uid: 243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2338,7 +2613,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 240
+  - uid: 244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2346,7 +2621,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 241
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2354,7 +2629,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 242
+  - uid: 246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2364,7 +2639,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraight
   entities:
-  - uid: 243
+  - uid: 247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2372,7 +2647,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 244
+  - uid: 248
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2380,7 +2655,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 245
+  - uid: 249
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2388,7 +2663,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 246
+  - uid: 250
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2396,7 +2671,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 247
+  - uid: 251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2404,21 +2679,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 248
+  - uid: 252
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 249
+  - uid: 253
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 250
+  - uid: 254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2426,7 +2701,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 251
+  - uid: 255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2434,7 +2709,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 252
+  - uid: 256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2442,7 +2717,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 253
+  - uid: 257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2452,7 +2727,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 254
+  - uid: 258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2460,14 +2735,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 255
+  - uid: 259
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 256
+  - uid: 260
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2477,7 +2752,7 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 257
+  - uid: 261
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2487,7 +2762,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPressurePump
   entities:
-  - uid: 258
+  - uid: 262
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2497,7 +2772,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentPump
   entities:
-  - uid: 259
+  - uid: 263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2508,7 +2783,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 260
+  - uid: 264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2516,7 +2791,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 261
+  - uid: 265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2529,7 +2804,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 262
+  - uid: 266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2540,7 +2815,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 263
+  - uid: 267
     components:
     - type: Transform
       pos: 0.5,3.5
@@ -2552,61 +2827,88 @@ entities:
       color: '#990000FF'
 - proto: Girder
   entities:
-  - uid: 264
+  - uid: 268
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 265
+  - uid: 269
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 266
+  - uid: 270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-- proto: JugBoriaticFuel
+- proto: HandheldGPSBasic
   entities:
-  - uid: 229
+  - uid: 306
     components:
     - type: Transform
-      parent: 228
+      parent: 302
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 230
+- proto: HandHeldMassScanner
+  entities:
+  - uid: 305
     components:
     - type: Transform
-      parent: 228
+      parent: 302
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: JetpackMiniFilled
+  entities:
+  - uid: 303
+    components:
+    - type: Transform
+      parent: 302
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: JugBoriaticFuel
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      parent: 232
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 234
+    components:
+    - type: Transform
+      parent: 232
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: MachineFrameDestroyed
   entities:
-  - uid: 267
+  - uid: 271
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
 - proto: MedkitFilled
   entities:
-  - uid: 80
+  - uid: 84
     components:
     - type: Transform
-      parent: 78
+      parent: 82
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: N14ChairMetalFolding
   entities:
-  - uid: 268
+  - uid: 272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2614,14 +2916,14 @@ entities:
       parent: 1
 - proto: N14GasPipeBend
   entities:
-  - uid: 269
+  - uid: 273
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 270
+  - uid: 274
     components:
     - type: Transform
       pos: 1.5,4.5
@@ -2630,7 +2932,7 @@ entities:
       color: '#0055CCFF'
 - proto: N14GasPipeStraight
   entities:
-  - uid: 271
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2638,7 +2940,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 272
+  - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2646,7 +2948,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 273
+  - uid: 277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2656,7 +2958,7 @@ entities:
       color: '#990000FF'
 - proto: N14GasPipeTJunction
   entities:
-  - uid: 274
+  - uid: 278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2664,7 +2966,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 275
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2672,7 +2974,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 276
+  - uid: 280
     components:
     - type: Transform
       pos: -0.5,1.5
@@ -2681,7 +2983,7 @@ entities:
       color: '#990000FF'
 - proto: N14TableDeskMetalSmall
   entities:
-  - uid: 277
+  - uid: 281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2689,7 +2991,7 @@ entities:
       parent: 1
 - proto: N14TableMetalWide
   entities:
-  - uid: 278
+  - uid: 282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2697,146 +2999,214 @@ entities:
       parent: 1
 - proto: N14TableWoodCabledrum
   entities:
-  - uid: 279
+  - uid: 283
     components:
     - type: Transform
-      pos: 6.5,-1.5
+      pos: 2.5,-1.5
       parent: 1
 - proto: NFAshtray
   entities:
-  - uid: 280
+  - uid: 284
     components:
     - type: Transform
       pos: 2.3614664,4.202509
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 281
+  - uid: 285
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: PlushieGnome
   entities:
-  - uid: 81
+  - uid: 85
     components:
     - type: Transform
-      parent: 78
+      parent: 82
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: PoweredlightSodium
   entities:
-  - uid: 282
+  - uid: 286
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-- proto: PoweredSmallLightMaintenance
+- proto: PoweredSmallLight
   entities:
-  - uid: 283
+  - uid: 287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
 - proto: PoweredSmallLightMaintenanceRed
   entities:
-  - uid: 284
+  - uid: 288
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 285
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,0.5
-      parent: 1
 - proto: Rack
   entities:
-  - uid: 286
+  - uid: 290
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 287
+  - uid: 291
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
+- proto: Railing
+  entities:
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
 - proto: SheetSteel1
   entities:
-  - uid: 288
+  - uid: 292
     components:
     - type: Transform
       pos: -3.231958,-0.52505654
       parent: 1
-  - uid: 289
+  - uid: 293
     components:
     - type: Transform
       pos: -3.681958,-0.8625565
       parent: 1
 - proto: ShuttleGunTorpedo
   entities:
-  - uid: 290
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
-      parent: 1
-    - type: Battery
-      startingCharge: 14547.434
-    - type: ApcPowerReceiverBattery
-      enabled: True
-  - uid: 291
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,1.5
       parent: 1
     - type: Battery
-      startingCharge: 14553.946
+      startingCharge: 16603.652
+    - type: ApcPowerReceiverBattery
+      enabled: True
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: Battery
+      startingCharge: 16596.846
     - type: ApcPowerReceiverBattery
       enabled: True
 - proto: SignalButton
   entities:
-  - uid: 292
+  - uid: 296
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        76:
+        80:
         - - Pressed
           - Toggle
-        75:
+        79:
         - - Pressed
           - Toggle
-  - uid: 293
+  - uid: 297
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        73:
+        77:
         - - Pressed
           - Toggle
-        74:
+        78:
         - - Pressed
           - Toggle
 - proto: SignEVA
   entities:
-  - uid: 294
+  - uid: 298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 295
+  - uid: 299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2844,56 +3214,60 @@ entities:
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 296
+  - uid: 300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 297
+  - uid: 301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-- proto: SuitStoragePilot
+- proto: SuitStorageBase
   entities:
-  - uid: 298
+  - uid: 302
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 303
+          - 304
+          - 305
+          - 306
 - proto: Thruster
   entities:
-  - uid: 299
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-  - uid: 300
+  - uid: 71
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,-1.5
+      pos: 8.5,-1.5
       parent: 1
-  - uid: 301
+  - uid: 309
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 302
+  - uid: 310
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 303
+  - uid: 311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 304
+  - uid: 312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2901,7 +3275,7 @@ entities:
       parent: 1
     - type: Thruster
       enabled: False
-  - uid: 305
+  - uid: 313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2909,304 +3283,288 @@ entities:
       parent: 1
     - type: Thruster
       enabled: False
-  - uid: 306
+  - uid: 314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 307
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 1
-  - uid: 308
+  - uid: 316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 309
+  - uid: 317
     components:
     - type: Transform
       pos: 2.5020914,4.827509
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 310
+  - uid: 318
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 311
+  - uid: 319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 312
+  - uid: 320
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 313
+  - uid: 321
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 314
+  - uid: 322
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 315
+  - uid: 323
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 316
+  - uid: 324
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 317
+  - uid: 325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 318
+  - uid: 326
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 319
+  - uid: 327
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 320
+  - uid: 328
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 321
+  - uid: 329
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 322
+  - uid: 330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 323
+  - uid: 331
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 324
+  - uid: 332
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 325
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 326
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-  - uid: 327
-    components:
-    - type: Transform
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 328
-    components:
-    - type: Transform
-      pos: 7.5,1.5
-      parent: 1
-  - uid: 329
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 330
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-2.5
-      parent: 1
-  - uid: 331
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 332
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 1
   - uid: 333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-2.5
+      pos: -1.5,3.5
       parent: 1
   - uid: 334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-2.5
+      pos: 3.5,-0.5
       parent: 1
   - uid: 335
     components:
     - type: Transform
-      pos: 5.5,2.5
+      pos: 3.5,3.5
       parent: 1
   - uid: 336
     components:
     - type: Transform
-      pos: 1.5,5.5
+      pos: 7.5,1.5
       parent: 1
   - uid: 337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 7.5,0.5
+      pos: -3.5,-2.5
       parent: 1
   - uid: 338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 7.5,-0.5
+      pos: 5.5,-2.5
       parent: 1
   - uid: 339
     components:
     - type: Transform
-      pos: 8.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
       parent: 1
   - uid: 340
     components:
     - type: Transform
-      pos: 8.5,-2.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
       parent: 1
   - uid: 341
     components:
     - type: Transform
-      pos: -1.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
       parent: 1
   - uid: 342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,5.5
+      pos: 3.5,-2.5
       parent: 1
   - uid: 343
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,4.5
+      pos: 5.5,2.5
       parent: 1
   - uid: 344
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,5.5
+      pos: 1.5,5.5
       parent: 1
   - uid: 345
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-3.5
+      pos: 7.5,0.5
       parent: 1
   - uid: 346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 347
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 348
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
+      pos: 7.5,-0.5
       parent: 1
   - uid: 349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,0.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,-0.5
+      pos: -0.5,5.5
       parent: 1
   - uid: 351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
+      pos: -1.5,4.5
       parent: 1
   - uid: 352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -6.5,-2.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 353
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,2.5
+      pos: 1.5,-3.5
       parent: 1
   - uid: 356
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,-2.5
+      pos: -2.5,-2.5
       parent: 1
   - uid: 357
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-2.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3214,57 +3572,57 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonalCurved
   entities:
-  - uid: 359
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-2.5
-      parent: 1
   - uid: 360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,-2.5
+      pos: -6.5,-2.5
       parent: 1
-  - uid: 361
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 369
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 362
+  - uid: 370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 363
+  - uid: 371
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 364
+  - uid: 372
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 365
+  - uid: 373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 1
-  - uid: 366
+  - uid: 374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 367
+  - uid: 375
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 368
+  - uid: 376
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3272,21 +3630,21 @@ entities:
       parent: 1
 - proto: WallSolidDiagonalSoutheastCurved
   entities:
-  - uid: 369
+  - uid: 377
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
 - proto: WallSolidDiagonalSouthwestCurved
   entities:
-  - uid: 370
+  - uid: 378
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
 - proto: WarpPointShip
   entities:
-  - uid: 371
+  - uid: 379
     components:
     - type: Transform
       pos: 0.5,-0.5


### PR DESCRIPTION

<img width="891" height="713" alt="kite MKII update" src="https://github.com/user-attachments/assets/6d15b0a2-df79-4953-8188-ae1eded71381" />
<img width="481" height="349" alt="kite MKII update suit storage" src="https://github.com/user-attachments/assets/5966f82a-f0ea-4784-85d1-7d9e96af5eff" />

Updated the Kite MKII's wings to be less annoying, it bugged me how its just jutting out for no good reason. 
Updated the interiors so the larp card table is actually inside a sealed area. 
The larp area is turned into the new cargo area, with railings to help control the spill of trade goods so it doesnt block reloads. 

replaced the pilot hardsuit with a kriti hardsuit. 

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked Kite MKII's wing + interior a little bit. Replaced the pilot hardsuit with kriti one. 

