### PR TITLE
orateur, nullweave robes, plates size

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/Empire/OuterClothing/outerclothing.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/Empire/OuterClothing/outerclothing.yml
@@ -41,7 +41,7 @@
       - ClothingOuterHardsuitClarizianWorker
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, StreeCredRedeemableHigh]
+  parent: [ClothingOuterHardsuitBase, StreeCredRedeemableHigh, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitInspector
   name: mk. IV 'ORATEUR' combat hardsuit
   description: A modular combat hardsuit for the Advocati Compliance Corps. Bears the colors of the Kaiserin's administration.
@@ -61,11 +61,11 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 25
-        Slash: 25
-        Piercing: 50
-        Heat: 25
-        Caustic: 25
+        Blunt: 8
+        Slash: 8
+        Piercing: 4
+        Heat: 6
+        Caustic: 6
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -745,11 +745,10 @@
     armorRepair: PlasteelPlate
     initialModifiers:
       flatReductions:
-        Blunt: 10
-        Slash: 20
-        Piercing: 20
-        Heat: 20
-        Caustic: 25
+        Blunt: 4
+        Heat: 4
+        Cold: 4
+        Caustic: 4
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/armor_inserts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/armor_inserts.yml
@@ -84,7 +84,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: steel
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,2,2
   - type: ArmorPlateItem
@@ -126,7 +126,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: ceramic
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,2,2
   - type: ArmorPlateItem
@@ -169,7 +169,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: plasteel
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,2,2
   - type: ArmorPlateItem
@@ -211,7 +211,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: PCK
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,2,2
   - type: ArmorPlateItem
@@ -254,7 +254,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: steel
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,3,3
   - type: ArmorPlateItem
@@ -296,7 +296,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: plastic
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,3,3
   - type: ArmorPlateItem
@@ -336,7 +336,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: ceramic
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,3,3
   - type: ArmorPlateItem
@@ -379,7 +379,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: plasteel
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,3,3
   - type: ArmorPlateItem
@@ -421,7 +421,7 @@
     sprite: _Crescent/Clothing/armorSprites.rsi
     state: PCK
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,3,3
   - type: ArmorPlateItem


### PR DESCRIPTION
- Brings the orateur and nullweave robes suits in line with other DSM hardsuits. Orateur can now fit plates, nullweave is slightly weaker than a worker suit.
- Upsizes plates to no longer fit in pockets

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
