### PR TITLE
tradegoods-fixes&changes

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/space_cash.yml
@@ -4,33 +4,33 @@
   suffix: 1500
   components:
   - type: Icon
-    sprite: Objects/Economy/cash.rsi 
-    state: cash_1000 
+    sprite: Objects/Economy/cash.rsi
+    state: cash_1000
   - type: Stack
     count: 1500
-    
+
 - type: entity
   parent: SpaceCash
   id: SpaceCash3500
   suffix: 3500
   components:
   - type: Icon
-    sprite: Objects/Economy/cash.rsi 
+    sprite: Objects/Economy/cash.rsi
     state: cash_1000
   - type: Stack
     count: 3500
-    
+
 - type: entity
   parent: SpaceCash
   id: SpaceCash4500
   suffix: 4500
   components:
   - type: Icon
-    sprite: Objects/Economy/cash.rsi 
+    sprite: Objects/Economy/cash.rsi
     state: cash_1000
   - type: Stack
     count: 4500
-    
+
 - type: entity
   parent: SpaceCash
   id: SpaceCash6000
@@ -38,6 +38,17 @@
   components:
   - type: Icon
     sprite: Objects/Economy/cash.rsi
-    state: cash_5000 
+    state: cash_5000
   - type: Stack
     count: 6000
+
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash7500
+  suffix: 7500
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi
+    state: cash_5000
+  - type: Stack
+    count: 7500

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/trade.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/trade.yml
@@ -544,6 +544,17 @@
 
 - type: entity
   parent: BaseItem
+  id: TradeDeedUnique
+  name: deed of delivery
+  description: A printed deed of delivery. Blocky letting informs that this deed is worth seven thousand five hundred Union credits to an official chartered station.
+  components:
+  - type: Sprite
+    sprite: _Crescent/Objects/TradeGoods/deed.rsi
+    layers:
+    - state: icon
+
+- type: entity
+  parent: BaseItem
   id: TradeDeedExotic
   name: deed of delivery
   description: A printed deed of delivery. Blocky letting informs that this deed is worth ten thousand Union credits to an official chartered station.

--- a/Resources/Prototypes/_Crescent/Entities/Structures/dispensers.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/dispensers.yml
@@ -78,6 +78,7 @@
       TradeDeedNormal: SpaceCash3500
       TradeDeedHigh: SpaceCash4500
       TradeDeedVeryHigh: SpaceCash6000
+      TradeDeedUnique: SpaceCash7500
       TradeDeedExotic: SpaceCash10000
   - type: Sprite
     sprite: _Crescent/Structures/deedsmachine.rsi
@@ -109,12 +110,12 @@
       TradeGoodCybernetics: TradeDeedLow
       TradeGoodGunparts: TradeDeedHigh
       TradeGoodRice: TradeDeedNormal
-      TradeGoodWine: TradeDeedHigh
+      TradeGoodWine: TradeDeedUnique
       TradeGoodAlloys: TradeDeedExotic
       TradeGoodMiltech: TradeDeedNormal
       TradeGoodFabrics: TradeDeedVeryHigh
       TradeGoodPlasma: TradeDeedVeryHigh
-      TradeGoodGoodScrap: TradeDeedExotic
+      TradeGoodGoodScrap: TradeDeedUnique
   - type: Sprite
     sprite: _Crescent/Structures/cargochute.rsi
     layers:
@@ -147,7 +148,7 @@
       TradeGoodFabrics: TradeDeedVeryHigh
       TradeGoodMiltech: TradeDeedNormal
       TradeGoodAlloys: TradeDeedExotic
-      TradeGoodWine: TradeDeedHigh
+      TradeGoodWine: TradeDeedUnique
   - type: Sprite
     sprite: _Crescent/Structures/cargochute.rsi
     layers:
@@ -324,7 +325,7 @@
       TradeGoodSugar: TradeDeedLow
       TradeGoodMiltech: TradeDeedNormal
       TradeGoodAlloys: TradeDeedExotic
-      TradeGoodGoodScrap: TradeDeedExotic
+      TradeGoodGoodScrap: TradeDeedUnique
       TradeGoodPlasma: TradeDeedVeryHigh
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedHigh
@@ -361,7 +362,7 @@
       TradeGoodSugar: TradeDeedLow
       TradeGoodGoodScrap: TradeDeedHigh
       TradeGoodPlasma: TradeDeedExotic
-      TradeGoodWine: TradeDeedHigh
+      TradeGoodWine: TradeDeedUnique
       TradeGoodFabrics: TradeDeedVeryHigh
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedHigh
@@ -398,7 +399,7 @@
       TradeGoodAlloys: TradeDeedExotic
       TradeGoodGoodScrap: TradeDeedVeryHigh
       TradeGoodPlasma: TradeDeedExotic
-      TradeGoodWine: TradeDeedHigh
+      TradeGoodWine: TradeDeedUnique
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedHigh
       TradeGoodOldParts: TradeDeedHigh
@@ -434,7 +435,7 @@
       TradeGoodMiltech: TradeDeedExotic
       TradeGoodAlloys: TradeDeedVeryHigh
       TradeGoodPlasma: TradeDeedHigh
-      TradeGoodWine: TradeDeedHigh
+      TradeGoodWine: TradeDeedUnique
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedExotic
       TradeGoodOldParts: TradeDeedHigh
@@ -469,8 +470,7 @@
       TradeGoodDrugs: TradeDeedHigh
       TradeGoodFabrics: TradeDeedVeryHigh
       TradeGoodMiltech: TradeDeedNormal
-      TradeGoodAlloys: TradeDeedExotic
-      TradeGoodWine: TradeDeedNormal
+      TradeGoodWine: TradeDeedUnique
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedHigh
       TradeGoodOldParts: TradeDeedHigh
@@ -501,9 +501,9 @@
       TradeGoodAntibiotics: TradeDeedLow
       TradeGoodFlour: TradeDeedLow
       TradeGoodSugar: TradeDeedLow
-      TradeGoodGoodScrap: TradeDeedExotic
+      TradeGoodGoodScrap: TradeDeedUnique
       TradeGoodFabrics: TradeDeedVeryHigh
-      TradeGoodWine: TradeDeedHigh
+      TradeGoodWine: TradeDeedUnique
       TradeGoodPlasma: TradeDeedVeryHigh
       TradeGoodNanoTrasen: TradeDeedHigh
       TradeGoodOldCyber: TradeDeedHigh


### PR DESCRIPTION
this pr aims to balance and fix post rebase issues with the tradegood system

changelog:
-adds a new type of tradegoods - unique (cost is 7500 per crate)
-gives this tradegood type to secured scrap (goodgoodscrap) and taypani wine (goodwine) on every cargo chute type
-removes unintended money glitch where saws could turn in their tradegoods on dochenskaya for 10k 


https://github.com/user-attachments/assets/2c81be8f-f1db-47f7-b13d-3d22250b9e39

