### PR TITLE
removing whitelists from roles

### DIFF
--- a/Resources/Prototypes/_Crescent/Roles/Jobs/ATH/kommandant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/ATH/kommandant.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-ath
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "ATH"
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/ATH/leutnant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/ATH/leutnant.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-ath
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "ATH"
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/adjutant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/adjutant.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/advocatus.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/advocatus.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/archscribe.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/archscribe.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/governor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/governor.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ministeroflabor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ministeroflabor.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ritter.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/ritter.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/FourFamilies/prophet.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/FourFamilies/prophet.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-prophet
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "TAP"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_commandant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_commandant.yml
@@ -19,7 +19,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterTraitRequirement
       inverted: true
       traits:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_fleetkapitan.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_fleetkapitan.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-ncwl-leaders
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 20000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_kommissar.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_kommissar.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-ncwl-kommissar
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 30000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_mvdofficer.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/NCWL/ncwl_mvdofficer.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-ncwl-mvd
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 30000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/board.yml
@@ -15,7 +15,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 18000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/executive.yml
@@ -15,7 +15,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 36000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SHI/highsec.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-shi
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 35000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/hunter.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/hunter.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-srm-hunters
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 43200
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/montagne.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/montagne.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-srm-leaders
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 64800
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/overseer.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/overseer.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-srm-overseer
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "SRM"
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/tender.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/SRM/tender.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-srm-hunters
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 57600
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/Shared/gliessiandockmaster.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/Shared/gliessiandockmaster.yml
@@ -15,7 +15,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 25000
   special:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/Shared/gliessiansheriff.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/Shared/gliessiansheriff.yml
@@ -15,7 +15,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 25000
   special:

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/coordinator.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/coordinator.yml
@@ -11,7 +11,7 @@
   supervisors: You answer to the interests of the Interdyne Pharmaceuticals company. Organize your employees. Secure stakeholders and profit.
   canBeAntag: false
   requirements:
-    - !type:CharacterSpeciesRequirement
+    #- !type:CharacterSpeciesRequirement
       inverted: true
       species:
         - Voidborn

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/coordinator.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/coordinator.yml
@@ -11,11 +11,11 @@
   supervisors: You answer to the interests of the Interdyne Pharmaceuticals company. Organize your employees. Secure stakeholders and profit.
   canBeAntag: false
   requirements:
-    #- !type:CharacterSpeciesRequirement
+    - !type:CharacterSpeciesRequirement
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 20000
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/intelligenceofficer.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/intelligenceofficer.yml
@@ -15,7 +15,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 10800
     - !type:FactionRequirement

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/ringleader.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/TFSC/ringleader.yml
@@ -15,7 +15,7 @@
       inverted: true
       species:
         - Voidborn
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:CharacterOverallTimeRequirement
       min: 10800
     - !type:FactionRequirement


### PR DESCRIPTION
Removed the whitelist for the roles we have in the server, by request of eb.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Removed whitelists for roles. 
