### PR TITLE
GSC Virago

### DIFF
--- a/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
@@ -674,7 +674,7 @@ entities:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-- proto: ComputerShuttle
+- proto: C_ComputerShuttle
   entities:
   - uid: 56
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
@@ -1,0 +1,1278 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 268.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/21/2026 20:13:32
+  entityCount: 142
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  4: Space
+  3: FloorDark
+  5: FloorHullReinforced
+  2: FloorTechMaint2
+  0: Lattice
+  1: Plating
+  6: PlatingBurnt
+  7: PlatingDamaged
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Shuttle TAN-629
+    - type: Transform
+      pos: 31.2751,-1.2613466
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAABAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAQAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAEAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAABAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAAABAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAcAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAHAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: SelfDeleteGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#DE3A3A96'
+            id: BoxGreyscale
+          decals:
+            72: 7,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            24: 2,-3
+            43: 3,0
+            44: 3,-1
+            59: 7,-1
+            60: 7,-2
+            61: 7,0
+            81: 4,-3
+            82: 8,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavyMonotile
+          decals:
+            62: 8,-2
+            74: 3,-3
+            75: 3,-3
+            83: 9,-1
+            84: 9,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            46: 4,-1
+            47: 4,-1
+            48: 4,-1
+            49: 3,-1
+            73: 3,-3
+            76: 5,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            25: 2,-3
+            26: 4,-4
+            27: 5,-4
+            28: 0,-1
+            29: 2,-1
+            30: 6,-1
+            31: 4,-2
+            32: 5,1
+            45: 4,-1
+            50: 5,-1
+            63: 7,-3
+            64: 8,-3
+            65: 9,-2
+            66: 8,-2
+            67: 8,-2
+            68: 9,-2
+            69: 7,0
+        - node:
+            zIndex: 1
+            id: LatticeCornerNE
+          decals:
+            11: 0,-5
+            115: 0,-5
+        - node:
+            zIndex: 1
+            id: LatticeCornerNW
+          decals:
+            8: 10,-5
+            122: 10,-5
+        - node:
+            zIndex: 1
+            id: LatticeCornerSE
+          decals:
+            14: 2,3
+            20: 0,0
+            35: 4,2
+            40: 6,2
+            91: 0,0
+            94: 2,3
+            98: 4,2
+            103: 6,2
+        - node:
+            zIndex: 1
+            id: LatticeCornerSW
+          decals:
+            17: 8,3
+            23: 10,0
+            37: 4,2
+            42: 6,2
+            100: 4,2
+            105: 6,2
+            109: 8,3
+            112: 10,0
+        - node:
+            id: LatticeEdgeE
+          decals:
+            9: 0,-5
+            13: 2,3
+            19: 0,0
+            34: 4,2
+            39: 6,2
+            90: 0,0
+            93: 2,3
+            97: 4,2
+            102: 6,2
+            113: 0,-5
+        - node:
+            id: LatticeEdgeN
+          decals:
+            2: 9,-6
+            3: 1,-6
+            4: 3,-7
+            5: 7,-7
+            6: 10,-5
+            10: 0,-5
+            114: 0,-5
+            116: 1,-6
+            117: 3,-7
+            118: 7,-7
+            119: 9,-6
+            120: 10,-5
+        - node:
+            id: LatticeEdgeS
+          decals:
+            0: 3,4
+            1: 7,4
+            12: 2,3
+            15: 8,3
+            18: 0,0
+            21: 10,0
+            33: 4,2
+            38: 6,2
+            89: 0,0
+            92: 2,3
+            95: 3,4
+            96: 4,2
+            101: 6,2
+            106: 7,4
+            107: 8,3
+            110: 10,0
+        - node:
+            id: LatticeEdgeW
+          decals:
+            7: 10,-5
+            16: 8,3
+            22: 10,0
+            36: 4,2
+            41: 6,2
+            99: 4,2
+            104: 6,2
+            108: 8,3
+            111: 10,0
+            121: 10,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: TechN
+          decals:
+            78: 4,0
+            87: 8,-1
+            88: 9,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: TechNE
+          decals:
+            77: 5,0
+        - node:
+            color: '#FFFFFFFF'
+            id: TechNW
+          decals:
+            51: 3,0
+            55: 7,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: TechS
+          decals:
+            54: 4,-1
+            58: 8,-2
+            85: 8,-1
+            86: 9,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: TechSE
+          decals:
+            53: 5,-1
+            56: 9,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: TechSW
+          decals:
+            52: 3,-1
+            57: 7,-2
+        - node:
+            color: '#DE3A3A96'
+            id: WarnBox
+          decals:
+            70: 7,0
+            71: 5,2
+        - node:
+            color: '#DE3A3A96'
+            id: WarnLineN
+          decals:
+            79: 1,-1
+        - node:
+            color: '#DE3A3A96'
+            id: WarnLineW
+          decals:
+            80: 1,-1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 16385
+            1: 1064
+          0,-1:
+            1: 61633
+          1,0:
+            1: 523
+            0: 1280
+          0,1:
+            0: 8
+          1,-1:
+            1: 63923
+          2,0:
+            1: 288
+            0: 4100
+          1,1:
+            0: 8
+          2,-1:
+            1: 13076
+          0,-2:
+            0: 4736
+          1,-2:
+            1: 1792
+            0: 128
+          2,-2:
+            0: 16896
+        uniqueMixes:
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: IFF
+      relations: {}
+      color: '#F6CE9C9C'
+      flags: IsPlayerShuttle
+    - type: ShuttleDeed
+      shuttleName: Shuttle TAN-629
+      shuttleUid: 1
+    - type: BecomesStation
+      id: Virago
+- proto: AAAHardpointFixed
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 56
+    - type: Physics
+      canCollide: False
+- proto: AirlockShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+- proto: AirlockSyndicateHorizontalLockedNCSPGorlex
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: Door
+      secondsUntilStateChange: -2354.7507
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+- proto: AirlockSyndicateLockedNCSPGorlex
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+- proto: BlastDoor
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: DeviceLinkSink
+      links:
+      - 72
+- proto: BoriaticGeneratorHerculesShuttle
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+    - type: FuelGenerator
+      on: False
+    - type: Physics
+      bodyType: Static
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        disk_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        id_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: DeviceLinkSource
+      linkedPorts:
+        2:
+        - - Group1
+          - Toggle
+- proto: CrateAluminium
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: EwarDevice
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+- proto: GrilleBroken
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+- proto: N14TableMetalGrate
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+- proto: NFHolopadShipAntag
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+- proto: OxygenCanister
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 1
+    - type: PointLight
+      energy: 0.5
+      color: '#FFB475FF'
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+    - type: PointLight
+      falloff: 9
+      energy: 0.3
+      color: '#FFB475FF'
+- proto: PoweredSmallLightMaintenanceRed
+  entities:
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+    - type: PointLight
+      falloff: 12
+      energy: 2
+      color: '#FF4444FF'
+- proto: Rack
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        10:
+        - - Pressed
+          - Toggle
+- proto: SmallGyroscope
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+- proto: ThrusterNCSPFighter
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-3.5
+      parent: 1
+    - type: Thruster
+      enabled: False
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-5.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+- proto: WallReinforcedDiagonalCurved
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-6.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 1
+- proto: WarpPointShip
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+- proto: WeaponTurretSmallArtillery
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        ballistic-ammo: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        gun_chamber: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+...

--- a/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
@@ -54,6 +54,7 @@ entities:
     - type: SpreaderGrid
     - type: SelfDeleteGrid
     - type: Shuttle
+      baseMaxLinearVelocity: 25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
@@ -700,6 +700,13 @@ entities:
         2:
         - - Group1
           - Toggle
+    - type: NamedModules
+      buttonNames:
+      - Fire 50mm cannon
+      - Empty Module
+      - Empty Module
+      - Empty Module
+      - Empty Module
 - proto: CrateAluminium
   entities:
   - uid: 57
@@ -834,7 +841,7 @@ entities:
         10:
         - - Pressed
           - Toggle
-- proto: SmallGyroscope
+- proto: Gyroscope
   entities:
   - uid: 73
     components:

--- a/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCSP/virago.yml
@@ -776,7 +776,7 @@ entities:
       falloff: 9
       energy: 0.3
       color: '#FFB475FF'
-- proto: PoweredSmallLightMaintenanceRed
+- proto: PoweredSmallLight
   entities:
   - uid: 66
     components:

--- a/Resources/Prototypes/_Crescent/DogtagStore/catalog_GSC.yml
+++ b/Resources/Prototypes/_Crescent/DogtagStore/catalog_GSC.yml
@@ -156,11 +156,11 @@
   - StoreCategoryGSCLPC
 
 - type: listing
-  id: StoreListingGSCItch
-  name: GSC Itch LPC.
-  description: A Cyberdawn Technologies IFF-cloaked fighter pattern licensed to GSC after some effective bargaining techniques.
+  id: StoreListingGSCVirago
+  name: GSC Virago LPC.
+  description: A multirole combat craft with a 50 milimeter gun, jammer and IFF cloaking.
   icon: { sprite: _Crescent/Objects/Misc/lpcchip.rsi, state: icon }
-  productEntity: ShipVoucherItch
+  productEntity: ShipVoucherVirago
   cost:
     PlunderGSC: 4
   categories:

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/shiplpcs.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/shiplpcs.yml
@@ -1062,6 +1062,26 @@
 
 - type: entity
   parent: BaseItem
+  id: ShipVoucherVirago
+  name: GSC 'Virago' pattern LPC fabprint disk
+  description: An LPC fabprint disk loaded with a Gorlex Security Consulting Virago-class stealth fighter. Has to be redeemed at a shipyard console.
+  components:
+  - type: Item
+    size: Small
+  - type: Sprite
+    sprite: _Crescent/Objects/Misc/lpcchip.rsi
+    layers:
+    - state: icon
+  - type: StaticPrice
+    price: 2500
+  - type: ShipVoucher
+    ship: Virago
+  - type: ReverseEngineering # SectorCrescent
+    recipes:
+      - ViragoLPC
+
+- type: entity
+  parent: BaseItem
   id: ShipVoucherThanapod
   name: SAW 'Thanapod' pattern LPC fabprint disk
   description: An LPC fabprint disk loaded with a Shipfitters Aeronautics union Thanapod-class versatile miner pattern. Has to be redeemed at a shipyard console.

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/privateer.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/privateer.yml
@@ -607,6 +607,15 @@
     ShipHull: 2500
 
 - type: latheRecipe
+  id: ViragoLPC
+  result: ShipVoucherVirago
+  completetime: 1.5
+  materials:
+    StarshipEngineComponents: 1500
+    ShipComponents: 1500
+    ShipHull: 2500
+
+- type: latheRecipe
   id: ReaverLPC
   result: ShipVoucherReaver
   completetime: 1.5

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -675,7 +675,7 @@
       - TickLPC
       - PiranhaLPC
       - ScuttlefishLPC
-      - ItchLPC
+      - ViragoLPC
       - ReaverLPC
       - CorvaxLPC
       - CleaverLPC

--- a/Resources/Prototypes/_Crescent/Entities/Structures/mothership_consoles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/mothership_consoles.yml
@@ -41,7 +41,7 @@
   - type: ShipyardListing
     shuttles:
     - Reaver
-    - Itch
+    - Virago
     - Sinn
     - Cerberus
     - Corvax

--- a/Resources/Prototypes/_Crescent/Maps/Ships/NCSP/virago.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/NCSP/virago.yml
@@ -1,0 +1,31 @@
+# Author info:
+# i don't give a shit about attribution have this ship for free geg
+
+- type: vessel
+  id: Virago
+  name: GSC Virago
+  description: A stealth fighter with basic boarding provisions and an electronic warfare suite.
+  price: 25000 #itch parity
+  category: Small
+  group: None
+  path: /Maps/_Crescent/Shuttles/NCSP/virago.yml
+
+- type: gameMap
+  id: Virago
+  mapName: 'GSC Virago'
+  mapPath: /Maps/_Crescent/Shuttles/NCSP/virago.yml
+  minPlayers: 0
+  stations:
+    Virago:
+      stationProto: StandardCrescentVessel
+      components:
+        - type: VesselIcon
+          iffIcon:
+            sprite: _Crescent/ShipIcons/ifficons.rsi
+            state: fighter
+        - type: StationNameSetup
+          mapNameTemplate: 'GSC Virago {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: VesselDesignation


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description
Adds the GSC Virago and derotates the Itch in favor of it

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.
The Itch is pretty damn ugly, post gun remap has nonexistent staying power and basically acts as a one trick pony that blows up bigger ships. Also, despite ostensibly being the IFF cloaked stealthy ship, it lacks the reaver's jammer - not that either ship is really stealthy, but if anyone ever decides to for example give GSC the cyberdawn "disguise as an asteroid" IFF thing then this might get used for workable ambushes.

Given that it oftentimes gets used as a de-facto troop ferry I decided that we might as well give it basic boarding provisions in the form of a cell charger and an oxy canister, bolt on the jammer and lean further into the boarder symbiosis niche. The 50 milimeter cannon provides decent stand off firepower (it is however on the backfoot against basically all other fighters), and the ship is maneuverable enough to evade fire.

I understand that the armament might be a point of contention, which is why if push comes to shove we can always just give this thing 48 mike and the screamer to make it functionally equivalent to the old Itch. I personally find the 50 mil to be a nice balance of "can fend off a vanguard on a good day" and "can bust open a bigger ship if need be," but the armament is probably the easiest to change aspect of this ship.

My intended use cases for this would be:
- Longer range complement to the reaver
- Self sufficient boarder+pilot base (support via jamming + standoff fire)
- Cheap iffless ferry for lategame
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Functional

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

<img width="887" height="743" alt="image" src="https://github.com/user-attachments/assets/ce29c28a-f753-4d79-833d-180ecfe10a3e" />
<img width="829" height="803" alt="image" src="https://github.com/user-attachments/assets/141668d3-a35a-4ccc-8c1c-f1d695e225db" />


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Replaced Itch in frontline GSC use by the Virago
