### PR TITLE
Tatsumoto commissary small tweaks

### DIFF
--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Shinohara/infantry-station.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Shinohara/infantry-station.yml
@@ -44,7 +44,7 @@
     sprite: _Crescent/Clothing/SHI/OuterClothing/corpsec_ua.rsi
     state: icon
   product: CrateShinoharaHardsuit
-  cost: 12500
+  cost: 10000
   category: cargoproduct-category-name-military
   group: shinoharastation
 
@@ -55,5 +55,25 @@
     state: icon
   product: CrateShinoharaC4
   cost: 15000
+  category: cargoproduct-category-name-military
+  group: shinoharastation
+
+- type: cargoProduct
+  id: VitalsTrackingShinoharaStationSuppliesShi
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateVitalsTrackingShinohara
+  cost: 500
+  category: cargoproduct-category-name-medical
+  group: shinoharastation
+
+- type: cargoProduct
+  id: ShinoharaLivestockSecDog
+  icon:
+    sprite: DeltaV/Mobs/Pets/secdog.rsi
+    state: secdog
+  product: CrateNPCSecDog
+  cost: 3500
   category: cargoproduct-category-name-military
   group: shinoharastation

--- a/Resources/Prototypes/_Crescent/Catalog/Cargo/Shinohara/shuttles-sation.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Cargo/Shinohara/shuttles-sation.yml
@@ -1,0 +1,19 @@
+- type: cargoProduct
+  id: ShuttleGunSlugthrowerShinohara
+  icon:
+    sprite: _Crescent/Objects/ShuttleWeapons/50cal.rsi
+    state: space_artillery
+  product: CrateShuttlegunSlugthrower
+  cost: 5000
+  category: cargoproduct-category-name-shuttle
+  group: shinoharastation
+
+- type: cargoProduct
+  id: ShuttleGunPlasmaRepeaterShinohara
+  icon:
+    sprite: _Crescent/Objects/ShuttleWeapons/lasersmall.rsi
+    state: lse-400c
+  product: CrateShuttlegunPlasmaRepeater
+  cost: 7500
+  category: cargoproduct-category-name-shuttle
+  group: shinoharastation


### PR DESCRIPTION
# Description

Adds shinohara vitals tracker, lower the price of the svbt-2 suit to 10k from 12500. Adds Sec dog crate to the shinohara commissary, Adds Plasma casters and Slugthrowers to the shinohara commissary at half the price.

---

# Changelog

:cl:
- tweak: Tweak Shinohara commissary
- adds: SHI related ship guns at half the price in Tatsumoto commissary 
