### PR TITLE
Phase Prevent Fix and Another.Turret.Rebalance.

### DIFF
--- a/Content.Server/_Crescent/ProjectilePhasePreventSystem.cs
+++ b/Content.Server/_Crescent/ProjectilePhasePreventSystem.cs
@@ -1,197 +1,198 @@
 using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
-using Content.Server.Lightning;
 using Content.Shared._Crescent;
-using Content.Shared._Lavaland.Weapons;
 using Content.Shared.Projectiles;
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
-using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Threading;
 
-
-/// <summary>
-///  Written by MLGTASTICa/SPCR 2025 for Hullrot EE
-///  This was initially using RobustParallel Manager, but the implementation is horrendous for this kind of task (threadPooling (fake c# threads) instead of high-performance single CPU threads)
-///  This system is expected to be ran on objects that DO not have any HARD-FIXTURES. As in all-collision events are handled only by this and not by physics due to actual body collision.
-/// </summary>
-///
-public class ProjectilePhasePreventerSystem : EntitySystem
+public sealed class ProjectilePhasePreventerSystem : EntitySystem
 {
     [Dependency] private readonly PhysicsSystem _phys = default!;
     [Dependency] private readonly TransformSystem _trans = default!;
-    [Dependency] private readonly RayCastSystem _raycast = default!;
-    [Dependency] private readonly IParallelManager _parallel = default!;
     [Dependency] private readonly ILogManager _logs = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly MapSystem _map = default!;
-    private EntityQuery<PhysicsComponent> physQuery;
-    private EntityQuery<FixturesComponent> fixtureQuery;
-    private List<RaycastBucket> processingBuckets = new();
-    public required ISawmill sawLogs;
-    /// <summary>
-    ///  how many rays will be put per thread
-    ///
-    /// </summary>
-    internal const int raysPerThread = 150;
 
-    public class RaycastBucket()
-    {
-        public HashSet<Entity<ProjectilePhasePreventComponent, ProjectileComponent>> items = new();
-        public List<HullrotBulletHitEvent> output = new();
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    private EntityQuery<FixturesComponent> _fixturesQuery;
 
-    };
+    private readonly HashSet<Entity<ProjectilePhasePreventComponent, ProjectileComponent>> _projectiles = new();
+
+    private ISawmill _sawmill = default!;
+
+    // xtra forgiveness beyond the projectile's exact movement distance. modify this if we ever raise tps opr have issues with phasing again
+    private const float RaycastExtraDistance = 2f;
+
+    // prevents tiny zero-length raycasts
+    private const float MinimumTravelDistance = 0.001f;
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<ProjectilePhasePreventComponent, ComponentStartup>(OnInit);
-        SubscribeLocalEvent<ProjectilePhasePreventComponent, ComponentShutdown>(OnRemove);
-        processingBuckets.Add(new RaycastBucket());
-        fixtureQuery = GetEntityQuery<FixturesComponent>();
-        physQuery = GetEntityQuery<PhysicsComponent>();
-        sawLogs = _logs.GetSawmill("Phase-Prevention");
+        base.Initialize();
+
+        SubscribeLocalEvent<ProjectilePhasePreventComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ProjectilePhasePreventComponent, ComponentShutdown>(OnShutdown);
+
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        _fixturesQuery = GetEntityQuery<FixturesComponent>();
+
+        _sawmill = _logs.GetSawmill("Phase-Prevention");
     }
 
-    private void OnInit(EntityUid uid, ProjectilePhasePreventComponent comp, ref ComponentStartup args)
+    private void OnStartup(EntityUid uid, ProjectilePhasePreventComponent comp, ref ComponentStartup args)
     {
         if (!TryComp<ProjectileComponent>(uid, out var projectile))
         {
-            sawLogs.Error($"Tried to initialize ProjectilePhasePreventComponent on entity without projectileComponent. Prototype : {MetaData(uid).EntityPrototype?.ID}");
+            _sawmill.Error($"Tried to initialize ProjectilePhasePreventComponent on entity without ProjectileComponent. Prototype: {MetaData(uid).EntityPrototype?.ID}");
             RemComp<ProjectilePhasePreventComponent>(uid);
             return;
-
         }
+
         comp.start = _trans.GetWorldPosition(uid);
         comp.mapId = _trans.GetMapId(uid);
-        /* Handled by  datafield in component.
-        foreach(var (key , fixture) in Comp<FixturesComponent>(uid).Fixtures)
-        {
-            comp.relevantBitmasks |= fixture.CollisionLayer;
-        };
-        */
-        if (processingBuckets.Last().items.Count >= raysPerThread)
-        {
-            processingBuckets.Add(new RaycastBucket());
-        }
-        processingBuckets.Last().items.Add((uid, comp, projectile));
-        comp.containedAt = processingBuckets.Last();
 
+        _projectiles.Add((uid, comp, projectile));
     }
 
-    private void OnRemove(EntityUid uid, ProjectilePhasePreventComponent comp, ref ComponentShutdown args)
+    private void OnShutdown(EntityUid uid, ProjectilePhasePreventComponent comp, ref ComponentShutdown args)
     {
         if (!TryComp<ProjectileComponent>(uid, out var projectile))
-        {
-            sawLogs.Error($"Failed to remot entity without projectileComponent. Prototype : {MetaData(uid).EntityPrototype?.ID} [] ID : {uid}");
             return;
-        }
-        if (comp.containedAt is RaycastBucket bucket)
-        {
-            bucket.items.Remove((uid, comp, projectile));
-            if (bucket.items.Count == 0 && processingBuckets.Count > 1)
-            {
-                processingBuckets.Remove(bucket);
-            }
-        }
 
+        _projectiles.Remove((uid, comp, projectile));
     }
 
-
-    public override void Update(float frametime)
+    public override void Update(float frameTime)
     {
-        Parallel.ForEach(processingBuckets, args =>
+        base.Update(frameTime);
+
+        foreach (var (owner, phase, projectile) in _projectiles)
         {
-            args.output.Clear();
-            Vector2 worldPos;
-            foreach(var (owner,  phase, projectile) in args.items)
+            if (TerminatingOrDeleted(owner))
+                continue;
+
+            if (!_physicsQuery.TryGetComponent(owner, out var bulletPhysics))
+                continue;
+
+            if (!_fixturesQuery.TryGetComponent(owner, out var bulletFixtures))
+                continue;
+
+            if (bulletFixtures.Fixtures.Count == 0)
+                continue;
+
+            var currentPos = _trans.GetWorldPosition(owner);
+            var currentMap = _trans.GetMapId(owner);
+
+            // Never raycast across maps
+            if (currentMap != phase.mapId)
             {
-                // will be removed through events. Just skip for now
-                if (TerminatingOrDeleted(owner))
-                    continue;
-                if (Deleted(owner)) //.2 2025 - MLG said we should do this because it fixes the metadata error
-                    continue;         // its trying to run this shit on a deleting entity so
-                worldPos = _trans.GetWorldPosition(owner);
-                if ((worldPos - phase.start).IsLengthZero())
-                    continue;
-                CollisionRay ray = new CollisionRay(worldPos, (phase.start - worldPos).Normalized(), phase.relevantBitmasks);
-                var rayLength = (phase.start - worldPos).Length();
-                phase.start = worldPos;
-                var bulletFixtures = fixtureQuery.GetComponent(owner);
-                var bulletString = bulletFixtures.Fixtures.Keys.First();
-                var checkUid = EntityUid.Invalid;
-                if (!TryComp<TransformComponent>(projectile.Weapon, out var projectileWeaponTransform))
-                    continue;
-                if (projectile.Weapon is not null && projectileWeaponTransform.GridUid is not null)
-                    checkUid = projectileWeaponTransform.GridUid!.Value;
-                foreach (var hit in _phys.IntersectRay(_trans.GetMapId(owner), ray,rayLength, projectile.Weapon, false))
+                phase.start = currentPos;
+                phase.mapId = currentMap;
+                continue;
+            }
+
+            var previousPos = phase.start;
+            var delta = currentPos - previousPos;
+            var distance = delta.Length();
+
+            if (distance <= MinimumTravelDistance)
+                continue;
+
+            var direction = delta / distance;
+            var perpendicular = new Vector2(-direction.Y, direction.X);
+            var rayStarts = new[]
+            {
+                previousPos,
+            };
+
+            var bulletFixturePair = bulletFixtures.Fixtures.First();
+            var bulletFixtureKey = bulletFixturePair.Key;
+
+            var ignoredGrid = EntityUid.Invalid;
+
+            if (projectile.Weapon != null &&
+                TryComp<TransformComponent>(projectile.Weapon, out var weaponXform) &&
+                weaponXform.GridUid != null)
+            {
+                ignoredGrid = weaponXform.GridUid.Value;
+            }
+
+            var hitSomething = false;
+
+            foreach (var rayStart in rayStarts)
+            {
+                var ray = new CollisionRay(rayStart, direction, phase.relevantBitmasks);
+
+                foreach (var hit in _phys.IntersectRay(
+                             currentMap,
+                             ray,
+                             distance + RaycastExtraDistance,
+                             projectile.Weapon,
+                             false))
                 {
-                    if (owner == hit.HitEntity)
+                    var hitEntity = hit.HitEntity;
+
+                    if (hitEntity == owner)
                         continue;
-                    // whilst the raycast supports a filter function . i do not want to package variabiles in lambdas in bulk
-                    if (projectile.Shooter == hit.HitEntity && projectile.IgnoreShooter)
+
+                    if (projectile.IgnoreShooter && projectile.Shooter == hitEntity)
                         continue;
-                    if (projectile.IgnoredEntities.Contains(hit.HitEntity))
+
+                    if (projectile.IgnoredEntities.Contains(hitEntity))
                         continue;
-                    if (!TryComp<TransformComponent>(hit.HitEntity, out var hitTransform))
+
+                    if (!TryComp<TransformComponent>(hitEntity, out var hitXform))
                         continue;
-                    // dont raise these. We cut some slack for the main thread by running it here.
-                    if (hitTransform.GridUid is not null && checkUid == hitTransform.GridUid && projectile.IgnoreWeaponGrid)
+
+                    if (projectile.IgnoreWeaponGrid &&
+                        ignoredGrid != EntityUid.Invalid &&
+                        hitXform.GridUid == ignoredGrid)
+                    {
                         continue;
-                    var targetPhysics = physQuery.GetComponent(hit.HitEntity);
-                    PhysicsComponent bulletPhysics = physQuery.GetComponent(owner);
-                    var targetFixtures = fixtureQuery.GetComponent(hit.HitEntity);
-                    var targetString = targetFixtures.Fixtures.Keys.First();
-                    // i hate how verbose this is. - SPCR 2025
-                    var bulletEvent = new HullrotBulletHitEvent()
+                    }
+
+                    if (!_physicsQuery.TryGetComponent(hitEntity, out _))
+                        continue;
+
+                    if (!_fixturesQuery.TryGetComponent(hitEntity, out var targetFixtures))
+                        continue;
+
+                    if (targetFixtures.Fixtures.Count == 0)
+                        continue;
+
+                    var targetFixturePair = targetFixtures.Fixtures.First();
+
+                    var bulletEvent = new HullrotBulletHitEvent
                     {
                         selfEntity = owner,
-                        hitEntity = hit.HitEntity,
-                        selfFixtureKey = bulletString,
-                        targetFixture = targetFixtures.Fixtures.Values.First(),
-                        targetFixtureKey = targetString,
+                        hitEntity = hitEntity,
+                        selfFixtureKey = bulletFixtureKey,
+                        targetFixture = targetFixturePair.Value,
+                        targetFixtureKey = targetFixturePair.Key,
                         selfPhys = bulletPhysics
                     };
 
-                    args.output.Add(bulletEvent);
+                    try
+                    {
+                        RaiseLocalEvent(owner, ref bulletEvent, true);
+                    }
+                    catch (Exception e)
+                    {
+                        _sawmill.Error($"Failed to raise phase-prevent hit event: {e}");
+                    }
+
+                    hitSomething = true;
+                    break;
                 }
 
+                if (hitSomething)
+                    break;
             }
-        });
 
-        if (processingBuckets.Count > 3)
-        {
-            sawLogs.Info($"Processing {processingBuckets.Count} buckets with estimated bullet count of {processingBuckets.Count * raysPerThread}");
+            // Update after all raycasts.
+            phase.start = currentPos;
+            phase.mapId = currentMap;
         }
-
-        var count = 0;
-        foreach (var bucket in processingBuckets)
-        {
-            foreach(var eventData in bucket.output)
-            {
-                if (TerminatingOrDeleted(eventData.selfEntity) || TerminatingOrDeleted(eventData.hitEntity))
-                    continue;
-                var fEv = eventData;
-                try
-                {
-                    count++;
-                    RaiseLocalEvent(eventData.selfEntity, ref fEv, true);
-                    //Logger.Debug($"Raised event on {MetaData(eventData.selfEntity).EntityName}"); //dont think we need this anymore .2 | 2025
-                }
-                catch (Exception e)
-                {
-                    sawLogs.Error(e.Message);
-                }
-            }
-        }
-        if (processingBuckets.Count > 3)
-        {
-            sawLogs.Info($"Processed {count} events on main-thread");
-        }
-
-
     }
 }

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Hybrid/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Hybrid/projectiles.yml
@@ -5,7 +5,10 @@
   parent: BaseBulletTrigger
   categories: [ HideSpawnMenu ]
   components:
-  - type: ProjectilePhasePrevent # still do not remove
+  - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Circle
     color: "#ea86f7" #you have no idea how hard it was to see the previous IFF color
@@ -34,6 +37,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Circle
     color: "#ea86f7"
@@ -69,6 +75,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Circle
     color: "#ea86f7"

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Hybrid/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Hybrid/projectiles.yml
@@ -20,7 +20,7 @@
     color: purple
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 11.8 #1000
+    lifetime: 4.2
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
     layers:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Hybrid/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Hybrid/turrets.yml
@@ -30,7 +30,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 80
+      projectileSpeed: 140
       fireRate: 8
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Laser/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Laser/projectiles.yml
@@ -36,6 +36,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -67,6 +70,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -128,6 +134,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -155,6 +164,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Laser/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Laser/projectiles.yml
@@ -72,7 +72,7 @@
     ignoreWeaponGrid: true
     damage:
       types:
-        Heat: 4
+        Heat: 40
   - type: ProjectileIFF
     visualType: Circle
     color: Red
@@ -81,7 +81,7 @@
     color: blue
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 3 #540
+    lifetime: 2.36
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/lasers.rsi
     layers:
@@ -98,6 +98,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -112,7 +115,7 @@
     color: blue
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 10.1 #1062
+    lifetime: 3.167
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/lasers.rsi
     layers:
@@ -139,7 +142,7 @@
     color: blue
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 18.2 #2000m
+    lifetime: 8
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/lasers.rsi
     layers:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Laser/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Laser/turrets.yml
@@ -170,8 +170,8 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 180
-      fireRate: 20
+      projectileSpeed: 330
+      fireRate: 10
       selectedMode: FullAuto
       availableModes:
         - FullAuto
@@ -231,7 +231,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 105
+      projectileSpeed: 300
       burstFireRate: 20
       burstCooldown: .2
       shotsPerBurst: 3
@@ -340,7 +340,7 @@
         gun_magazine: !type:ContainerSlot
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 110
+      projectileSpeed: 250
       burstFireRate: 20 #6.67 effective RPS
       burstCooldown: 1.05
       shotsPerBurst: 10

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Missile/projectiles.yml
@@ -7,6 +7,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -146,6 +149,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -298,6 +304,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -507,6 +516,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -568,75 +580,6 @@
       - !type:ExplodeBehavior
   # - type: IgnoresHullrotShields
 
-# - type: entity
-#   id: ProjectileGargoyleNCWL
-#   name: homeguard-issue 240mm heatseeking heavy torpedo
-#   description: Shit.
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ShipWeaponProjectile
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 1000
-#         Blunt: 200
-#   - type: TimedDespawn
-#     lifetime: 40 #2040m
-#   - type: Sprite
-#     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/gargoyle.rsi
-#     layers:
-#       - state: ncwlgargoylefired
-#   - type: ExplodeOnTrigger
-#   - type: Explosive
-#     explosionType: Default
-#     maxIntensity: 750
-#     intensitySlope: 50
-#     totalIntensity: 8000
-#     maxTileBreak: 16
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: ProjectileIFF
-#     visualType: SquareReticle
-#     color: Red
-#   - type: HeatSeeking
-#     rotationSpeed: 10
-#     acceleration: 35
-#     topSpeed: 110
-#     fieldOfView: 25
-#     defaultSeekingRange: 2300
-#     guidanceAlgorithm: PurePursuit
-#   - type: Fixtures
-#     fixtures:
-#       projectile:
-#         shape:
-#           !type:PhysShapeAabb
-#           bounds: "-0.25,-0.45,0.25,0.25"
-#         layer:
-#         - BulletImpassable
-#         mask:
-#         - Impassable
-#         - BulletImpassable
-#         hard: true
-#         density: 100
-#   - type: Damageable
-#     damageContainer: StructuralInorganic
-#     damageModifierSet: StructuralMetallic
-#   - type: Destructible
-#     thresholds:
-#     - trigger:
-#         !type:DamageTrigger
-#         damage: 900 #its a very slow and not agile missile
-#       behaviors:
-#       - !type:DoActsBehavior
-#         acts: [ "Destruction" ]
-#       - !type:ExplodeBehavior
-#   - type: IgnoresHullrotShields
-
 #catapult
 
 - type: entity
@@ -647,6 +590,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -719,6 +665,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     damage:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Missile/projectiles.yml
@@ -15,7 +15,7 @@
         Structural: 200
         Blunt: 50
   - type: TimedDespawn
-    lifetime: 10.7 #1500m
+    lifetime: 10
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/shortbow.rsi
     layers:
@@ -154,7 +154,7 @@
         Structural: 250
         Blunt: 100
   - type: TimedDespawn
-    lifetime: 20
+    lifetime: 10
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/azimuth.rsi
     layers:
@@ -306,7 +306,7 @@
         Structural: 500
         Blunt: 200
   - type: TimedDespawn
-    lifetime: 45.4 #2496
+    lifetime: 31.25
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/arbalest.rsi
     layers:
@@ -515,7 +515,7 @@
         Structural: 1000
         Blunt: 200
   - type: TimedDespawn
-    lifetime: 80 #3996
+    lifetime: 80
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/gargoyle.rsi
     layers:
@@ -655,7 +655,7 @@
         Structural: 1250
         Blunt: 500
   - type: TimedDespawn
-    lifetime: 111.1 #4998
+    lifetime: 112.5
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/catapult.rsi
     layers:
@@ -726,7 +726,7 @@
         Structural: 125
         Blunt: 40
   - type: TimedDespawn
-    lifetime: 25 #1250m + Lock on = 1650m
+    lifetime: 5.714
   - type: Sprite
     sprite: _Crescent/Objects/Turrets/Ammunition/Projectiles/shortbow.rsi
     layers:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Missile/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Missile/turrets.yml
@@ -31,7 +31,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 75
+      projectileSpeed: 120
       fireRate: 2
       selectedMode: FullAuto
       availableModes:
@@ -97,7 +97,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 60
+      projectileSpeed: 150
       fireRate: 1
       selectedMode: FullAuto
       availableModes:
@@ -189,7 +189,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 55
+      projectileSpeed: 80
       fireRate: 0.2
       selectedMode: FullAuto
       availableModes:
@@ -370,7 +370,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 45
+      projectileSpeed: 40
       fireRate: 0.1
       selectedMode: FullAuto
       availableModes:
@@ -423,7 +423,7 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 80
+      projectileSpeed: 140
       fireRate: 4
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/magazines.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/magazines.yml
@@ -57,7 +57,7 @@
       tags:
         - Cartridge35mm
     proto: Cartridge35mm
-    capacity: 150
+    capacity: 100
     soundRack:
       path: /Audio/Weapons/Guns/Bolt/lmg_bolt_closed.ogg
       params:
@@ -450,7 +450,7 @@
   id: PowerCageGlare
   parent: BaseItem
   name: Power Cage - Glare
-  description: A rechargeable power cage, configured for use as as a power source for 'Glare' ship-laser weaponry and its variants. 
+  description: A rechargeable power cage, configured for use as as a power source for 'Glare' ship-laser weaponry and its variants.
   components:
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/projectiles.yml
@@ -6,6 +6,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Circle
     color: White
@@ -59,42 +62,6 @@
       - state: base-projectile
   - type: ShipWeaponProjectile
 
-# - type: entity
-#   id: Bullet20mmFrag # DONTUSE
-#   name: 20mm fragmentation projectile
-#   description: Uh oh.
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ProjectileIFF
-#     visualType: Circle
-#     color: White
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 10
-#         Piercing: 40
-#   - type: ExplodeOnTrigger
-#   - type: Explosive
-#     explosionType: Fragmentation #basically a small grenade
-#     maxIntensity: 5
-#     intensitySlope: 3
-#     totalIntensity: 100
-#     maxTileBreak: 0
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: TimedDespawn
-#     lifetime: 3 #501
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
-#     layers:
-#       - state: base-projectile
-#   - type: ShipWeaponProjectile
-
 - type: entity
   id: Bullet35mmBase
   name: 35mm Armor Piercing projectile
@@ -103,6 +70,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Circle
     color: White
@@ -124,42 +94,6 @@
       - state: base-projectile
   - type: ShipWeaponProjectile
 
-# - type: entity
-#   id: Bullet35mmHE
-#   name: 35mm High Explosive projectile #DONTUSE
-#   description: Uh oh.
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ProjectileIFF
-#     visualType: Circle
-#     color: White
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 25
-#         Piercing: 75
-#   - type: ExplodeOnTrigger
-#   - type: Explosive
-#     explosionType: Default
-#     maxIntensity: 15
-#     intensitySlope: 10
-#     totalIntensity: 350
-#     maxTileBreak: 0
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: TimedDespawn
-#     lifetime: 15 #1800
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
-#     layers:
-#       - state: base-projectile
-#   - type: ShipWeaponProjectile
-
 #50mm
 
 - type: entity
@@ -169,6 +103,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Square
     color: White
@@ -190,76 +127,6 @@
     layers:
       - state: base-projectile
 
-# - type: entity
-#   id: Bullet50mmHE #DONTUSE
-#   name: 50mm High Explosive projectile
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ProjectileIFF
-#     visualType: Square
-#     color: White
-#   - type: ShipWeaponProjectile
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 50
-#         Piercing: 50
-#   - type: ExplodeOnTrigger
-#   - type: Explosive
-#     explosionType: Default
-#     maxIntensity: 25
-#     intensitySlope: 15
-#     totalIntensity: 500
-#     maxTileBreak: 0
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: TimedDespawn
-#     lifetime: 10 #1500
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
-#     layers:
-#       - state: base-projectile
-
-# - type: entity
-#   id: Bullet50mmSAPHE #DONTUSE
-#   name: 50mm SAPHE projectile
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ProjectileIFF
-#     visualType: Square
-#     color: White
-#   - type: ShipWeaponProjectile
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 150
-#         Piercing: 150
-#   - type: ExplodeOnTrigger
-#   - type: Explosive
-#     explosionType: Default
-#     maxIntensity: 45
-#     intensitySlope: 50
-#     totalIntensity: 300
-#     maxTileBreak: 0
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: TimedDespawn
-#     lifetime: 10 #1500
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
-#     layers:
-#       - state: base-projectile
-
 #Resolute DONTUSE
 
 - type: entity
@@ -273,6 +140,9 @@
     color: White
   - type: ShipWeaponProjectile
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: Projectile
     ignoreWeaponGrid: true
     damage:
@@ -297,34 +167,6 @@
     layers:
       - state: base-projectile
 
-# - type: entity
-#   id: Bullet90mmAP
-#   name: 90mm Armor Piercing shell
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectileIFF
-#     visualType: Square
-#     color: White
-#   - type: ShipWeaponProjectile
-#   - type: ProjectilePhasePrevent
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 2000
-#         Piercing: 500
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: TimedDespawn
-#     lifetime: 20 #3000m
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/mortarcasing.rsi
-#     layers:
-#       - state: base-projectile
-
 - type: entity
   id: Bullet90mmBase
   name: 90mm Armor Piercing High Explosive shell
@@ -335,6 +177,9 @@
     visualType: Square
     color: White
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true
@@ -369,6 +214,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Diamond
     color: White
@@ -397,76 +245,6 @@
     energy: 0.5
   - type: ShipWeaponProjectile
 
-# - type: entity
-#   id: Bullet120mmFlux
-#   name: 120mm Flux-core Armor Piercing shell
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ProjectileIFF
-#     visualType: Diamond
-#     color: White
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 750
-#         Piercing: 250
-#   - type: TimedDespawn
-#     lifetime: 10 #2000m
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
-#     layers:
-#       - state: base-projectile
-#   - type: ExplodeOnTrigger
-#   - type: EmpOnTrigger
-#     range: 4
-#     energyConsumption: 4500 #IPCs hate this... (nap time)
-#     disableDuration: 4
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: ShipWeaponProjectile
-
-# - type: entity
-#   id: Bullet120mmFlak
-#   name: 120mm Flak shell
-#   parent: BaseBulletTrigger
-#   categories: [ HideSpawnMenu ]
-#   components:
-#   - type: ProjectilePhasePrevent
-#   - type: ProjectileIFF
-#     visualType: Diamond
-#     color: White
-#   - type: Projectile
-#     ignoreWeaponGrid: true
-#     damage:
-#       types:
-#         Structural: 250
-#         Piercing: 250
-#   - type: TimedDespawn
-#     lifetime: 10 #2000m
-#   - type: Sprite
-#     sprite: _NF/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
-#     layers:
-#       - state: base-projectile
-#   - type: ExplodeOnTrigger
-#   - type: Explosive
-#     explosionType: Default
-#     maxIntensity: 100
-#     intensitySlope: 5
-#     totalIntensity: 5000
-#     maxTileBreak: 1
-#   - type: ProximityFuse
-#     maxRange: 5
-#   - type: PointLight
-#     radius: 3.5
-#     color: orange
-#     energy: 0.5
-#   - type: ShipWeaponProjectile
-
 - type: entity
   id: Bullet300mmBase
   name: 300mm subnuclear artillery shell
@@ -474,6 +252,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: Projectile
     ignoreWeaponGrid: true
     damage:
@@ -509,6 +290,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ShipWeaponProjectile
   - type: Projectile
     ignoreWeaponGrid: true

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/projectiles.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/projectiles.yml
@@ -20,7 +20,7 @@
     color: orange
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 3 #540
+    lifetime: 2.33
   - type: Sprite
     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
     layers:
@@ -35,6 +35,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ProjectilePhasePrevent
+    mask:
+    - Impassable
+    - BulletImpassable
   - type: ProjectileIFF
     visualType: Circle
     color: White
@@ -49,7 +52,7 @@
     color: orange
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 7.7 #850
+    lifetime: 3
   - type: Sprite
     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
     layers:
@@ -114,7 +117,7 @@
     color: orange
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 9.8 #980
+    lifetime: 4
   - type: Sprite
     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
     layers:
@@ -181,7 +184,7 @@
     color: orange
     energy: 0.5
   - type: TimedDespawn
-    lifetime: 15.8 #1500
+    lifetime: 6.7
   - type: Sprite
     sprite: _NF/Objects/SpaceArtillery/pdtcasing.rsi
     layers:
@@ -376,7 +379,7 @@
         Structural: 950
         Piercing: 300
   - type: TimedDespawn
-    lifetime: 22.2 #1995
+    lifetime: 10
   - type: Sprite
     sprite: _NF/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
     layers:
@@ -517,7 +520,7 @@
     tags:
       - FlakShell
   - type: TimedDespawn
-    lifetime: 15 #1500m
+    lifetime: 4
   - type: Sprite
     sprite: _Crescent/Objects/ShuttleWeapons/flak.rsi
     layers:

--- a/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Turrets/Projectile/turrets.yml
@@ -30,8 +30,8 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 180
-      fireRate: 20
+      projectileSpeed: 300
+      fireRate: 10
       selectedMode: FullAuto
       availableModes:
         - FullAuto
@@ -98,7 +98,7 @@
     - type: Gun
       fireOnDropChance: 0
       fireRate: 10
-      projectileSpeed: 110
+      projectileSpeed: 280
       selectedMode: FullAuto
       availableModes:
         - FullAuto
@@ -227,7 +227,7 @@
     - type: Gun
       fireOnDropChance: 0
       fireRate: 18
-      projectileSpeed: 100
+      projectileSpeed: 280
       angleDecay: 0.75
       minAngle: 1.5
       maxAngle: 2.5
@@ -291,7 +291,7 @@
     - type: MagazineAmmoProvider
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 100
+      projectileSpeed: 250
       burstFireRate: 20
       shotsPerBurst: 2
       burstCooldown: 0.20
@@ -426,7 +426,7 @@
                 collection: MetalGlassBreak
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 95
+      projectileSpeed: 220
       fireRate: 4
       selectedMode: FullAuto
       availableModes:
@@ -563,7 +563,7 @@
         ballistic-ammo: !type:Container
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 90
+      projectileSpeed: 200
       fireRate: 0.6
       selectedMode: FullAuto
       availableModes:
@@ -831,8 +831,8 @@
           ents: []
     - type: Gun
       fireOnDropChance: 0
-      projectileSpeed: 80
-      fireRate: 1.5
+      projectileSpeed: 200
+      fireRate: 3
       selectedMode: FullAuto
       availableModes:
         - FullAuto


### PR DESCRIPTION
I fixed the Phase Prevent system to the best of my abilities, I would like to visit it again but I've attached clips of it working on Local. 

https://medal.tv/games/requested/clips/mBxd5IEXW6O6Zey4x?invite=cr-MSxrU3IsNDAzMTAyMTI1&v=67
This is with a 300velocity projectile, that visual bug of the projectile phasing is annoying, but it's just a phantom, this is preferably to projectiles just phasing through walls and killing you
Only significant issue is some items messing with the raycast weirdly, I need to investigate why but I assume it's simple enough. At least now, projectiles should never phase through walls. Should! 

Turrets have been rebalanced completely to use our new velocity cap! I've also separated Ultralight weapons from normal ship mounted turrets. Ultralight speed advantages allows them to control the battlefield and when give similarly ranged weapons to larger combat shuttles, they control the battlefield completely, now instead they are forced to chose their approach more carefully  and commit to engagements.

I've standarized velocities across the board and reworked range progression to define engagement ranges. 
Weapons are grouped into these roles now
Point Defense (PDT): High velocity, short range, interception-focused
Light Cannons: Flexible, direct-fire combat weapons
Energy Weapons: Sustained fire, power-dependent systems
Artillery: Long-range, low-rate, high-impact weapons

The 300cc hybrid cannon has been retired, it overlapped on too many roles and was not necessary.
The 60mm is a outliar in missile balance as it is the only unguided missile, it is also the only missile to ignore shields.

Pending tweaks from playtesting, this is the last overhaul I am doing with turrets, it's finally in a spot that I am mostly happy with