### PR TITLE
Global increase to civilian shipyard maxspeeds

### DIFF
--- a/Resources/Maps/_Crescent/Shuttles/Civilian/birdie.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/birdie.yml
@@ -59,7 +59,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 30
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/cockroach.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/cockroach.yml
@@ -90,6 +90,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/comet.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/comet.yml
@@ -69,7 +69,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/dungbeetle.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/dungbeetle.yml
@@ -61,7 +61,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 45
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/exhumer.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/exhumer.yml
@@ -73,7 +73,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 30
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/hammerhead.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/hammerhead.yml
@@ -74,7 +74,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 15
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/homesteader.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/homesteader.yml
@@ -73,7 +73,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/kite.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/kite.yml
@@ -66,7 +66,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/manatee.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/manatee.yml
@@ -67,7 +67,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/mercury.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/mercury.yml
@@ -62,7 +62,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/paracelsus.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/paracelsus.yml
@@ -61,7 +61,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/pear.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/pear.yml
@@ -63,7 +63,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/qian.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/qian.yml
@@ -85,6 +85,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/roachling.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/roachling.yml
@@ -59,7 +59,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 45
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/_Crescent/Shuttles/Civilian/termite.yml
+++ b/Resources/Maps/_Crescent/Shuttles/Civilian/termite.yml
@@ -62,7 +62,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      baseMaxLinearVelocity: 25
+      baseMaxLinearVelocity: 35
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

As said in the title, all ships from the civilian shipyard now enjoy a blanket 35 topspeed across the board, the ONLY exception to this are the ULs deployed from the Cockroach which have instead been increased to 45.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
