### PR TITLE
CSA - 240 Anti Personnel Turret 

### DIFF
--- a/Resources/Locale/en-US/_Crescent/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Crescent/access/accesses.ftl
@@ -9,14 +9,14 @@ id-card-access-level-ncwljail = Homeguard Cells
 
 # syndicate
 
-id-card-access-level-syndicatebasic = Privateer
+id-card-access-level-syndicatebasic = Syndicate
 id-card-access-level-syndicatecommand = Syndicate Command
-id-card-access-level-syndicategorlex = Gorlex Security Consulting
-id-card-access-level-syndicateinterdyne = Interdyne Pharmaceutics
-id-card-access-level-syndicatesaws = Shipfitters and Astronautics Workers Union
-id-card-access-level-syndicateramzi = Halflight Media
-id-card-access-level-syndicateringleader = Privateer Ringleader
-id-card-access-level-syndicatearmory = Privateers' Armory
+id-card-access-level-syndicategorlex = GSC
+id-card-access-level-syndicateinterdyne = Interdyne
+id-card-access-level-syndicatesaws = SAW
+id-card-access-level-syndicateramzi = Cybersun
+id-card-access-level-syndicateringleader = Ringleader
+id-card-access-level-syndicatearmory = Syndicate Armory
 
 # empire
 

--- a/Resources/Prototypes/Access/syndicate.yml
+++ b/Resources/Prototypes/Access/syndicate.yml
@@ -5,3 +5,14 @@
 - type: accessLevel
   id: SyndicateAgent
   name: id-card-access-level-syndicate-agent
+
+
+- type: accessGroup
+  id: Syndicate
+  tags:
+  - SyndicateBasic
+  - SyndicateInterdyne
+  - SyndicateGorlex
+  - SyndicateRamzi
+  - SyndicateCommand
+  - SyndicateSaws

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets/turrets_energy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets/turrets_energy.yml
@@ -173,3 +173,25 @@
   - type: DeviceNetwork
     receiveFrequencyId: TurretControlAI
     transmitFrequencyId: TurretAI
+
+- type: entity
+  parent: WeaponEnergyTurretStation
+  id: CSA-240APT
+  name: CSA - 240 Energy Antipersonnel Turret
+  description: A high-tech autonomous weapons.
+  components:
+  - type: AccessReader
+    access: [["SyndicateRamzi"], ["SyndicateCommand"]]
+  - type: TurretTargetSettings
+    exemptAccessLevels:
+    - SyndicateBasic
+    - SyndicateInterdyne
+    - SyndicateGorlex
+    - SyndicateRamzi
+    - SyndicateCommand
+    - SyndicateSaws
+  - type: Machine
+    board: WeaponEnergyTurretAIMachineCircuitboard
+  - type: DeviceNetwork
+    receiveFrequencyId: TurretControlAI
+    transmitFrequencyId: TurretAI

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -212,3 +212,32 @@
   - type: ContainerFill
     containers:
       board: [ WeaponEnergyTurretAIControlPanelElectronics ]
+
+- type: entity
+  parent: WeaponEnergyTurretStationControlPanel
+  id: WeaponCSAEnergyTurretControlPanel
+  name: CSA - 240 turret control panel
+  description: A wall-mounted interface that allows a local artifical intelligence to adjust the operational parameters of linked sentry turrets.
+  components:
+  - type: AccessReader
+    access: [["SyndicateRamzi"], ["SyndicateCommand"]]
+  - type: TurretTargetSettings
+    exemptAccessLevels:
+    - SyndicateRamzi
+    - SyndicateCommand
+  - type: DeployableTurretController
+    accessGroups:
+      - Syndicate
+    accessLevels:
+    - SyndicateBasic
+    - SyndicateInterdyne
+    - SyndicateGorlex
+    - SyndicateRamzi
+    - SyndicateCommand
+    - SyndicateSaws
+  - type: DeviceNetwork
+    receiveFrequencyId: TurretAI
+    transmitFrequencyId: TurretControlAI
+  - type: ContainerFill
+    containers:
+      board: [ WeaponEnergyTurretAIControlPanelElectronics ]


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a station anti-personnel turret that won't shoot fellow Syndicate members and follows with the high-tech theme of the faction 

It's probably weaker than the regular station PD mostly because it can be cheesed with just picking up and access card however I feel like it's more interesting this way.

Also, I changed a few of the TSFC accesses to be shorter and more descriptive. 

This is technically a player-facing change; however, this will be the only way to actually see the access because the access configurator isn't set up.

Also I added a Syndicate group 


<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="629" height="551" alt="image" src="https://github.com/user-attachments/assets/18f4d0c3-88cf-4be4-a523-96390227228a" />

<img width="453" height="149" alt="image" src="https://github.com/user-attachments/assets/0ff696fe-4692-4bd9-bab3-bc6753374eb3" />

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: CSA - 240 Anti personnel Turret .
- add: CSA - 240 Anti personnelTurret Control panel.
- tweak: TSFC Access names 