### PR TITLE
feat: delete most common ghost roles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -666,15 +666,6 @@
   components:
   - type: Singer
     proto: HarpySinger
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-squackroach-name
-    description: ghost-role-information-squackroach-description
-    rules: ghost-role-information-freeagent-rules
-    mindRoles:
-    - MindRoleGhostRoleFreeAgent
   - type: Fixtures
     fixtures:
       fix1:
@@ -686,7 +677,6 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
-  - type: GhostTakeoverAvailable
   - type: Speech
     speechVerb: Harpy
     speechSounds: Harpy
@@ -1435,11 +1425,6 @@
     tags:
     - DoorBumpOpener
     - FootstepSound
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-kangaroo-name
-    description: ghost-role-information-kangaroo-description
-  - type: GhostTakeoverAvailable
   - type: Vocal
     sounds:
       Unsexed: Kangaroo
@@ -1646,12 +1631,6 @@
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-primate
   - type: AlwaysRevolutionaryConvertible
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-monkey-name
-    description: ghost-role-information-monkey-description
-  - type: GhostTakeoverAvailable
   - type: Clumsy
     gunShootFailDamage:
       types:
@@ -1687,18 +1666,6 @@
   - type: NpcFactionMember
     factions:
     - Syndicate
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-monkey-name
-    description: ghost-role-information-monkey-description
-    rules: ghost-role-information-syndicate-reinforcement-rules
-    mindRoles:
-    # This is for syndicate monkeys that randomly gain sentience, thus have no summoner to team with
-    - MindRoleGhostRoleSoloAntagonist
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
 
@@ -1784,14 +1751,8 @@
     - id: FoodMeat
       amount: 2
   - type: AlwaysRevolutionaryConvertible
-  - type: GhostTakeoverAvailable
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-kobold
-  - type: GhostRole
-    prob: 0.1
-    makeSentient: true
-    name: ghost-role-information-kobold-name
-    description: ghost-role-information-kobold-description
   - type: RandomBark
     barkMultiplier: 0.65
     barkType: kobold
@@ -1872,16 +1833,6 @@
   components:
   - type: Body
     prototype: Mouse
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-mouse-name
-    description: ghost-role-information-mouse-description
-    rules: ghost-role-information-freeagent-rules
-    mindRoles:
-    - MindRoleGhostRoleFreeAgent
-  - type: GhostTakeoverAvailable
   - type: Speech
     speechSounds: Squeak
     speechVerb: SmallMob
@@ -2724,16 +2675,6 @@
   - type: HTN
     rootTask:
       task: SimpleHostileCompound
-  - type: GhostRole
-    makeSentient: true
-    name: ghost-role-information-giant-spider-name
-    description: ghost-role-information-giant-spider-description
-    rules: ghost-role-information-giant-spider-rules
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-    raffle:
-      settings: short
-  - type: GhostTakeoverAvailable
 
 - type: entity
   name: tarantula
@@ -3364,17 +3305,6 @@
         Base: syndicat
       Dead:
         Base: syndicat_dead
-  - type: GhostRole
-    prob: 1
-    name: ghost-role-information-SyndiCat-name
-    allowMovement: true
-    description: ghost-role-information-SyndiCat-description
-    rules: ghost-role-information-SyndiCat-rules
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
   - type: AutoImplant
     implants:
     - MicroBombImplant
@@ -3651,13 +3581,6 @@
   id: MobHamster
   description: A cute, fluffy, robust hamster.
   components:
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-hamster-name
-    description: ghost-role-information-hamster-description
-  - type: GhostTakeoverAvailable
   - type: Speech
     speechVerb: SmallMob
     speechSounds: Squeak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -187,18 +187,6 @@
   parent: MobCarp
   components:
     - type: Absorbable
-    - type: GhostRole
-      allowMovement: true
-      allowSpeech: true
-      makeSentient: true
-      name: ghost-role-information-sentient-carp-name
-      description: ghost-role-information-sentient-carp-description
-      rules: ghost-role-information-space-dragon-summoned-carp-rules
-      mindRoles:
-      - MindRoleGhostRoleTeamAntagonist
-      raffle:
-        settings: short
-    - type: GhostTakeoverAvailable
     - type: HTN
       rootTask:
         task: DragonCarpCompound

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -393,16 +393,6 @@
   components:
   - type: Body
     prototype: Mouse
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: false
-    allowMovement: true
-    name: ghost-role-information-snail-name
-    description: ghost-role-information-snail-description
-    rules: ghost-role-information-freeagent-rules
-    mindRoles:
-    - MindRoleGhostRoleFreeAgent
-  - type: GhostTakeoverAvailable
   - type: Sprite
     drawdepth: SmallMobs
     sprite: Mobs/Animals/snail.rsi
@@ -543,10 +533,6 @@
   id: MobSnailSpeed
   suffix: Speed
   components:
-  - type: GhostRole
-    name: ghost-role-information-snailspeed-name
-    description: ghost-role-information-snailspeed-description
-    rules: ghost-role-information-freeagent-rules
   - type: Sprite
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
@@ -572,10 +558,6 @@
   components:
   - type: Body
     prototype: Mothroach
-  - type: GhostRole
-    name: ghost-role-information-snoth-name
-    description: ghost-role-information-snoth-description
-    rules: ghost-role-information-freeagent-rules
   - type: Sprite
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -104,20 +104,12 @@
 #    description: ghost-role-information-xeno-description
 #    rules: ghost-role-information-xeno-rules
 #  - type: GhostTakeoverAvailable
-#
-#- type: entity
-#  name: Rouny
-#  parent: MobXenoRounyNPC
-#  id: MobXenoRouny
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
+
+- type: entity
+  name: Rouny
+  parent: MobXenoRounyNPC
+  id: MobXenoRouny
+
 #
 #- type: entity
 #  name: Spitter

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -13,115 +13,52 @@
   components:
   - type: SalvageMobRestrictions
 
-# Delta V variants of Xenos to allow ghost takeover again
-#
-#- type: entity
-#  name: Burrower
-#  id: MobXenoPlayer
-#  parent: MobXeno
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
-#
-#- type: entity
-#  name: Praetorian
-#  parent: MobXenoPraetorianNPC
-#  id: MobXenoPraetorian
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
-#
-#- type: entity
-#  name: Drone
-#  parent: MobXenoDroneNPC
-#  id: MobXenoDrone
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
-#
-#- type: entity
-#  name: Queen
-#  parent: MobXenoQueenNPC
-#  id: MobXenoQueen
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
-#
-#- type: entity
-#  name: Ravager
-#  parent: MobXenoRavagerNPC
-#  id: MobXenoRavager
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
-#
-#- type: entity
-#  name: Runner
-#  parent: MobXenoRunnerNPC
-#  id: MobXenoRunner
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
+# Delta V variants of Xenos to allow ghost takeover again - except not anymore and these are just kept around for linter purposes
+
+- type: entity
+  name: Burrower
+  id: MobXenoPlayer
+  parent: MobXeno
+  suffix: Player
+
+- type: entity
+  name: Praetorian
+  parent: MobXenoPraetorianNPC
+  id: MobXenoPraetorian
+  suffix: Player
+
+- type: entity
+  name: Drone
+  parent: MobXenoDroneNPC
+  id: MobXenoDrone
+  suffix: Player
+
+- type: entity
+  name: Queen
+  parent: MobXenoQueenNPC
+  id: MobXenoQueen
+  suffix: Player
+
+- type: entity
+  name: Ravager
+  parent: MobXenoRavagerNPC
+  id: MobXenoRavager
+  suffix: Player
+
+- type: entity
+  name: Runner
+  parent: MobXenoRunnerNPC
+  id: MobXenoRunner
+  suffix: Player
 
 - type: entity
   name: Rouny
   parent: MobXenoRounyNPC
   id: MobXenoRouny
 
-#
-#- type: entity
-#  name: Spitter
-#  parent: MobXenoSpitterNPC
-#  id: MobXenoSpitter
-#  suffix: Player
-#  components:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-xeno-name
-#    description: ghost-role-information-xeno-description
-#    rules: ghost-role-information-xeno-rules
-#  - type: GhostTakeoverAvailable
+- type: entity
+  name: Spitter
+  parent: MobXenoSpitterNPC
+  id: MobXenoSpitter
+  suffix: Player
+

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -5,147 +5,131 @@
   parent: MobPurpleSnake
   id: MobPurpleSnakeGhost
   components:
-  - type: GhostTakeoverAvailable
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: false
-    makeSentient: true
-    name: salvage snake
-    description: You are a salvage snake hunting for a meal.
-    rules: You are an antagonist, kill!
   - type: SalvageMobRestrictions
 
 - type: entity
   parent: MobSmallPurpleSnake
   id: MobSmallPurpleSnakeGhost
   components:
-  - type: GhostTakeoverAvailable
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: false
-    makeSentient: true
-    name: salvage snake
-    description: You are a salvage snake hunting for a meal.
-    rules: You are an antagonist, kill!
   - type: SalvageMobRestrictions
 
 # Delta V variants of Xenos to allow ghost takeover again
-
-- type: entity
-  name: Burrower
-  id: MobXenoPlayer
-  parent: MobXeno
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Praetorian
-  parent: MobXenoPraetorianNPC
-  id: MobXenoPraetorian
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Drone
-  parent: MobXenoDroneNPC
-  id: MobXenoDrone
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Queen
-  parent: MobXenoQueenNPC
-  id: MobXenoQueen
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Ravager
-  parent: MobXenoRavagerNPC
-  id: MobXenoRavager
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Runner
-  parent: MobXenoRunnerNPC
-  id: MobXenoRunner
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Rouny
-  parent: MobXenoRounyNPC
-  id: MobXenoRouny
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
-
-- type: entity
-  name: Spitter
-  parent: MobXenoSpitterNPC
-  id: MobXenoSpitter
-  suffix: Player
-  components:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Burrower
+#  id: MobXenoPlayer
+#  parent: MobXeno
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Praetorian
+#  parent: MobXenoPraetorianNPC
+#  id: MobXenoPraetorian
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Drone
+#  parent: MobXenoDroneNPC
+#  id: MobXenoDrone
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Queen
+#  parent: MobXenoQueenNPC
+#  id: MobXenoQueen
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Ravager
+#  parent: MobXenoRavagerNPC
+#  id: MobXenoRavager
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Runner
+#  parent: MobXenoRunnerNPC
+#  id: MobXenoRunner
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Rouny
+#  parent: MobXenoRounyNPC
+#  id: MobXenoRouny
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable
+#
+#- type: entity
+#  name: Spitter
+#  parent: MobXenoSpitterNPC
+#  id: MobXenoSpitter
+#  suffix: Player
+#  components:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-xeno-name
+#    description: ghost-role-information-xeno-description
+#    rules: ghost-role-information-xeno-rules
+#  - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_EE/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/NPCs/carp.yml
@@ -4,16 +4,6 @@
   id: MobCarpGoldfish
   description: A domesticated variety of space carp, much smaller but no less aggressive.
   components:
-    - type: GhostRole
-      allowMovement: true
-      allowSpeech: true
-      makeSentient: true
-      name: ghost-role-information-space-goldfish-name
-      description: ghost-role-information-space-goldfish-description
-      rules: ghost-role-information-freeagent-rules
-      mindRoles:
-      - MindRoleGhostRoleFreeAgent
-    - type: GhostTakeoverAvailable
     - type: Sprite
       drawdepth: Mobs
       sprite: Mobs/Aliens/Carps/goldfish.rsi


### PR DESCRIPTION
# Description

I looked at eB's todo list and it says "nuke ghostroles". EZPZ! This PR deletes the ghost role component off of the things that are most common (spider, carp, etc). Also now xenos.

---

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog
:cl:
- remove: common ghostroles (carp, xenos, etc)