### PR TITLE
Armor no longer degrades, adjusts flat damage resistances for the most commonly seen armors

### DIFF
--- a/Content.Shared/_Crescent/DegradeableArmor/DegradeableArmorSystem.cs
+++ b/Content.Shared/_Crescent/DegradeableArmor/DegradeableArmorSystem.cs
@@ -150,7 +150,7 @@ public sealed class DegradeableArmorSystem : EntitySystem
     {
         if (component.armorHealth <= 0)
             return;
-        var armorDamage = 0f;
+        //var armorDamage = 0f;
 
 
         var damageDictionary = args.Args.Damage.DamageDict;
@@ -190,11 +190,11 @@ public sealed class DegradeableArmorSystem : EntitySystem
             }
 
             trueReduction = Math.Clamp(trueReduction - args.Args.HullrotArmorPen, 0f, (float) value);
-            armorDamage += (float) value * component.armorDamageCoefficients[type];
+            //armorDamage += (float) value * component.armorDamageCoefficients[type];
             //Logger.Error($"Damage adjusted for type {type}, old {value}, new {Math.Max(0f, (float) value - trueReduction)}  Armor damage {armorDamage}. Armor Health {component.armorHealth}. Stamina damage {trueReduction * component.staminaConversions[type]}");
             damageDictionary[type] = Math.Max(0f, (float) value - trueReduction);
         }
-        component.armorHealth = Math.Max(0, component.armorHealth - armorDamage);
+        //component.armorHealth = Math.Max(0, component.armorHealth - armorDamage);
         Dirty(uid, component);
     }
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -159,11 +159,11 @@
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 20
-        Slash: 20
-        Piercing: 20
-        Heat: 15
-        Caustic: 25
+        Blunt: 2
+        Slash: 2
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -186,15 +186,15 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.3
+    damageCoefficient: 0.9
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.5
+#        Blunt: 0.7
+#        Slash: 0.7
+#        Piercing: 0.5
         Radiation: 0.3
-        Caustic: 0.7
+#        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Empire/OuterClothing/outerclothing.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Empire/OuterClothing/outerclothing.yml
@@ -132,11 +132,11 @@
     armorRepair: DuraThread
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 5
-        Heat: 5
-        Caustic: 25
+        Blunt: 4
+        Slash: 4
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: StaticPrice
     price: 500
   - type: ClothingAddFaction
@@ -410,8 +410,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Heat: 35
-        Caustic: 35
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: AllowSuitStorage
@@ -482,8 +485,11 @@
     armorRepair: NTPolymer
     initialModifiers:
       flatReductions:
-        Heat: 35
-        Caustic: 35
+        Blunt: 12
+        Slash: 12
+        Heat: 4
+        Cold: 4
+        Caustic: 4
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: StaticPrice
@@ -518,11 +524,11 @@
     armorRepair: DuraThread
     initialModifiers:
       flatReductions:
-        Blunt: 5
-        Slash: 15
-        Piercing: 15
-        Heat: 5
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: StaticPrice
     price: 1500
   - type: ClothingAddFaction
@@ -545,10 +551,10 @@
     initialModifiers:
       flatReductions:
         Blunt: 10
-        Slash: 20
-        Piercing: 20
-        Heat: 10
-        Caustic: 25
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: StaticPrice
     price: 1500
   - type: ClothingAddFaction
@@ -570,11 +576,11 @@
     armorRepair: DuraThread
     initialModifiers:
       flatReductions:
-        Blunt: 5
-        Slash: 5
-        Piercing: 5
-        Heat: 5
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: StaticPrice
     price: 1500
   - type: ClothingAddFaction
@@ -596,11 +602,11 @@
     armorRepair: NTPolymer
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 15
-        Piercing: 15
-        Heat: 10
-        Caustic: 25
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: StaticPrice
     price: 2000
   - type: ClothingAddFaction
@@ -691,11 +697,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 30
-        Slash: 25
-        Piercing: 15
-        Heat: 20
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Empire/OuterClothing/outerclothing.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Empire/OuterClothing/outerclothing.yml
@@ -21,11 +21,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 5
-        Heat: 10
-        Caustic: 10
+        Blunt: 2
+        Slash: 2
+        Heat: 8
+        Cold: 8
+        Caustic: 8
   - type: ClothingSpeedModifier
     walkModifier: 0.97
     sprintModifier: 0.97
@@ -194,6 +194,12 @@
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandatecommand.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandatecommand.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
@@ -205,11 +211,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 5
-        Slash: 5
-        Piercing: 10
-        Heat: 30
-        Caustic: 30
+        Blunt: 7
+        Slash: 7
+        Heat: 7
+        Cold: 7
+        Caustic: 7
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -230,6 +236,12 @@
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandatesoldier.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandatesoldier.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
@@ -243,9 +255,9 @@
       flatReductions:
         Blunt: 5
         Slash: 5
-        Piercing: 10
-        Heat: 30
-        Caustic: 30
+        Heat: 5
+        Cold: 5
+        Caustic: 5
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -273,6 +285,12 @@
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandateknight.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandateknight.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
@@ -284,11 +302,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 20
-        Heat: 30
-        Caustic: 30
+        Blunt: 6
+        Slash: 6
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.97
     sprintModifier: 0.97
@@ -328,6 +346,12 @@
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandatejuggernaut.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Empire/OuterClothing/mandatejuggernaut.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
@@ -339,11 +363,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 20
-        Heat: 30
-        Caustic: 30
+        Blunt: 8
+        Slash: 8
+        Heat: 8
+        Cold: 8
+        Caustic: 8
   - type: ClothingSpeedModifier #mildly better than other jugsuits, but far worse protection than a T2
     walkModifier: 0.6
     sprintModifier: 0.6

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Independents/OuterClothing/outerclothing.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Independents/OuterClothing/outerclothing.yml
@@ -19,11 +19,11 @@
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 20
-        Slash: 20
-        Piercing: 25
-        Heat: 15
-        Caustic: 25
+        Blunt: 2
+        Slash: 2
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -33,7 +33,7 @@
     price: 750
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitFishbed
   name: NMS-21 'FISHBED' combat hardsuit
   description: Designed by Northrop-Martin for mercenary use and heavily modified by Taypani owners.
@@ -53,9 +53,11 @@
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 36
+        Blunt: 6
+        Slash: 6
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/NCWL/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/NCWL/OuterClothing/armor.yml
@@ -14,11 +14,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 35
-        Heat: 15
-        Caustic: 15
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -51,11 +51,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 20
-        Slash: 20
-        Piercing: 35
-        Heat: 20
-        Caustic: 25
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -94,8 +94,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Heat: 25
-        Caustic: 25
+        Blunt: 12
+        Slash: 12
+        Heat: 4
+        Cold: 4
+        Caustic: 4
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -131,11 +134,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 35
-        Heat: 10
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -166,12 +169,12 @@
     armorType: Metallic
     armorRepair: Kevlar
     initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 25
+       flatReductions:
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -211,8 +214,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Heat: 10
-        Caustic: 10
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -248,11 +254,11 @@
     armorRepair: Kevlar
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -285,11 +291,11 @@
     armorRepair: Kevlar
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -322,11 +328,11 @@
     armorRepair: Kevlar
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 45
-        Heat: 15
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -360,11 +366,11 @@
     armorRepair: Kevlar
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 25
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/NCWL/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/NCWL/OuterClothing/armor.yml
@@ -437,8 +437,8 @@
       flatReductions:
         Blunt: 5
         Slash: 5
-        Piercing: 5
         Heat: 5
+        Cold: 5
         Caustic: 5
   - type: ClothingSpeedModifier
     walkModifier: 1
@@ -483,11 +483,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 5
-        Slash: 5
-        Piercing: 5
-        Heat: 5
-        Caustic: 5
+        Blunt: 2
+        Slash: 2
+        Heat: 8
+        Cold: 8
+        Caustic: 8
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -533,11 +533,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 15
-        Heat: 30
-        Caustic: 30
+        Blunt: 5
+        Slash: 5
+        Heat: 5
+        Cold: 5
+        Caustic: 5
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -581,11 +581,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Piercing: 20
-        Heat: 30
-        Caustic: 30
+        Blunt: 6
+        Slash: 6
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.97
     sprintModifier: 0.97
@@ -631,11 +631,11 @@
     armorRepair: HomelandAlloy
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 30
-        Heat: 35
-        Caustic: 35
+        Blunt: 8
+        Slash: 8
+        Heat: 8
+        Cold: 8
+        Caustic: 8
   - type: ClothingSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
@@ -115,11 +115,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 10
-        Heat: 10
-        Caustic: 15
-        Radiation: 45
+        Blunt: 2
+        Slash: 2
+        Heat: 8
+        Cold: 8
+        Caustic: 8
   - type: ClothingSpeedModifier
     walkModifier: 0.97
     sprintModifier: 0.97
@@ -158,8 +158,11 @@
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
+        Blunt: 6
+        Slash: 6
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -230,8 +233,11 @@
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Heat: 35
-        Caustic: 25
+        Blunt: 8
+        Slash: 8
+        Heat: 8
+        Cold: 8
+        Caustic: 8
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.6
@@ -288,8 +294,11 @@
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
+        Blunt: 5
+        Slash: 5
+        Heat: 5
+        Cold: 5
+        Caustic: 5
   - type: ClothingSpeedModifier
     sprintModifier: 1.3
   - type: FootstepModifier
@@ -314,7 +323,7 @@
   parent: [ClothingOuterArmorBasic, ClothingArmorInsert]
   id: ClothingOuterArmorShinoharaHOSVest
   name: Shinohara Corporation Bulwark-1 Combat Vest
-  description: A simple yet effective load bearing vest and plate carrier, designed to be used by SHI soldiers in atmosphere. Comes with a healthy layer of cushy SHI branded memory foam, for maximum user comfort. 
+  description: A simple yet effective load bearing vest and plate carrier, designed to be used by SHI soldiers in atmosphere. Comes with a healthy layer of cushy SHI branded memory foam, for maximum user comfort.
   components:
   - type: Sprite
     sprite: _Crescent/Clothing/SHI/OuterClothing/hosvest.rsi

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
@@ -341,8 +341,11 @@
     armorRepair: PlasteelEncasedKevlar
     initialModifiers:
       flatReductions:
-        Heat: 20
-        Caustic: 15
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -379,8 +382,11 @@
     armorRepair: PlasteelEncasedKevlar
     initialModifiers:
       flatReductions:
-        Heat: 20
-        Caustic: 15
+        Blunt: 6
+        Slash: 6
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -419,8 +425,11 @@
     armorRepair: NTPolymer
     initialModifiers:
       flatReductions:
-        Heat: 35
-        Caustic: 35
+        Blunt: 12
+        Slash: 12
+        Heat: 4
+        Cold: 4
+        Caustic: 4
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 1.0

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Syndicate/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Syndicate/OuterClothing/armor.yml
@@ -319,11 +319,11 @@
     armorRepair: Kevlar
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 15
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -354,11 +354,11 @@
     armorRepair: Kevlar
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 15
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -404,13 +404,6 @@
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndiehazardvest.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndiehazardvest.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.70
-        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -432,17 +425,6 @@
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/ipm_arpon.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/ipm_arpon.rsi
-  - type: DegradeableArmor
-    armorMaxHealth: 500
-    armorType: Metallic
-    armorRepair: Kevlar
-    initialModifiers:
-      flatReductions:
-        Blunt: 10
-        Slash: 15
-        Piercing: 20
-        Heat: 15
-        Caustic: 25
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -458,7 +440,7 @@
       - ClothingOuterArmorSyndicateApron
 
 - type: entity
-  parent: ClothingOuterArmorBasic
+  parent: [ClothingOuterArmorBasic, ClothingArmorInsert]
   id: ClothingOuterArmorSyndicateArmorvest
   name: frontliner's ballistic vest
   description: A bulky ceramic-faced ballistic vest, touched with the colors of the TFSC.
@@ -467,17 +449,23 @@
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndiearmor.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndiearmor.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: DegradeableArmor
     armorMaxHealth: 650
     armorType: Ceramic
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 75
-        Heat: 10
-        Caustic: 10
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -494,7 +482,7 @@
       - ClothingHeadHelmetSyndicateBasic
 
 - type: entity
-  parent: ClothingOuterArmorBasic
+  parent: [ClothingOuterArmorBasic, ClothingArmorInsert]
   id: ClothingOuterArmorSyndicateArmorvestInterdyne
   name: traumasec ballistic vest
   description: A bulky steel-plate ballistic vest, touched with the colors of interdyne.
@@ -503,6 +491,12 @@
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/ipm_vest.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/ipm_vest.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: DegradeableArmor
     armorMaxHealth: 750
     armorType: Metallic
@@ -511,9 +505,9 @@
       flatReductions:
         Blunt: 10
         Slash: 10
-        Piercing: 45
-        Heat: 10
-        Caustic: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -545,11 +539,11 @@
     armorRepair: NTPolymer
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 15
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -581,11 +575,11 @@
     armorRepair: NTPolymer
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 30
-        Heat: 15
-        Caustic: 15
+        Blunt: 10
+        Slash: 10
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -616,11 +610,11 @@
     armorRepair: Durathread
     initialModifiers:
       flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 25
-        Heat: 15
-        Caustic: 15
+        Blunt: 12
+        Slash: 12
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Syndicate/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Syndicate/OuterClothing/armor.yml
@@ -27,9 +27,11 @@
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
-        Radiation: 35
+        Blunt: 4
+        Slash: 4
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.97
     sprintModifier: 0.97
@@ -72,9 +74,11 @@
     armorRepair: SteelPlate
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
-        Radiation: 35
+        Blunt: 6
+        Slash: 6
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -118,8 +122,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
+        Blunt: 4
+        Slash: 4
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingAddFaction
     faction: TFSC
   - type: ReverseEngineering # Sector Crescent
@@ -153,8 +160,11 @@
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
+        Blunt: 8
+        Slash: 8
+        Heat: 2
+        Cold: 2
+        Caustic: 2
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -195,8 +205,11 @@
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
+        Blunt: 4
+        Slash: 4
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -237,8 +250,11 @@
     armorRepair: NTCeramic
     initialModifiers:
       flatReductions:
-        Heat: 15
-        Caustic: 15
+        Blunt: 6
+        Slash: 6
+        Heat: 6
+        Cold: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

armorhp system switched off without touching underlying systems

T1/T2/Jug/Worker hardsuits for all factions now have at least some base blunt/slash/heat/cold/caustic flat-res but none of them go higher than 8 in any particular damage type

Fishbed and Kriti given resistances inline with a T1/Worker dichotomy but with worse levels than any faction equivalent

Fishbed given armor plate capacity same as any other combat suit, for the off chance some vagrant actually manages to get a hold of some

Non-EVA plate carriers given adjusted flat resistances leaning toward higher blunt/slash over heat/cold/caustic, with the expectation being that piercing resistances will be conveyed by plates

Various FL/2IC armored coats given similar changes to flat resistances but notably **_without_** the ability to carry plates, requiring commanders to don 'proper' combat gear during firefights

### ALL HAIL ARMOR PLATES

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
