### PR TITLE
Buffs Ripley movespeed, hydraulic clamp doafters completely removed and powerdraw-per-crate slightly lowered

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -22,8 +22,10 @@
   - type: Sprite
     state: mecha_clamp
   - type: MechGrabber
-    grabDelay: 0.2
+    grabSound: /Audio/Machines/airlock_emergencyon.ogg
+    grabDelay: 0
     maxContents: 5
+    grabEnergyDelta: -20
   - type: UIFragment
     ui: !type:MechGrabberUi
   - type: ContainerContainer
@@ -34,14 +36,15 @@
   id: MechEquipmentGrabberSmall
   parent: BaseMechEquipment
   name: small hydraulic clamp
-  description: Gives the mech the ability to grab things and drag them around.
+  description: Gives the mech the ability to grab things and drag them around. Stresses a mech's power supply half as much over a standard model in exchange for lowered capacity.
   components:
   - type: Sprite
     state: mecha_clamp_small
   - type: MechGrabber
-    maxContents: 4
-    grabDelay: 0.2
-    grabEnergyDelta: -20
+    grabSound: /Audio/Machines/airlock_emergencyon.ogg
+    maxContents: 3
+    grabDelay: 0
+    grabEnergyDelta: -10
   - type: UIFragment
     ui: !type:MechGrabberUi
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -181,8 +181,8 @@
       types:
         Blunt: 14 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2.25
-    baseSprintSpeed: 3.6
+    baseWalkSpeed: 2.5
+    baseSprintSpeed: 5
 
 - type: entity
   id: MechRipleyBattery

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -74,8 +74,8 @@
       types:
         Blunt: 20
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1
-    baseSprintSpeed: 2
+    baseWalkSpeed: 2
+    baseSprintSpeed: 4
   - type: Damageable
     damageModifierSet: MediumArmorNT
   - type: StaticPrice
@@ -85,7 +85,7 @@
     - DoorBumpOpener
     - FootstepSound
     - RipleyMkII
-    
+
 - type: entity
   id: MechRipley2Battery
   parent: MechRipley2
@@ -133,7 +133,7 @@
         Blunt: 26
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 4.5
+    baseSprintSpeed: 5
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: StaticPrice
@@ -204,7 +204,7 @@
         Blunt: 25
         Structural: 180
   - type: CanMoveInAir
-  - type: MovementAlwaysTouching        
+  - type: MovementAlwaysTouching
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 2.6


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Ripley being slower than both Clarke and the DSM utility mech felt more like a weird 'vanilla' holdover than anything else, so now all mechs should be roughly the same speed as an unladen human.

Clamps have had their audio file changed as well, because for some ungodly reason it can't be set to have **_no_** sfx attached to it.

### Rejoice in the new convenience around mech-assisted crate hauling!

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
