### PR TITLE
feat: nerf Fishbed & TAP hardsuits, DegradeableArmor no longer able to be repaired

### DIFF
--- a/Content.Shared/_Crescent/DegradeableArmor/DegradeableArmorSystem.cs
+++ b/Content.Shared/_Crescent/DegradeableArmor/DegradeableArmorSystem.cs
@@ -87,7 +87,7 @@ public sealed class DegradeableArmorSystem : EntitySystem
             return;
         }
 
-        args.Handled = _toolSystem.UseTool(args.Used, args.User, owner.Owner, 15, "Welding", new ArmorRepairDoAfterEvent(), 50);
+//        args.Handled = _toolSystem.UseTool(args.Used, args.User, owner.Owner, 15, "Welding", new ArmorRepairDoAfterEvent(), 50);
 
     }
 

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
@@ -15,17 +15,15 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 1000
-    armorType: Metallic
+  - type: DegradeableArmor # I am completely winging this. This is complete dogshit. Thankfully, 'abysmal dogshit' is all that's being asked of me.
+    armorMaxHealth: 100
+    armorType: Plastic
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 35
-        Slash: 35
-        Piercing: 50
-        Heat: 20
-        Caustic: 5
+        Blunt: 15
+        Slash: 15
+        Piercing: 36
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -56,19 +54,17 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 750
-    armorType: Metallic
-    armorRepair: PlasteelPlate
+    armorMaxHealth: 100
+    armorType: Plastic
+    armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 35
-        Slash: 35
-        Piercing: 75
-        Heat: 55
-        Caustic: 25
+        Blunt: 15
+        Slash: 15
+        Piercing: 36
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitArabet
   - type: StaticPrice
@@ -90,16 +86,14 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 750
-    armorType: Metallic
+    armorMaxHealth: 100
+    armorType: Plastic
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 35
-        Slash: 25
-        Piercing: 35
-        Heat: 10
-        Caustic: 25
+        Blunt: 15
+        Slash: 15
+        Piercing: 36
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -130,19 +124,17 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 1000
-    armorType: Metallic
+    armorMaxHealth: 100
+    armorType: Plastic
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 20
-        Heat: 10
-        Caustic: 25
+        Blunt: 15
+        Slash: 15
+        Piercing: 36
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitThukker
   - type: StaticPrice
@@ -201,7 +193,7 @@
   - type: StaticPrice
     price: 250
   - type: ReverseEngineering
-    recipes: 
+    recipes:
       - ClothingOuterArmorServileAlseik
       - ClothingHeadHatServile
       - ClothingOuterArmorDraugrAlseik
@@ -238,7 +230,7 @@
   - type: StaticPrice
     price: 500
   - type: ReverseEngineering
-    recipes: 
+    recipes:
       - ClothingOuterArmorDraugrAlseik
       - ClothingHeadHatDraugr
       - ClothingOuterArmorServileAlseik

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Independents/OuterClothing/outerclothing.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Independents/OuterClothing/outerclothing.yml
@@ -48,19 +48,17 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: DegradeableArmor
-    armorMaxHealth: 600
-    armorType: Metallic
-    armorRepair: PlasteelPlate
+    armorMaxHealth: 100
+    armorType: Plastic
+    armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
         Blunt: 15
         Slash: 15
-        Piercing: 40
-        Heat: 25
-        Caustic: 15
+        Piercing: 36
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitFishbed
   - type: StaticPrice


### PR DESCRIPTION
# Description

I was asked to "give all of the fishbed and tap hardsuits extremely poor stats", more specifically, "make them capable of eating a singular 5.56 round and lose their ability to be repaired with welder." This is that, though, just a *little* more protective because the DegradeableArmorSystem is actually fairly complicated and has a LOT of variables. So, I really did just try my best.

---
<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>
---

# Changelog

:cl:
- tweak: armor values of fishbed and TAP hardsuits
- remove: ability for DegradeableArmor to be able to be repaired with a welder
