### PR TITLE
feat: makes wrecks less dense

### DIFF
--- a/Resources/Prototypes/_Crescent/PortedShit.yml
+++ b/Resources/Prototypes/_Crescent/PortedShit.yml
@@ -493,7 +493,7 @@
   clippedValue: 1.658 # magic number for chunk size.
   inputMultiplier: 10 # Makes density hopefully low noise in the local area while still being interesting at scale.
   outputMultiplier: 75.0 # Increased from 50.0 to 75.0 for more debris
-  minimum: 60.0 # Increased from 45.0 to 60.0 for higher base density
+  minimum: 45.0 # Increased from 45.0 to 60.0 for higher base density
 
 - type: noiseChannel
   id: WreckGraveyard

--- a/Resources/Prototypes/_Crescent/World/basic.yml
+++ b/Resources/Prototypes/_Crescent/World/basic.yml
@@ -88,7 +88,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.4, 0.6
+    - 0.495, 0.505
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -164,7 +164,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.4, 0.6
+    - 0.495, 0.505
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -237,7 +237,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.4, 0.6
+    - 0.495, 0.505
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -312,7 +312,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.4, 0.6
+    - 0.495, 0.505
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -328,7 +328,7 @@
     densityNoiseChannel: Density
   - type: NoiseRangeCarver
     ranges:
-    - 0.4, 0.6
+    - 0.495, 0.505
     noiseChannel: Carver
   - type: SimpleDebrisSelector
     debrisTable:
@@ -358,7 +358,7 @@
     densityNoiseChannel: Density
   - type: NoiseRangeCarver
     ranges:
-    - 0.4, 0.6
+    - 0.495, 0.505
     noiseChannel: Carver
   - type: SimpleDebrisSelector
     debrisTable:

--- a/Resources/Prototypes/_Crescent/World/basic.yml
+++ b/Resources/Prototypes/_Crescent/World/basic.yml
@@ -88,7 +88,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.495, 0.505
+    - 0.4, 0.6
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -164,7 +164,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.495, 0.505
+    - 0.4, 0.6
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -237,7 +237,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.495, 0.505
+    - 0.4, 0.6
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -312,7 +312,7 @@
       prob: 1
   - type: NoiseRangeCarver
     ranges:
-    - 0.495, 0.505
+    - 0.4, 0.6
     noiseChannel: Carver
 
 - type: spaceBiome
@@ -328,7 +328,7 @@
     densityNoiseChannel: Density
   - type: NoiseRangeCarver
     ranges:
-    - 0.495, 0.505
+    - 0.4, 0.6
     noiseChannel: Carver
   - type: SimpleDebrisSelector
     debrisTable:
@@ -358,7 +358,7 @@
     densityNoiseChannel: Density
   - type: NoiseRangeCarver
     ranges:
-    - 0.495, 0.505
+    - 0.4, 0.6
     noiseChannel: Carver
   - type: SimpleDebrisSelector
     debrisTable:


### PR DESCRIPTION
alt title: scrap field less dense
# Description

As requested by the big 'green shroom-queen.

---

# TODO
- [x] Test

---

<details><summary><h1>Media</h1></summary>
<p>

![before](https://cdn.discordapp.com/attachments/1480820926323888170/1495426774895689728/image.png?ex=69e63436&is=69e4e2b6&hm=47258fa64ad92d1d638da6f423a690a94cf72be8cd9ecd8948e2de62ea651436&)

![after](https://cdn.discordapp.com/attachments/1480820926323888170/1495430747299905739/image.png?ex=69e637e9&is=69e4e669&hm=661734b45afda07a1349b5382e6cb0a6ceaebab6785001c931680bc3c53bffa2&)

</p>
</details>

---

# Changelog
:cl:
- tweak: normalize wreck distribution to make it slightly less dense
