### PR TITLE
PTA ZHANSHI-X3 Rebalancing 

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/corporate.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/corporate.yml
@@ -121,14 +121,14 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 1500
+    armorMaxHealth: 850
     armorType: Ceramic
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
         Blunt: 15
         Slash: 15
-        Piercing: 60
+        Piercing: 55
         Heat: 15
         Caustic: 15
   - type: ClothingSpeedModifier


### PR DESCRIPTION
Rebalances the armor numbers of the PTA ZHANSHI-X3 hardsuit to be more in line with other hardsuits of it's tier.

Armor Durability: 1500 --> 850 
Piercing Resist: 60 --> 55

This change was supposed to happen several months ago when hardsuit armor was lowered across the board, but it was just forgotten or something since PTA armor was unobtanium. 