### PR TITLE
Adjusts NAP armor to the new coefficients

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/NAP/OuterClothing/outerclothing.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/NAP/OuterClothing/outerclothing.yml
@@ -1,7 +1,7 @@
 #hardsuits
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitNAPRangerMEPA
   name: american ranger Mk.V(B) 'MEPA' combat hardsuit
   description: a beaten and well worn combat hardsuit design, the Multiple Environment Personal Armour has been built up from its introduction at the founding of the New American Ranger corps and served its soldiers from foul smelling reservist suits in boot camp to the modern plated harness. The iterative design process has left it particularly weak to blunt impact however.
@@ -15,17 +15,14 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 700
-    armorType: Ceramic
-    armorRepair: PlasteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 25
-        Piercing: 80
-        Heat: 25
-        Caustic: 20
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Heat: 0.8
+        Cold: 0.8
+        Caustic: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -37,7 +34,7 @@
 # armor
 
 - type: entity
-  parent: ClothingOuterBaseLarge
+  parent: [ClothingOuterBaseLarge, ClothingArmorInsert]
   id: ClothingOuterArmorNAPRangerBIPArmorVest
   name: american ranger 'BIP' armor vest
   description: The Ballistic Insert Plated Vest is typically issued to New American Ranger and Marine reservists for in-atmosphere theatres. Concentrating ballistic protection to center mass allows the wearer to retain mobility and lowers weight.
@@ -46,17 +43,14 @@
     sprite: _Crescent/Clothing/NAP/OuterClothing/bipvest.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/NAP/OuterClothing/bipvest.rsi
-  - type: DegradeableArmor
-    armorMaxHealth: 750
-    armorType: Ceramic
-    armorRepair: NTCeramic
-    initialModifiers:
-      flatReductions:
-        Blunt: 25
-        Slash: 25
-        Piercing: 70
-        Heat: 20
-        Caustic: 25
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Heat: 0.9
+        Cold: 0.9
+        Caustic: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: AllowSuitStorage


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Whodathunk you could still get NAP armor from that one wreck, thus making you omega-overpowered? Welp, none of that now.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
