### PR TITLE
NCWL Gun Tweaks

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -112,7 +112,7 @@
   name: NCWL MK-13 Conscript 12.7x99mm
   id: WeaponLightMachineGunConscript
   parent: [BaseItem, StreeCredRedeemable]
-  description: A ripped out .50 cal PDT gun adapted to be fired from the hip. Heavy as shit and innacurate as shit but it turns people into a fine red mist.
+  description: An old Point Defense turret, ripped off its mount, and modified to fire from the hip. Neither the enemy, nor your shoulder will survive this thing.
   components:
   - type: Clothing
     sprite: _Crescent/Objects/Weapons/Guns/conscript.rsi

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/pistols.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/pistols.yml
@@ -226,7 +226,7 @@
   name: NCWL T-91 Quasar .327
   parent: [BaseWeaponPistol, StreeCredRedeemable]
   id: WeaponPistolT91
-  description: A semi-automatic communard solution to self-defense issues amidst officers and heavyhitters. Ironically chambered in .327 Imperial.
+  description: A hefy semi-automatic handgun, designed to be much better at breaking armor than the T-18. Ironically chambered in .327 Imperial.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/Weapons/Guns/quasar.rsi

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/rifles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/rifles.yml
@@ -363,7 +363,7 @@
   name: NCWL MK-3 Batanya 7.62x51mm
   parent: [BaseWeaponRifle, StreeCredRedeemable]
   id: WeaponRifleNCWLBatanya
-  description: An iconic weapon of war from the Union Foundry. Developed for use by their Homeguard. Comes equipped with NightGlo tracer dot sights. Chambered in 7.62x51mm, the proletariat's chamber.
+  description: The standard issue battle rifle in use by the People's Homeguard, and an iconic firearm, featured in most of the Union's propaganda. The Batanya will put a hole in damn near anything, and look great while doing it.
   components:
   - type: Item
     shape:
@@ -494,7 +494,7 @@
 - type: entity
   name: PTA D5 Takemura 7.62x51mm/5.56x45mm
   parent: [BaseWeaponRifle, StreeCredRedeemable]
-  id: WeaponRifleTakemura
+  id: WeaponRiflefTakemura
   description: A multicaliber fast shooting battle rifle from the Pang Tai Arms design labs. Capable of shooting both 7.62x51mm and 5.56x45mm.
   components:
   - type: Item
@@ -608,7 +608,7 @@
   name: NCWL MK-2 Falin 5.56x45mm
   parent: [BaseWeaponRifle, StreeCredRedeemable]
   id: WeaponRifleFAL
-  description: Reverse-engineered from Imperial light battle rifle designs. Sacrifices heavier calibers for better rifling, allowing for more rapid fire.
+  description: A more modern League rifle design, based off of stolen schematics for an older version of the DA-8 Miller. Made with subpar materials, and shoddier machining, the Falin falls behind the performance of the DA-8, but still out performs older Union designs.
   components:
   - type: Item
     shape:

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/rifles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/rifles.yml
@@ -494,7 +494,7 @@
 - type: entity
   name: PTA D5 Takemura 7.62x51mm/5.56x45mm
   parent: [BaseWeaponRifle, StreeCredRedeemable]
-  id: WeaponRiflefTakemura
+  id: WeaponRifleTakemura
   description: A multicaliber fast shooting battle rifle from the Pang Tai Arms design labs. Capable of shooting both 7.62x51mm and 5.56x45mm.
   components:
   - type: Item

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/shotguns.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/shotguns.yml
@@ -2,7 +2,7 @@
   name: NCWL Toz-123 Maul 4g
   parent: [BaseWeaponShotgun, BaseGunWieldable, StreeCredRedeemable]
   id: WeaponShotgunToz123
-  description: A licensed copy of the Mod-23 shotgun by Pang Tai Arms, shortened for ease of use in cramped spaces.
+  description: An enormous shotgun, chambered in 4 gauge, and featuring a shortened barrel. The Toz-123 will put anyone on their ass, and in the ground, guaranteed.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/Weapons/Guns/maul.rsi
@@ -39,7 +39,7 @@
   name: NCWL Toz-97 Proletar 12g
   parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunProletar
-  description: A 12-gauge pump-action shotgun with the magazine tube mounted above the barrel and a reversed pumping action. Comes with an extended tube.
+  description: A simple 12 gauge shotgun, with some odd design choices. The reversed pump action is designed to increase stability, and the magazine tube being placed above the barrel supposedly makes chambering rounds easier on the mechanics.
   components:
   - type: Item
     size: Normal

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/smgs.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/smgs.yml
@@ -3,7 +3,7 @@
   name: NCWL DS3 Militant 9x39mm
   parent: [BaseWeaponRifle, StreeCredRedeemable]
   id: WeaponSubMachineGunMilitant
-  description: A 9x39 submachinegun designed for the NCWL internal police, comes with a huge supressor that makes it a pain in the ass to holster.
+  description: A 9x39 compact rifle, designed to be used by special forces units, and internal police. The integral suppressor makes the rifle a bitch to holster, but the silence is worth it.
   components:
   - type: Item
     shape:
@@ -39,11 +39,7 @@
     availableModes:
     - SemiAuto
     - FullAuto
-    angleIncrease: 15
-    angleDecay: 90
-    maxAngle: 90
-    minAngle: 1
-    fireRate: 12
+    fireRate: 7
     soundGunshot:
       path: /Audio/_Crescent/Weapons/Guns/supressed_2/supressed_gunshot_2.ogg
       params:
@@ -64,7 +60,7 @@
   name: NCWL DS1 Watchdog 9x19mm
   parent: [BaseWeaponSubMachineGun, StreeCredRedeemable]
   id: WeaponSubMachineGunNCWLWatchdog
-  description: A light submachinegun of communard design. Union Foundries makes these for the common grunt, and the cheap materials probably reflect that.
+  description: A light, easily procurable sub machine gun, produced by the NCWL for Homeguard troops. The complete lack of stock does not breed much faith in the accuracy of this firearm.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/Weapons/Guns/watchdog.rsi
@@ -153,7 +149,7 @@
   name: NCWL DS2 Liberator .327
   parent: [BaseWeaponSubMachineGun, StreeCredRedeemable]
   id: WeaponSubMachineGunBloodhound
-  description: Manufactured for internal use by the Homeguard, the second entry of the Union Foundries focuses primarily on stopping power while sacrificing speed and agility.
+  description: A robust sub machine gun, chambered in a magnum caliber, and issued to lighter armed boarding troops. Beware, the frame of the firearm does not provide much control over the kick of the monsterous .327 cartridge.
   components:
     - type: Sprite
       sprite: _Crescent/Objects/Weapons/Guns/liberator.rsi

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/snipers.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Weapons/snipers.yml
@@ -133,7 +133,7 @@
   name: NCWL PTRD-94 Molot 15.2x169mm
   parent: [BaseWeaponRifleDMR, BaseGunWieldableDMR, StreeCredRedeemable]
   id: WeaponSniperMolot
-  description: A cheap communard anti-materiel. Fires the large 15.2×169mm round.
+  description: A robust yet cheap anti-materiel rifle, designed in Chengridz. Excels at punching walls down, but works on people too.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/Weapons/Guns/molot.rsi


### PR DESCRIPTION
Rewrites the descriptions of most of the NCWL firearms
Removes spread from the DS-3 Militant
Slashes the DS-3 Militant's firerate from 11rps to 7rps (AR-02 and Takemura)