### PR TITLE
Ship Component Reparability Update Part 1

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -37,7 +37,7 @@
         sound:
           collection: GlassBreak
       - !type:ChangeConstructionNodeBehavior
-        node: monitorBroken
+        node: electronicsDestroyed
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: InteractionVerbs
@@ -62,9 +62,20 @@
         enum.ConstructionVisuals.Layer:
           frameUnsecured: { state: 0 }
           boardUnsecured: { state: 1 }
-          missingWires: { state: 2 }
+          electronicsRepairing: { state: 2}
+          missingWires: { state: 3 }
           monitorMissing: { state: 3 }
+          electronicsDestroyed: { state: 3 }
           monitorUnsecured: { state: 4 }
+          electronicsRepaired: { state: 4}
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 900
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseStructureComputer

--- a/Resources/Prototypes/Entities/Structures/Walls/girders.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girders.yml
@@ -73,7 +73,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 200
+            damage: 1200
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
@@ -82,7 +82,7 @@
                 collection: MetalBreak
         - trigger:
             !type:DamageTrigger
-            damage: 50
+            damage: 1000
           behaviors:
             - !type:SpawnEntitiesBehavior
               spawn:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
@@ -140,3 +140,55 @@
           steps:
             - tool: Prying
               doAfter: 2
+
+    - node: electronicsDestroyed
+      entity: ComputerFrame
+      actions:
+        - !type:SetAnchor { }
+        - !type:AppearanceChange
+      edges:
+        - to: electronicsRepairing
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - tool: Screwing
+              doAfter: 2
+            - tool: Cutting
+        - to: electronicsRepaired
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - material: Cable
+              amount: 5
+        - to: computer
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - tool: Screwing
+              doAfter: 2
+
+    - node: electronicsRepairing
+      entity: ComputerFrame
+      actions:
+        - !type:SetAnchor { }
+        - !type:AppearanceChange
+      edges:
+        - to: electronicsRepaired
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - material: Cable
+              amount: 5
+
+    - node: electronicsRepaired
+      entity: ComputerFrame
+      actions:
+        - !type:SetAnchor { }
+        - !type:AppearanceChange
+      edges:
+        - to: computer
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - tool: Screwing
+              doAfter: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -320,6 +320,8 @@
             - material: Plasteel
               amount: 2
               doAfter: 1
+            - tool: Welding
+              doAfter: 4
 
         - to: shuttleWall #Nyano
           completed:

--- a/Resources/Prototypes/_Crescent/Entities/Structures/Machines/Computers/consoles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/Machines/Computers/consoles.yml
@@ -61,10 +61,12 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 100
+          damage: 250
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
+          - !type:ChangeConstructionNodeBehavior
+            node: electronicsDestroyed
 
 - type: entity
   parent: [BaseStructureComputerTabletop, C_ComputerShuttle]

--- a/Resources/Prototypes/_Crescent/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/Walls/walls.yml
@@ -19,7 +19,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 700
+        damage: 1000
       behaviors:
       - !type:PlaySoundBehavior #Nyano
         sound:
@@ -37,14 +37,13 @@
         sound:
           collection: MetalSlam
       - !type:ChangeConstructionNodeBehavior
-        node: girder
+        node: reinforcedGirder
       - !type:SpawnEntitiesBehavior
           spawn:
             SteelScrap1:
               min: 2
               max: 4
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+
   - type: IconSmooth
     key: walls
     base: reinf_over


### PR DESCRIPTION
I want field repairs to be more common, I've tried my best to make a more innovative system for repairing walls and consoles, here is what is new.

Reinforced walls now break into reinforced girders, previously just girders, which saves a step in the repairing process. Girders have significantly higher health, they do not act as armor and are only damaged by explosions. May tune this more if it negatively impacts gameplay. From a reinforced girder, one 1second do-after with 2 plasteel sheets (this may change before the weekend) in hand followed by a four second do-after with a welder to fix a reinforced wall. I will be adding plasteel sheets to our alloy furnace for easy production, as a part of the industry update.
Currently nothing planned for plastitanium walls, I want to see how this goes before making their construction graphs

Consoles follow a new construction graph, fixed a issue with our shuttle consoles not using a destroyed state and just disappearing. Consoles now go, 2 second screwdriver do-after > wirecutter > 5xlvcable > 2 second screwdriver do-after > repaired. Consoles also now have slightly more hp, their damaged state has alot more. This may need to be tweaked with some testing.

Thrusters are on my to do list, I have a new sprite for them but am struggling to figure out how I want to handle them, currently their process is fine, a single screwdriver action is okay when you often need to anchor and eva to repair them. 

Guns are also on my to do list, but because of their massive hp pools, they rarely get destroyed. 

Next up is my salvaging update, I want ships to break down 1:1 into the resources that it cost to make. 