### PR TITLE
Lister and Sunesis light remapping

### DIFF
--- a/Resources/Maps/_Crescent/Shuttles/DSM/Battlecruisers/sunesis.yml
+++ b/Resources/Maps/_Crescent/Shuttles/DSM/Battlecruisers/sunesis.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 268.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/01/2026 11:26:23
-  entityCount: 1129
+  time: 05/03/2026 11:57:14
+  entityCount: 1127
 maps: []
 grids:
 - 1
@@ -61,11 +61,11 @@ entities:
           version: 7
         -1,1:
           ind: -1,1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAB6AAAAAAAACQAAAAAAAAkAAAAAAACCAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAAIIAAAAAAAAFAAAAAAAABQAAAAAAAIIAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAAAAAACCAAAAAAAABQAAAAAAAAUAAAAAAABxAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAAUAAAAAAAAFAAAAAAAAcQAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAABxAAAAAAAAggAAAAAAAIIAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAACCAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIIAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAAB6AAAAAAAAcQAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCAAAAAAAAegAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHEAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAACCAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAAsAAAAAAAALAAAAAAAAcQAAAAAAACIAAAAAAAAiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIIAAAAAAAALAAAAAAAACwAAAAAAAIIAAAAAAABxAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAIIAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBAAAAAAAAggAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAB6AAAAAAAACQAAAAAAAAkAAAAAAACCAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAAAAAIIAAAAAAAAFAAAAAAAABQAAAAAAAIIAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAAAAAACCAAAAAAAABQAAAAAAAAUAAAAAAABxAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAAUAAAAAAAAFAAAAAAAAcQAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAABxAAAAAAAAggAAAAAAAIIAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAACCAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIIAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAAB6AAAAAAAAcQAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCAAAAAAAAegAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHEAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAACCAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAAsAAAAAAAALAAAAAAAAcQAAAAAAACIAAAAAAAAiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIIAAAAAAAALAAAAAAAACwAAAAAAAIIAAAAAAABxAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAIIAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBAAAAAAAAggAAAAAAAA==
           version: 7
         0,1:
           ind: 0,1
-          tiles: AwAAAAAAAAMAAAAAAABxAAAAAAAAcQAAAAAAAHEAAAAAAABxAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAAAiAAAAAAAAIgAAAAAAACIAAAAAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAABxAAAAAAAAIgAAAAAAACIAAAAAAAAiAAAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAggAAAAAAACIAAAAAAAAiAAAAAAAAIgAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAACCAAAAAAAAcQAAAAAAAHEAAAAAAAA9AAAAAAAAcQAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAcQAAAAAAAHEAAAAAAABxAAAAAAAAPQAAAAAAAHEAAAAAAACCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAwAAAAAAAHEAAAAAAABxAAAAAAAAcQAAAAAAAD0AAAAAAABxAAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAACCAAAAAAAAcQAAAAAAAHEAAAAAAAA9AAAAAAAAcQAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAABxAAAAAAAAPQAAAAAAAHEAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiAAAAAAAAIgAAAAAAACIAAAAAAABxAAAAAAAAcQAAAAAAAHEAAAAAAABxAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAABxAAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: AwAAAAAAAAMAAAAAAABxAAAAAAAAcQAAAAAAAHEAAAAAAABxAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACBAAAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAAAiAAAAAAAAIgAAAAAAACIAAAAAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAABxAAAAAAAAIgAAAAAAACIAAAAAAAAiAAAAAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAggAAAAAAACIAAAAAAAAiAAAAAAAAIgAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAACCAAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAACCAAAAAAAAcQAAAAAAAHEAAAAAAAA9AAAAAAAAcQAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAcQAAAAAAAHEAAAAAAABxAAAAAAAAPQAAAAAAAHEAAAAAAACCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAwAAAAAAAHEAAAAAAABxAAAAAAAAcQAAAAAAAD0AAAAAAABxAAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAACCAAAAAAAAcQAAAAAAAHEAAAAAAAA9AAAAAAAAcQAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHEAAAAAAACCAAAAAAAAggAAAAAAAIIAAAAAAABxAAAAAAAAPQAAAAAAAHEAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiAAAAAAAAIgAAAAAAACIAAAAAAABxAAAAAAAAcQAAAAAAAHEAAAAAAABxAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAABxAAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAAIIAAAAAAACBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 7
     - type: Broadphase
     - type: Physics
@@ -398,6 +398,13 @@ entities:
             1247: -2,-3
             1256: 9,-1
             1267: -7,20
+            1331: -9,10
+            1337: -7,9
+            1340: -9,-1
+            1345: -5,-2
+            1348: -2,-3
+            1357: 9,-1
+            1368: -7,20
         - node:
             zIndex: 1
             id: LatticeCornerNW
@@ -461,6 +468,14 @@ entities:
             1258: 9,-1
             1291: 7,20
             1296: 7,26
+            1310: 7,9
+            1316: 9,10
+            1342: -9,-1
+            1351: 2,-3
+            1354: 5,-2
+            1359: 9,-1
+            1392: 7,20
+            1397: 7,26
         - node:
             zIndex: 1
             id: LatticeCornerSE
@@ -548,6 +563,17 @@ entities:
             1273: -6,29
             1276: -3,30
             1279: -2,31
+            1305: 7,6
+            1325: -14,4
+            1328: -10,5
+            1334: -7,6
+            1371: -7,26
+            1374: -6,29
+            1377: -3,30
+            1380: -2,31
+            1406: 7,17
+            1414: -7,17
+            1419: -9,16
         - node:
             zIndex: 1
             id: LatticeCornerSW
@@ -638,6 +664,17 @@ entities:
             1295: 7,26
             1299: 7,27
             1302: 9,16
+            1307: 7,6
+            1313: 8,6
+            1319: 10,5
+            1322: 14,4
+            1383: 2,31
+            1386: 3,30
+            1396: 7,26
+            1400: 7,27
+            1408: 7,17
+            1411: 9,16
+            1416: -7,17
         - node:
             id: LatticeEdgeE
           decals:
@@ -780,6 +817,24 @@ entities:
             1272: -6,29
             1275: -3,30
             1278: -2,31
+            1304: 7,6
+            1324: -14,4
+            1327: -10,5
+            1329: -9,10
+            1333: -7,6
+            1335: -7,9
+            1338: -9,-1
+            1343: -5,-2
+            1346: -2,-3
+            1355: 9,-1
+            1366: -7,20
+            1370: -7,26
+            1373: -6,29
+            1376: -3,30
+            1379: -2,31
+            1405: 7,17
+            1413: -7,17
+            1418: -9,16
         - node:
             id: LatticeEdgeN
           decals:
@@ -882,6 +937,19 @@ entities:
             1266: -7,20
             1289: 7,20
             1293: 7,26
+            1308: 7,9
+            1314: 9,10
+            1330: -9,10
+            1336: -7,9
+            1339: -9,-1
+            1344: -5,-2
+            1347: -2,-3
+            1349: 2,-3
+            1352: 5,-2
+            1356: 9,-1
+            1367: -7,20
+            1390: 7,20
+            1394: 7,26
         - node:
             id: LatticeEdgeS
           decals:
@@ -1032,6 +1100,25 @@ entities:
             1292: 7,26
             1297: 7,27
             1300: 9,16
+            1303: 7,6
+            1311: 8,6
+            1317: 10,5
+            1320: 14,4
+            1323: -14,4
+            1326: -10,5
+            1332: -7,6
+            1369: -7,26
+            1372: -6,29
+            1375: -3,30
+            1378: -2,31
+            1381: 2,31
+            1384: 3,30
+            1393: 7,26
+            1398: 7,27
+            1404: 7,17
+            1409: 9,16
+            1412: -7,17
+            1417: -9,16
         - node:
             id: LatticeEdgeW
           decals:
@@ -1177,6 +1264,24 @@ entities:
             1294: 7,26
             1298: 7,27
             1301: 9,16
+            1306: 7,6
+            1309: 7,9
+            1312: 8,6
+            1315: 9,10
+            1318: 10,5
+            1321: 14,4
+            1341: -9,-1
+            1350: 2,-3
+            1353: 5,-2
+            1358: 9,-1
+            1382: 2,31
+            1385: 3,30
+            1391: 7,20
+            1395: 7,26
+            1399: 7,27
+            1407: 7,17
+            1410: 9,16
+            1415: -7,17
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
@@ -1230,6 +1335,12 @@ entities:
             1064: 4,23
             1065: 4,24
             1066: 4,25
+        - node:
+            color: '#EFB34196'
+            id: WarnBox
+          decals:
+            1420: 8,17
+            1421: -8,17
         - node:
             angle: 4.71238898038469 rad
             color: '#EFB34196'
@@ -1887,7 +1998,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 152
+      - 146
     - type: Physics
       canCollide: False
 - proto: AAAHardpointSmallEnergy
@@ -1905,6 +2016,20 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-0.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: -7.5,17.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: 8.5,17.5
       parent: 1
     - type: Physics
       canCollide: False
@@ -2018,16 +2143,9 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 30
-    components:
-    - type: Transform
-      parent: 29
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: AmeController
   entities:
-  - uid: 36
+  - uid: 30
     components:
     - type: Transform
       pos: 8.5,4.5
@@ -2039,23 +2157,23 @@ entities:
         fuelSlot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 37
+          ent: 31
 - proto: AmeJar
   entities:
-  - uid: 37
+  - uid: 31
     components:
     - type: Transform
-      parent: 36
+      parent: 30
     - type: Physics
       canCollide: False
 - proto: AmeShielding
   entities:
-  - uid: 38
+  - uid: 32
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 39
+  - uid: 33
     components:
     - type: Transform
       pos: 6.5,3.5
@@ -2063,81 +2181,81 @@ entities:
     - type: PointLight
       radius: 2
       enabled: True
-  - uid: 40
+  - uid: 34
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 41
+  - uid: 35
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 42
+  - uid: 36
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 43
+  - uid: 37
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 44
+  - uid: 38
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 45
+  - uid: 39
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 46
+  - uid: 40
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 47
+  - uid: 41
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 48
+  - uid: 42
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 49
+  - uid: 43
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 50
+  - uid: 44
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
-  - uid: 51
+  - uid: 45
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 52
+  - uid: 46
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 53
+  - uid: 47
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,29.5
       parent: 1
-  - uid: 54
+  - uid: 48
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2145,336 +2263,336 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 55
+  - uid: 49
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 56
+  - uid: 50
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 57
+  - uid: 51
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,12.5
       parent: 1
-  - uid: 58
+  - uid: 52
     components:
     - type: Transform
       pos: 9.5,12.5
       parent: 1
-  - uid: 59
+  - uid: 53
     components:
     - type: Transform
       pos: 9.5,13.5
       parent: 1
-  - uid: 60
+  - uid: 54
     components:
     - type: Transform
       pos: 9.5,14.5
       parent: 1
-  - uid: 61
+  - uid: 55
     components:
     - type: Transform
       pos: 5.5,27.5
       parent: 1
-  - uid: 62
+  - uid: 56
     components:
     - type: Transform
       pos: 6.5,27.5
       parent: 1
-  - uid: 63
+  - uid: 57
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 64
+  - uid: 58
     components:
     - type: Transform
       pos: 9.5,16.5
       parent: 1
-  - uid: 65
+  - uid: 59
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 1
-  - uid: 66
+  - uid: 60
     components:
     - type: Transform
       pos: -6.5,26.5
       parent: 1
-  - uid: 67
+  - uid: 61
     components:
     - type: Transform
       pos: 7.5,20.5
       parent: 1
-  - uid: 68
+  - uid: 62
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 1
-  - uid: 69
+  - uid: 63
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 1
-  - uid: 70
+  - uid: 64
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 1
-  - uid: 71
+  - uid: 65
     components:
     - type: Transform
       pos: -5.5,29.5
       parent: 1
-  - uid: 72
+  - uid: 66
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
-  - uid: 73
+  - uid: 67
     components:
     - type: Transform
       pos: -6.5,20.5
       parent: 1
-  - uid: 74
+  - uid: 68
     components:
     - type: Transform
       pos: -5.5,19.5
       parent: 1
-  - uid: 75
+  - uid: 69
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-  - uid: 76
+  - uid: 70
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 1
-  - uid: 77
+  - uid: 71
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 1
-  - uid: 78
+  - uid: 72
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 1
-  - uid: 79
+  - uid: 73
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
-  - uid: 80
+  - uid: 74
     components:
     - type: Transform
       pos: 3.5,30.5
       parent: 1
-  - uid: 81
+  - uid: 75
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 82
+  - uid: 76
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 83
+  - uid: 77
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 84
+  - uid: 78
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 85
+  - uid: 79
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 1
-  - uid: 86
+  - uid: 80
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 1
-  - uid: 87
+  - uid: 81
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 88
+  - uid: 82
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 89
+  - uid: 83
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 90
+  - uid: 84
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 91
+  - uid: 85
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 92
+  - uid: 86
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 93
+  - uid: 87
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 94
+  - uid: 88
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 95
+  - uid: 89
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 96
+  - uid: 90
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 97
+  - uid: 91
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 98
+  - uid: 92
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 99
+  - uid: 93
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 100
+  - uid: 94
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 101
+  - uid: 95
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 102
+  - uid: 96
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 103
+  - uid: 97
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 104
+  - uid: 98
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 105
+  - uid: 99
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 106
+  - uid: 100
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 107
+  - uid: 101
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
-  - uid: 108
+  - uid: 102
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 1
-  - uid: 109
+  - uid: 103
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 1
-  - uid: 110
+  - uid: 104
     components:
     - type: Transform
       pos: -8.5,10.5
       parent: 1
-  - uid: 111
+  - uid: 105
     components:
     - type: Transform
       pos: -8.5,16.5
       parent: 1
-  - uid: 112
+  - uid: 106
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 1
-  - uid: 113
+  - uid: 107
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 1
-  - uid: 114
+  - uid: 108
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 1
-  - uid: 115
+  - uid: 109
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
-  - uid: 116
+  - uid: 110
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 1
 - proto: Beaker
   entities:
-  - uid: 117
+  - uid: 111
     components:
     - type: Transform
       pos: -3.2714598,19.573797
       parent: 1
 - proto: Bed
   entities:
-  - uid: 118
+  - uid: 112
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 1
 - proto: BedsheetRD
   entities:
-  - uid: 119
+  - uid: 113
     components:
     - type: MetaData
       desc: Made from fine-spun mothsilk.
@@ -2484,7 +2602,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpCorner
   entities:
-  - uid: 120
+  - uid: 114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2492,7 +2610,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpLeft
   entities:
-  - uid: 121
+  - uid: 115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2500,7 +2618,7 @@ entities:
       parent: 1
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 122
+  - uid: 116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2508,7 +2626,7 @@ entities:
       parent: 1
 - proto: BenchSteelLeft
   entities:
-  - uid: 123
+  - uid: 117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2516,7 +2634,7 @@ entities:
       parent: 1
 - proto: BenchSteelRight
   entities:
-  - uid: 124
+  - uid: 118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2524,16 +2642,16 @@ entities:
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 125
+  - uid: 119
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 822
-      - 152
-  - uid: 126
+      - 818
+      - 146
+  - uid: 120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2541,8 +2659,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 816
-  - uid: 127
+      - 812
+  - uid: 121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2550,8 +2668,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 820
-  - uid: 128
+      - 816
+  - uid: 122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2559,8 +2677,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 820
-  - uid: 129
+      - 816
+  - uid: 123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2568,76 +2686,76 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 820
-  - uid: 130
+      - 816
+  - uid: 124
     components:
     - type: Transform
       pos: 6.5,27.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 822
-      - 152
-  - uid: 131
+      - 818
+      - 146
+  - uid: 125
     components:
     - type: Transform
       pos: 5.5,27.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 822
-      - 152
+      - 818
+      - 146
 - proto: BlastDoorOpen
   entities:
-  - uid: 132
+  - uid: 126
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 817
-  - uid: 133
+      - 813
+  - uid: 127
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 813
-  - uid: 134
+      - 809
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 813
-  - uid: 135
+      - 809
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 813
-  - uid: 136
+      - 809
+  - uid: 130
     components:
     - type: Transform
       pos: -4.5,29.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 814
-  - uid: 137
+      - 810
+  - uid: 131
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 814
-  - uid: 138
+      - 810
+  - uid: 132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2645,8 +2763,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 814
-  - uid: 139
+      - 810
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2654,8 +2772,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 814
-  - uid: 140
+      - 810
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2663,8 +2781,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 821
-  - uid: 141
+      - 817
+  - uid: 135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2672,17 +2790,17 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 821
+      - 817
 - proto: ButtonFrameCaution
   entities:
-  - uid: 142
+  - uid: 136
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 143
+  - uid: 137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2690,47 +2808,47 @@ entities:
       parent: 1
 - proto: ButtonFrameJanitor
   entities:
-  - uid: 144
+  - uid: 138
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,11.5
       parent: 1
-  - uid: 145
+  - uid: 139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 146
+  - uid: 140
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 1
-  - uid: 147
+  - uid: 141
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,28.5
       parent: 1
-  - uid: 148
+  - uid: 142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 149
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,10.5
       parent: 1
-  - uid: 150
+  - uid: 144
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 1
-  - uid: 151
+  - uid: 145
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2738,7 +2856,7 @@ entities:
       parent: 1
 - proto: C_ComputerTabletopShuttle
   entities:
-  - uid: 152
+  - uid: 146
     components:
     - type: Transform
       pos: 0.5,30.5
@@ -2748,13 +2866,13 @@ entities:
         2:
         - - Group1
           - SpaceArtilleryFire
+        119:
+        - - Group2
+          - Toggle
         125:
         - - Group2
           - Toggle
-        131:
-        - - Group2
-          - Toggle
-        130:
+        124:
         - - Group2
           - Toggle
     - type: ContainerContainer
@@ -2780,1009 +2898,1009 @@ entities:
       - Empty Module
 - proto: CableApcExtension
   entities:
-  - uid: 153
+  - uid: 147
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 154
+  - uid: 148
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 155
+  - uid: 149
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 156
+  - uid: 150
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 157
+  - uid: 151
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 158
+  - uid: 152
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 159
+  - uid: 153
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 160
+  - uid: 154
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 161
+  - uid: 155
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 162
+  - uid: 156
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 163
+  - uid: 157
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 164
+  - uid: 158
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 165
+  - uid: 159
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 166
+  - uid: 160
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 167
+  - uid: 161
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 168
+  - uid: 162
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 169
+  - uid: 163
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 170
+  - uid: 164
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
-  - uid: 171
+  - uid: 165
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
-  - uid: 172
+  - uid: 166
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 1
-  - uid: 173
+  - uid: 167
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 1
-  - uid: 174
+  - uid: 168
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 1
-  - uid: 175
+  - uid: 169
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 1
-  - uid: 176
+  - uid: 170
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
-  - uid: 177
+  - uid: 171
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-  - uid: 178
+  - uid: 172
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
-  - uid: 179
+  - uid: 173
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 1
-  - uid: 180
+  - uid: 174
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 1
-  - uid: 181
+  - uid: 175
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 1
-  - uid: 182
+  - uid: 176
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 183
+  - uid: 177
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 184
+  - uid: 178
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 185
+  - uid: 179
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 186
+  - uid: 180
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 187
+  - uid: 181
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 188
+  - uid: 182
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 189
+  - uid: 183
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 1
-  - uid: 190
+  - uid: 184
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
-  - uid: 191
+  - uid: 185
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 192
+  - uid: 186
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 193
+  - uid: 187
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 194
+  - uid: 188
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 195
+  - uid: 189
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 196
+  - uid: 190
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 197
+  - uid: 191
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 198
+  - uid: 192
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 199
+  - uid: 193
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 200
+  - uid: 194
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 201
+  - uid: 195
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 202
+  - uid: 196
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 203
+  - uid: 197
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 204
+  - uid: 198
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 205
+  - uid: 199
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 206
+  - uid: 200
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 207
+  - uid: 201
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 208
+  - uid: 202
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 209
+  - uid: 203
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 210
+  - uid: 204
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 211
+  - uid: 205
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 212
+  - uid: 206
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 213
+  - uid: 207
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 214
+  - uid: 208
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 215
+  - uid: 209
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 216
+  - uid: 210
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 217
+  - uid: 211
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 218
+  - uid: 212
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 219
+  - uid: 213
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 220
+  - uid: 214
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 221
+  - uid: 215
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 222
+  - uid: 216
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 223
+  - uid: 217
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 224
+  - uid: 218
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 225
+  - uid: 219
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 226
+  - uid: 220
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 227
+  - uid: 221
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 228
+  - uid: 222
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 229
+  - uid: 223
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 230
+  - uid: 224
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 231
+  - uid: 225
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 232
+  - uid: 226
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 233
+  - uid: 227
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 234
+  - uid: 228
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 235
+  - uid: 229
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 236
+  - uid: 230
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 237
+  - uid: 231
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 238
+  - uid: 232
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 239
+  - uid: 233
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 240
+  - uid: 234
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 241
+  - uid: 235
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 242
+  - uid: 236
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
-  - uid: 243
+  - uid: 237
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 244
+  - uid: 238
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
-  - uid: 245
+  - uid: 239
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 246
+  - uid: 240
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 247
+  - uid: 241
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 248
+  - uid: 242
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 249
+  - uid: 243
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 1
-  - uid: 250
+  - uid: 244
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 251
+  - uid: 245
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 252
+  - uid: 246
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 253
+  - uid: 247
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 1
-  - uid: 254
+  - uid: 248
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 1
-  - uid: 255
+  - uid: 249
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
-  - uid: 256
+  - uid: 250
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 1
-  - uid: 257
+  - uid: 251
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 258
+  - uid: 252
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 259
+  - uid: 253
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
-  - uid: 260
+  - uid: 254
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 1
-  - uid: 261
+  - uid: 255
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 262
+  - uid: 256
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 1
-  - uid: 263
+  - uid: 257
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 1
-  - uid: 264
+  - uid: 258
     components:
     - type: Transform
       pos: 0.5,29.5
       parent: 1
-  - uid: 265
+  - uid: 259
     components:
     - type: Transform
       pos: -0.5,29.5
       parent: 1
-  - uid: 266
+  - uid: 260
     components:
     - type: Transform
       pos: -1.5,29.5
       parent: 1
-  - uid: 267
+  - uid: 261
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 1
-  - uid: 268
+  - uid: 262
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 1
-  - uid: 269
+  - uid: 263
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 1
-  - uid: 270
+  - uid: 264
     components:
     - type: Transform
       pos: -0.5,27.5
       parent: 1
-  - uid: 271
+  - uid: 265
     components:
     - type: Transform
       pos: -1.5,27.5
       parent: 1
-  - uid: 272
+  - uid: 266
     components:
     - type: Transform
       pos: -2.5,27.5
       parent: 1
-  - uid: 273
+  - uid: 267
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 1
-  - uid: 274
+  - uid: 268
     components:
     - type: Transform
       pos: -4.5,27.5
       parent: 1
-  - uid: 275
+  - uid: 269
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 1
-  - uid: 276
+  - uid: 270
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-  - uid: 277
+  - uid: 271
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 1
-  - uid: 278
+  - uid: 272
     components:
     - type: Transform
       pos: 3.5,27.5
       parent: 1
-  - uid: 279
+  - uid: 273
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 280
+  - uid: 274
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
-  - uid: 281
+  - uid: 275
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 282
+  - uid: 276
     components:
     - type: Transform
       pos: -3.5,23.5
       parent: 1
-  - uid: 283
+  - uid: 277
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 1
-  - uid: 284
+  - uid: 278
     components:
     - type: Transform
       pos: -3.5,21.5
       parent: 1
-  - uid: 285
+  - uid: 279
     components:
     - type: Transform
       pos: -3.5,20.5
       parent: 1
-  - uid: 286
+  - uid: 280
     components:
     - type: Transform
       pos: -3.5,19.5
       parent: 1
-  - uid: 287
+  - uid: 281
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
-  - uid: 288
+  - uid: 282
     components:
     - type: Transform
       pos: -2.5,19.5
       parent: 1
-  - uid: 289
+  - uid: 283
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 1
-  - uid: 290
+  - uid: 284
     components:
     - type: Transform
       pos: -5.5,23.5
       parent: 1
-  - uid: 291
+  - uid: 285
     components:
     - type: Transform
       pos: -2.5,23.5
       parent: 1
-  - uid: 292
+  - uid: 286
     components:
     - type: Transform
       pos: -4.5,25.5
       parent: 1
-  - uid: 293
+  - uid: 287
     components:
     - type: Transform
       pos: -5.5,25.5
       parent: 1
-  - uid: 294
+  - uid: 288
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 1
-  - uid: 295
+  - uid: 289
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
-  - uid: 296
+  - uid: 290
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 1
-  - uid: 297
+  - uid: 291
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 298
+  - uid: 292
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-  - uid: 299
+  - uid: 293
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 1
-  - uid: 300
+  - uid: 294
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 1
-  - uid: 301
+  - uid: 295
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
-  - uid: 302
+  - uid: 296
     components:
     - type: Transform
       pos: -6.5,13.5
       parent: 1
-  - uid: 303
+  - uid: 297
     components:
     - type: Transform
       pos: -6.5,14.5
       parent: 1
-  - uid: 304
+  - uid: 298
     components:
     - type: Transform
       pos: -6.5,15.5
       parent: 1
-  - uid: 305
+  - uid: 299
     components:
     - type: Transform
       pos: -7.5,14.5
       parent: 1
-  - uid: 306
+  - uid: 300
     components:
     - type: Transform
       pos: -5.5,14.5
       parent: 1
-  - uid: 307
+  - uid: 301
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 308
+  - uid: 302
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 1
-  - uid: 309
+  - uid: 303
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 1
-  - uid: 310
+  - uid: 304
     components:
     - type: Transform
       pos: -5.5,19.5
       parent: 1
-  - uid: 311
+  - uid: 305
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 1
-  - uid: 312
+  - uid: 306
     components:
     - type: Transform
       pos: -4.5,19.5
       parent: 1
-  - uid: 313
+  - uid: 307
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 314
+  - uid: 308
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 315
+  - uid: 309
     components:
     - type: Transform
       pos: -6.5,16.5
       parent: 1
-  - uid: 316
+  - uid: 310
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 1
-  - uid: 317
+  - uid: 311
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 318
+  - uid: 312
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 319
+  - uid: 313
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 1
-  - uid: 320
+  - uid: 314
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 321
+  - uid: 315
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 322
+  - uid: 316
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 323
+  - uid: 317
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 324
+  - uid: 318
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 325
+  - uid: 319
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 326
+  - uid: 320
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 327
+  - uid: 321
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 328
+  - uid: 322
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 329
+  - uid: 323
     components:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
-  - uid: 330
+  - uid: 324
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 1
-  - uid: 331
+  - uid: 325
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
-  - uid: 332
+  - uid: 326
     components:
     - type: Transform
       pos: 8.5,15.5
       parent: 1
-  - uid: 333
+  - uid: 327
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 334
+  - uid: 328
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 335
+  - uid: 329
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 336
+  - uid: 330
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 337
+  - uid: 331
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 338
+  - uid: 332
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 339
+  - uid: 333
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 340
+  - uid: 334
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 341
+  - uid: 335
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 342
+  - uid: 336
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 343
+  - uid: 337
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 1
-  - uid: 344
+  - uid: 338
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 345
+  - uid: 339
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 1
-  - uid: 346
+  - uid: 340
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 347
+  - uid: 341
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 348
+  - uid: 342
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 349
+  - uid: 343
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
-  - uid: 350
+  - uid: 344
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 351
+  - uid: 345
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 352
+  - uid: 346
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
 - proto: CableApcStack
   entities:
-  - uid: 353
+  - uid: 347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3790,621 +3908,621 @@ entities:
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 354
+  - uid: 348
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 355
+  - uid: 349
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 356
+  - uid: 350
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 357
+  - uid: 351
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 358
+  - uid: 352
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 359
+  - uid: 353
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
-  - uid: 360
+  - uid: 354
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 361
+  - uid: 355
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 362
+  - uid: 356
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 363
+  - uid: 357
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 1
-  - uid: 364
+  - uid: 358
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 365
+  - uid: 359
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 366
+  - uid: 360
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 367
+  - uid: 361
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 368
+  - uid: 362
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 369
+  - uid: 363
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
-  - uid: 370
+  - uid: 364
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 371
+  - uid: 365
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 372
+  - uid: 366
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 373
+  - uid: 367
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 374
+  - uid: 368
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 375
+  - uid: 369
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 376
+  - uid: 370
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 377
+  - uid: 371
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 378
+  - uid: 372
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 379
+  - uid: 373
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 380
+  - uid: 374
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 381
+  - uid: 375
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 382
+  - uid: 376
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 383
+  - uid: 377
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 384
+  - uid: 378
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 385
+  - uid: 379
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 386
+  - uid: 380
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 387
+  - uid: 381
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 388
+  - uid: 382
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 389
+  - uid: 383
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 390
+  - uid: 384
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 391
+  - uid: 385
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 392
+  - uid: 386
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 393
+  - uid: 387
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 394
+  - uid: 388
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 395
+  - uid: 389
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 396
+  - uid: 390
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 397
+  - uid: 391
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 398
+  - uid: 392
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 399
+  - uid: 393
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 400
+  - uid: 394
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 401
+  - uid: 395
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 402
+  - uid: 396
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 403
+  - uid: 397
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 404
+  - uid: 398
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 405
+  - uid: 399
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 406
+  - uid: 400
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 407
+  - uid: 401
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 408
+  - uid: 402
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 409
+  - uid: 403
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 410
+  - uid: 404
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 411
+  - uid: 405
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 412
+  - uid: 406
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 413
+  - uid: 407
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 414
+  - uid: 408
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 415
+  - uid: 409
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 416
+  - uid: 410
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 417
+  - uid: 411
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 418
+  - uid: 412
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 419
+  - uid: 413
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 420
+  - uid: 414
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 421
+  - uid: 415
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 422
+  - uid: 416
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 423
+  - uid: 417
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 424
+  - uid: 418
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 425
+  - uid: 419
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 426
+  - uid: 420
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 427
+  - uid: 421
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 428
+  - uid: 422
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 429
+  - uid: 423
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 430
+  - uid: 424
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 431
+  - uid: 425
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 432
+  - uid: 426
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 433
+  - uid: 427
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 434
+  - uid: 428
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 435
+  - uid: 429
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 436
+  - uid: 430
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 437
+  - uid: 431
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 438
+  - uid: 432
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 439
+  - uid: 433
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 1
-  - uid: 440
+  - uid: 434
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
-  - uid: 441
+  - uid: 435
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 1
-  - uid: 442
+  - uid: 436
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 1
-  - uid: 443
+  - uid: 437
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 1
-  - uid: 444
+  - uid: 438
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-  - uid: 445
+  - uid: 439
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 1
-  - uid: 446
+  - uid: 440
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 1
-  - uid: 447
+  - uid: 441
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 1
-  - uid: 448
+  - uid: 442
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 449
+  - uid: 443
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
-  - uid: 450
+  - uid: 444
     components:
     - type: Transform
       pos: -1.5,24.5
       parent: 1
-  - uid: 451
+  - uid: 445
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 1
-  - uid: 452
+  - uid: 446
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 453
+  - uid: 447
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
-  - uid: 454
+  - uid: 448
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 455
+  - uid: 449
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 456
+  - uid: 450
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 457
+  - uid: 451
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
-  - uid: 458
+  - uid: 452
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 459
+  - uid: 453
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 460
+  - uid: 454
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
-  - uid: 461
+  - uid: 455
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 462
+  - uid: 456
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 463
+  - uid: 457
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 464
+  - uid: 458
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 465
+  - uid: 459
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 466
+  - uid: 460
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 467
+  - uid: 461
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 468
+  - uid: 462
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 1
-  - uid: 469
+  - uid: 463
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 470
+  - uid: 464
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 471
+  - uid: 465
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
-  - uid: 472
+  - uid: 466
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 473
+  - uid: 467
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 474
+  - uid: 468
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 475
+  - uid: 469
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 476
+  - uid: 470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4412,149 +4530,149 @@ entities:
       parent: 1
 - proto: CarpetPurple
   entities:
-  - uid: 477
+  - uid: 471
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 1
-  - uid: 478
+  - uid: 472
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
-  - uid: 479
+  - uid: 473
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 1
-  - uid: 480
+  - uid: 474
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 481
+  - uid: 475
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 482
+  - uid: 476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,11.5
       parent: 1
-  - uid: 483
+  - uid: 477
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 484
+  - uid: 478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 1
-  - uid: 485
+  - uid: 479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,12.5
       parent: 1
-  - uid: 486
+  - uid: 480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,13.5
       parent: 1
-  - uid: 487
+  - uid: 481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,14.5
       parent: 1
-  - uid: 488
+  - uid: 482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,15.5
       parent: 1
-  - uid: 489
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,15.5
       parent: 1
-  - uid: 490
+  - uid: 484
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 491
+  - uid: 485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 492
+  - uid: 486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 493
+  - uid: 487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 494
+  - uid: 488
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 495
+  - uid: 489
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 496
+  - uid: 490
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 1
-  - uid: 497
+  - uid: 491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 1
-  - uid: 498
+  - uid: 492
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 499
+  - uid: 493
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 500
+  - uid: 494
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 501
+  - uid: 495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-0.5
       parent: 1
-  - uid: 502
+  - uid: 496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4562,26 +4680,26 @@ entities:
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 503
+  - uid: 497
     components:
     - type: Transform
       pos: 3.6451461,1.5415804
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 504
+  - uid: 498
     components:
     - type: Transform
       pos: -2.551067,19.618185
       parent: 1
-  - uid: 505
+  - uid: 499
     components:
     - type: Transform
       pos: -4.452246,28.58722
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 506
+  - uid: 500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4589,69 +4707,69 @@ entities:
       parent: 1
 - proto: CheapRollerBed
   entities:
-  - uid: 507
+  - uid: 501
     components:
     - type: Transform
       pos: -2.5016901,25.542173
       parent: 1
-  - uid: 508
+  - uid: 502
     components:
     - type: Transform
       pos: -3.54203,25.527308
       parent: 1
 - proto: ChemistryHotplate
   entities:
-  - uid: 509
+  - uid: 503
     components:
     - type: Transform
       pos: -2.5,18.5
       parent: 1
 - proto: Cigarette
   entities:
-  - uid: 511
+  - uid: 505
     components:
     - type: Transform
-      parent: 510
+      parent: 504
     - type: Physics
       canCollide: False
 - proto: CigarRoyalCase
   entities:
-  - uid: 512
+  - uid: 506
     components:
     - type: Transform
       pos: -10.735416,1.8942165
       parent: 1
 - proto: CircuitImprinter
   entities:
-  - uid: 513
+  - uid: 507
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
 - proto: ClosetEmergencyFilledRandom
   entities:
-  - uid: 514
+  - uid: 508
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: ClosetFireFilled
   entities:
-  - uid: 515
+  - uid: 509
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
 - proto: ClothingHandsGlovesColorYellow
   entities:
-  - uid: 516
+  - uid: 510
     components:
     - type: Transform
       pos: 3.8823526,20.49948
       parent: 1
 - proto: ClothingHeadHatWeldingMaskPainted
   entities:
-  - uid: 517
+  - uid: 511
     components:
     - type: Transform
       pos: 3.468076,0.6929819
@@ -4665,26 +4783,12 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 31
-    components:
-    - type: Transform
-      parent: 29
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitImperialWorker
   entities:
   - uid: 25
     components:
     - type: Transform
       parent: 22
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 32
-    components:
-    - type: Transform
-      parent: 29
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -4697,16 +4801,9 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 33
-    components:
-    - type: Transform
-      parent: 29
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: ComputerAdvancedRadar
   entities:
-  - uid: 518
+  - uid: 512
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4714,7 +4811,7 @@ entities:
       parent: 1
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 519
+  - uid: 513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4722,12 +4819,12 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        689:
+        684:
         - - ArtifactAnalyzerSender
           - ArtifactAnalyzerReceiver
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 520
+  - uid: 514
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4735,7 +4832,7 @@ entities:
       parent: 1
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 521
+  - uid: 515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4746,7 +4843,7 @@ entities:
       allowedFlags: Hide
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 522
+  - uid: 516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4754,14 +4851,14 @@ entities:
       parent: 1
 - proto: ComputerTabletopCommsShip
   entities:
-  - uid: 523
+  - uid: 517
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 1
 - proto: ComputerTabletopPowerMonitoring
   entities:
-  - uid: 524
+  - uid: 518
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4769,28 +4866,39 @@ entities:
       parent: 1
 - proto: ComputerTabletopTargeting
   entities:
-  - uid: 525
+  - uid: 519
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 1
+    - type: TargetingConsole
+      cannonGroups:
+        all:
+        - 1115
+        - 1116
+        - 1117
+        200cc 'Retribution' Pulse Laser:
+        - 1116
+        - 1117
+        300mm 'Leviathan' Siege Battery:
+        - 1115
 - proto: CrateEngineeringAMEJar
   entities:
-  - uid: 526
+  - uid: 520
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
 - proto: CrescentMultitool
   entities:
-  - uid: 527
+  - uid: 521
     components:
     - type: Transform
       pos: 3.2432864,20.603542
       parent: 1
 - proto: CrescentScrewdriver
   entities:
-  - uid: 528
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4798,7 +4906,7 @@ entities:
       parent: 1
 - proto: CrewMonitoringServer
   entities:
-  - uid: 529
+  - uid: 523
     components:
     - type: Transform
       pos: -2.5,16.5
@@ -4808,45 +4916,45 @@ entities:
       available: False
 - proto: CryogenicSleepUnitSpawnerLateJoin
   entities:
-  - uid: 530
+  - uid: 524
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 531
+  - uid: 525
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
 - proto: CurtainsPurpleOpen
   entities:
-  - uid: 532
+  - uid: 526
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 533
+  - uid: 527
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 1
 - proto: DoorElectronics
   entities:
-  - uid: 534
+  - uid: 528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.4936867,3.329946
       parent: 1
-  - uid: 535
+  - uid: 529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.3530617,3.329946
       parent: 1
-  - uid: 536
+  - uid: 530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4854,21 +4962,21 @@ entities:
       parent: 1
 - proto: DrinkWhiskeyColaGlass
   entities:
-  - uid: 537
+  - uid: 531
     components:
     - type: Transform
       pos: -10.261126,1.699523
       parent: 1
 - proto: DrinkWineGlass
   entities:
-  - uid: 538
+  - uid: 532
     components:
     - type: Transform
       pos: 1.325413,28.6433
       parent: 1
 - proto: Dropper
   entities:
-  - uid: 539
+  - uid: 533
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4876,172 +4984,172 @@ entities:
       parent: 1
 - proto: EmergencyLight
   entities:
-  - uid: 540
+  - uid: 534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,25.5
       parent: 1
-  - uid: 541
+  - uid: 535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,25.5
       parent: 1
-  - uid: 542
+  - uid: 536
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,25.5
       parent: 1
-  - uid: 543
+  - uid: 537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 544
+  - uid: 538
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 545
+  - uid: 539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 546
+  - uid: 540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 547
+  - uid: 541
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 548
+  - uid: 542
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 549
+  - uid: 543
     components:
     - type: Transform
       pos: -4.5,27.5
       parent: 1
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 550
+  - uid: 544
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 551
+  - uid: 545
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 552
+  - uid: 546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 553
+  - uid: 547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,26.5
       parent: 1
-  - uid: 554
+  - uid: 548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,27.5
       parent: 1
-  - uid: 555
+  - uid: 549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,24.5
       parent: 1
-  - uid: 556
+  - uid: 550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,23.5
       parent: 1
-  - uid: 557
+  - uid: 551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,24.5
       parent: 1
-  - uid: 558
+  - uid: 552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,23.5
       parent: 1
-  - uid: 559
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,19.5
       parent: 1
-  - uid: 560
+  - uid: 554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 1
-  - uid: 561
+  - uid: 555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 562
+  - uid: 556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 563
+  - uid: 557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 564
+  - uid: 558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 565
+  - uid: 559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 566
+  - uid: 560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,21.5
       parent: 1
-  - uid: 567
+  - uid: 561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5049,7 +5157,7 @@ entities:
       parent: 1
 - proto: FloorDrain
   entities:
-  - uid: 568
+  - uid: 562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5059,13 +5167,13 @@ entities:
       fixtures: {}
 - proto: GasPassiveVent
   entities:
-  - uid: 569
+  - uid: 563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,14.5
       parent: 1
-  - uid: 570
+  - uid: 564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5073,53 +5181,53 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 571
+  - uid: 565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,12.5
       parent: 1
-  - uid: 572
+  - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 1
-  - uid: 573
+  - uid: 567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,14.5
       parent: 1
-  - uid: 574
+  - uid: 568
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,14.5
       parent: 1
-  - uid: 575
+  - uid: 569
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 576
+  - uid: 570
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 1
-  - uid: 577
+  - uid: 571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 578
+  - uid: 572
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 579
+  - uid: 573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5127,361 +5235,361 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 580
+  - uid: 574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 1
-  - uid: 581
+  - uid: 575
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 582
+  - uid: 576
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 583
+  - uid: 577
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 584
+  - uid: 578
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 585
+  - uid: 579
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 586
+  - uid: 580
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 587
+  - uid: 581
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 588
+  - uid: 582
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 589
+  - uid: 583
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 590
+  - uid: 584
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 591
+  - uid: 585
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 592
+  - uid: 586
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 593
+  - uid: 587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,13.5
       parent: 1
-  - uid: 594
+  - uid: 588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,15.5
       parent: 1
-  - uid: 595
+  - uid: 589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,16.5
       parent: 1
-  - uid: 596
+  - uid: 590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,17.5
       parent: 1
-  - uid: 597
+  - uid: 591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,18.5
       parent: 1
-  - uid: 598
+  - uid: 592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,19.5
       parent: 1
-  - uid: 599
+  - uid: 593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,20.5
       parent: 1
-  - uid: 600
+  - uid: 594
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,21.5
       parent: 1
-  - uid: 601
+  - uid: 595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,22.5
       parent: 1
-  - uid: 602
+  - uid: 596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,23.5
       parent: 1
-  - uid: 603
+  - uid: 597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,25.5
       parent: 1
-  - uid: 604
+  - uid: 598
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,26.5
       parent: 1
-  - uid: 605
+  - uid: 599
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,27.5
       parent: 1
-  - uid: 606
+  - uid: 600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,28.5
       parent: 1
-  - uid: 607
+  - uid: 601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,24.5
       parent: 1
-  - uid: 608
+  - uid: 602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,28.5
       parent: 1
-  - uid: 609
+  - uid: 603
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,27.5
       parent: 1
-  - uid: 610
+  - uid: 604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,26.5
       parent: 1
-  - uid: 611
+  - uid: 605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,25.5
       parent: 1
-  - uid: 612
+  - uid: 606
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,24.5
       parent: 1
-  - uid: 613
+  - uid: 607
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,23.5
       parent: 1
-  - uid: 614
+  - uid: 608
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,22.5
       parent: 1
-  - uid: 615
+  - uid: 609
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,21.5
       parent: 1
-  - uid: 616
+  - uid: 610
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,20.5
       parent: 1
-  - uid: 617
+  - uid: 611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,19.5
       parent: 1
-  - uid: 618
+  - uid: 612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,18.5
       parent: 1
-  - uid: 619
+  - uid: 613
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,17.5
       parent: 1
-  - uid: 620
+  - uid: 614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,16.5
       parent: 1
-  - uid: 621
+  - uid: 615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,15.5
       parent: 1
-  - uid: 622
+  - uid: 616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 623
+  - uid: 617
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 624
+  - uid: 618
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 625
+  - uid: 619
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 626
+  - uid: 620
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 627
+  - uid: 621
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 628
+  - uid: 622
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 629
+  - uid: 623
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 630
+  - uid: 624
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 631
+  - uid: 625
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 632
+  - uid: 626
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 633
+  - uid: 627
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 634
+  - uid: 628
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 635
+  - uid: 629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 636
+  - uid: 630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 1
-  - uid: 637
+  - uid: 631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 638
+  - uid: 632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 639
+  - uid: 633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 640
+  - uid: 634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,8.5
       parent: 1
-  - uid: 641
+  - uid: 635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 642
+  - uid: 636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,6.5
       parent: 1
-  - uid: 643
+  - uid: 637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5489,25 +5597,25 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 644
+  - uid: 638
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 645
+  - uid: 639
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 1
-  - uid: 646
+  - uid: 640
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 1
-  - uid: 647
+  - uid: 641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5515,12 +5623,12 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 648
+  - uid: 642
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 649
+  - uid: 643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5528,14 +5636,14 @@ entities:
       parent: 1
 - proto: GasPressurePump
   entities:
-  - uid: 650
+  - uid: 644
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: GasValve
   entities:
-  - uid: 651
+  - uid: 645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5545,17 +5653,17 @@ entities:
       open: False
 - proto: GasVentPump
   entities:
-  - uid: 652
+  - uid: 646
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 653
+  - uid: 647
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 1
-  - uid: 654
+  - uid: 648
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5563,17 +5671,17 @@ entities:
       parent: 1
 - proto: GasVentScrubber
   entities:
-  - uid: 655
+  - uid: 649
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 656
+  - uid: 650
     components:
     - type: Transform
       pos: -0.5,29.5
       parent: 1
-  - uid: 657
+  - uid: 651
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5581,145 +5689,157 @@ entities:
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 658
+  - uid: 652
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 659
+  - uid: 653
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 1
-  - uid: 660
+  - uid: 654
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 1
-  - uid: 661
+  - uid: 655
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 1
-  - uid: 662
+  - uid: 656
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
-  - uid: 663
+  - uid: 657
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
-  - uid: 664
+  - uid: 658
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,11.5
       parent: 1
-  - uid: 665
+  - uid: 659
     components:
     - type: Transform
       pos: -7.5,12.5
       parent: 1
-  - uid: 666
+  - uid: 660
     components:
     - type: Transform
       pos: -4.5,15.5
       parent: 1
-  - uid: 667
+  - uid: 661
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,15.5
       parent: 1
-  - uid: 668
+  - uid: 662
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 1
-  - uid: 669
+  - uid: 663
     components:
     - type: Transform
       pos: -4.5,14.5
       parent: 1
-  - uid: 670
+  - uid: 664
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 1
-  - uid: 671
+  - uid: 665
     components:
     - type: Transform
       pos: -8.5,15.5
       parent: 1
-  - uid: 672
+  - uid: 666
     components:
     - type: Transform
       pos: -5.5,12.5
       parent: 1
-  - uid: 673
+  - uid: 667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,23.5
       parent: 1
-  - uid: 674
+  - uid: 668
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,24.5
       parent: 1
-  - uid: 675
+  - uid: 669
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 1
-  - uid: 676
+  - uid: 670
     components:
     - type: Transform
       pos: -4.5,29.5
       parent: 1
-  - uid: 677
+  - uid: 671
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 1
-  - uid: 678
+  - uid: 672
     components:
     - type: Transform
       pos: -5.5,28.5
       parent: 1
-  - uid: 679
+  - uid: 673
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
-  - uid: 680
+  - uid: 674
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 1
-  - uid: 681
+  - uid: 675
     components:
     - type: Transform
       pos: -5.5,27.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 682
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,2.5
       parent: 1
-  - uid: 1128
+  - uid: 677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,1.5
       parent: 1
 - proto: HandheldGPSBasic
   entities:
@@ -5730,28 +5850,21 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 34
-    components:
-    - type: Transform
-      parent: 29
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: HandheldHealthAnalyzer
   entities:
-  - uid: 683
+  - uid: 678
     components:
     - type: Transform
       pos: -5.5337596,25.475395
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 684
+  - uid: 679
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
-  - uid: 685
+  - uid: 680
     components:
     - type: Transform
       pos: -2.5,25.5
@@ -5765,37 +5878,30 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 35
-    components:
-    - type: Transform
-      parent: 29
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: KitchenMicrowave
   entities:
-  - uid: 686
+  - uid: 681
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 687
+  - uid: 682
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
 - proto: LargeBeaker
   entities:
-  - uid: 688
+  - uid: 683
     components:
     - type: Transform
       pos: -3.64301,19.662994
       parent: 1
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 689
+  - uid: 684
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5803,85 +5909,85 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 519
+      - 513
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 690
+  - uid: 685
     components:
     - type: Transform
       pos: -4.686625,25.906515
       parent: 1
 - proto: MedkitBruteFilled
   entities:
-  - uid: 691
+  - uid: 686
     components:
     - type: Transform
       pos: -4.671764,25.53486
       parent: 1
 - proto: MedkitBurnFilled
   entities:
-  - uid: 692
+  - uid: 687
     components:
     - type: Transform
       pos: -4.671764,25.742987
       parent: 1
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 693
+  - uid: 688
     components:
     - type: Transform
       pos: -4.3002133,25.921381
       parent: 1
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 694
+  - uid: 689
     components:
     - type: Transform
       pos: -4.3150754,25.72812
       parent: 1
 - proto: MedkitToxinFilled
   entities:
-  - uid: 695
+  - uid: 690
     components:
     - type: Transform
       pos: -4.3002133,25.53486
       parent: 1
 - proto: MiningDrill
   entities:
-  - uid: 696
+  - uid: 691
     components:
     - type: Transform
       pos: 4.4993134,10.772878
       parent: 1
-  - uid: 697
+  - uid: 692
     components:
     - type: Transform
       pos: 4.4993134,16.749092
       parent: 1
 - proto: N14BedWood
   entities:
-  - uid: 698
+  - uid: 693
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: N14BedWoodBunk
   entities:
-  - uid: 699
+  - uid: 694
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: N14ClosetCabinetWood
   entities:
-  - uid: 700
+  - uid: 695
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
 - proto: NFAshtray
   entities:
-  - uid: 510
+  - uid: 504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5889,7 +5995,7 @@ entities:
       parent: 1
     - type: Storage
       storedItems:
-        511:
+        505:
           position: 0,0
           _rotation: South
     - type: ContainerContainer
@@ -5898,75 +6004,75 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 511
+          - 505
 - proto: NFHolopadShip
   entities:
-  - uid: 701
+  - uid: 696
     components:
     - type: Transform
       pos: -1.5,29.5
       parent: 1
 - proto: OreBag
   entities:
-  - uid: 702
+  - uid: 697
     components:
     - type: Transform
       pos: 4.692519,16.496367
       parent: 1
-  - uid: 703
+  - uid: 698
     components:
     - type: Transform
       pos: 4.677657,10.430955
       parent: 1
 - proto: OreBox
   entities:
-  - uid: 704
+  - uid: 699
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 705
+  - uid: 700
     components:
     - type: Transform
       pos: 5.5,16.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 706
+  - uid: 701
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 707
+  - uid: 702
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 708
+  - uid: 703
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 709
+  - uid: 704
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 710
+  - uid: 705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 711
+  - uid: 706
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 712
+  - uid: 707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5974,24 +6080,24 @@ entities:
       parent: 1
 - proto: PlasmaWindowDirectional
   entities:
-  - uid: 713
+  - uid: 708
     components:
     - type: Transform
       pos: 1.5,28.5
       parent: 1
-  - uid: 714
+  - uid: 709
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 1
-  - uid: 715
+  - uid: 710
     components:
     - type: Transform
       pos: -0.5,28.5
       parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 716
+  - uid: 711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5999,253 +6105,253 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 717
+  - uid: 712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,21.5
       parent: 1
-  - uid: 718
+  - uid: 713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,18.5
       parent: 1
-  - uid: 719
+  - uid: 714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,18.5
       parent: 1
-  - uid: 720
+  - uid: 715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,21.5
       parent: 1
-  - uid: 721
+  - uid: 716
     components:
     - type: Transform
       pos: 1.5,25.5
       parent: 1
-  - uid: 722
+  - uid: 717
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 1
-  - uid: 723
+  - uid: 718
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 724
+  - uid: 719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 725
+  - uid: 720
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,12.5
       parent: 1
-  - uid: 726
+  - uid: 721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
-  - uid: 727
+  - uid: 722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,11.5
       parent: 1
-  - uid: 728
+  - uid: 723
     components:
     - type: Transform
       pos: -7.5,15.5
       parent: 1
-  - uid: 729
+  - uid: 724
     components:
     - type: Transform
       pos: -5.5,15.5
       parent: 1
-  - uid: 730
+  - uid: 725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,18.5
       parent: 1
-  - uid: 731
+  - uid: 726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,20.5
       parent: 1
-  - uid: 732
+  - uid: 727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,22.5
       parent: 1
-  - uid: 733
+  - uid: 728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,25.5
       parent: 1
-  - uid: 734
+  - uid: 729
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,25.5
       parent: 1
-  - uid: 735
+  - uid: 730
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,22.5
       parent: 1
-  - uid: 736
+  - uid: 731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,22.5
       parent: 1
-  - uid: 737
+  - uid: 732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,15.5
       parent: 1
-  - uid: 738
+  - uid: 733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,11.5
       parent: 1
-  - uid: 739
+  - uid: 734
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 1
-  - uid: 740
+  - uid: 735
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,15.5
       parent: 1
-  - uid: 741
+  - uid: 736
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 1
-  - uid: 742
+  - uid: 737
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,10.5
       parent: 1
-  - uid: 743
+  - uid: 738
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 744
+  - uid: 739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 745
+  - uid: 740
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 746
+  - uid: 741
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 747
+  - uid: 742
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 748
+  - uid: 743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 1
-  - uid: 749
+  - uid: 744
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,1.5
       parent: 1
-  - uid: 750
+  - uid: 745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 751
+  - uid: 746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 1
-  - uid: 752
+  - uid: 747
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
-  - uid: 753
+  - uid: 748
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,27.5
       parent: 1
-  - uid: 754
+  - uid: 749
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,27.5
       parent: 1
-  - uid: 755
+  - uid: 750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,29.5
       parent: 1
-  - uid: 756
+  - uid: 751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,29.5
       parent: 1
-  - uid: 757
+  - uid: 752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,28.5
       parent: 1
-  - uid: 758
+  - uid: 753
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,27.5
       parent: 1
-  - uid: 759
+  - uid: 754
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6253,7 +6359,7 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 760
+  - uid: 755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6261,48 +6367,48 @@ entities:
       parent: 1
 - proto: PristineMicroforge
   entities:
-  - uid: 761
+  - uid: 756
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
 - proto: Rack
   entities:
-  - uid: 762
+  - uid: 757
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 763
+  - uid: 758
     components:
     - type: Transform
       pos: -4.5,25.5
       parent: 1
-  - uid: 764
+  - uid: 759
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 765
+  - uid: 760
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 1
 - proto: Railing
   entities:
-  - uid: 766
+  - uid: 761
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 1
-  - uid: 767
+  - uid: 762
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,13.5
       parent: 1
-  - uid: 768
+  - uid: 763
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6310,134 +6416,134 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 1129
+  - uid: 764
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 769
+  - uid: 765
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 1
-  - uid: 770
+  - uid: 766
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
-  - uid: 771
+  - uid: 767
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 1
-  - uid: 772
+  - uid: 768
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
-  - uid: 773
+  - uid: 769
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 1
-  - uid: 774
+  - uid: 770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,15.5
       parent: 1
-  - uid: 775
+  - uid: 771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 1
-  - uid: 776
+  - uid: 772
     components:
     - type: Transform
       pos: -5.5,28.5
       parent: 1
-  - uid: 777
+  - uid: 773
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 1
-  - uid: 778
+  - uid: 774
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 1
-  - uid: 779
+  - uid: 775
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
-  - uid: 780
+  - uid: 776
     components:
     - type: Transform
       pos: -5.5,27.5
       parent: 1
-  - uid: 781
+  - uid: 777
     components:
     - type: Transform
       pos: -4.5,29.5
       parent: 1
-  - uid: 782
+  - uid: 778
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 1
-  - uid: 783
+  - uid: 779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,24.5
       parent: 1
-  - uid: 784
+  - uid: 780
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,23.5
       parent: 1
-  - uid: 785
+  - uid: 781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,15.5
       parent: 1
-  - uid: 786
+  - uid: 782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,13.5
       parent: 1
-  - uid: 787
+  - uid: 783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,12.5
       parent: 1
-  - uid: 788
+  - uid: 784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,12.5
       parent: 1
-  - uid: 789
+  - uid: 785
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,13.5
       parent: 1
-  - uid: 790
+  - uid: 786
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 1
-  - uid: 791
+  - uid: 787
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6445,19 +6551,19 @@ entities:
       parent: 1
 - proto: ReinforcedShuttleWallCMM
   entities:
-  - uid: 792
+  - uid: 788
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 793
+  - uid: 789
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
 - proto: RemoteSignallerAdvanced
   entities:
-  - uid: 794
+  - uid: 790
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6465,14 +6571,14 @@ entities:
       parent: 1
 - proto: ResearchAndDevelopmentServerImperial
   entities:
-  - uid: 795
+  - uid: 791
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 796
+  - uid: 792
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6480,9 +6586,9 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 818
-      - 819
-  - uid: 797
+      - 814
+      - 815
+  - uid: 793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6490,9 +6596,9 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 818
-      - 819
-  - uid: 798
+      - 814
+      - 815
+  - uid: 794
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6500,35 +6606,35 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 818
-      - 819
+      - 814
+      - 815
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 799
+  - uid: 795
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 815
-  - uid: 800
+      - 811
+  - uid: 796
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 815
-  - uid: 801
+      - 811
+  - uid: 797
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 815
-  - uid: 802
+      - 811
+  - uid: 798
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6536,8 +6642,8 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 815
-  - uid: 803
+      - 811
+  - uid: 799
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6545,16 +6651,16 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 815
+      - 811
 - proto: ShuttleLightRed
   entities:
-  - uid: 804
+  - uid: 800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,25.5
       parent: 1
-  - uid: 805
+  - uid: 801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6562,43 +6668,43 @@ entities:
       parent: 1
 - proto: ShuttleLightSodium
   entities:
-  - uid: 806
+  - uid: 802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 807
+  - uid: 803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,19.5
       parent: 1
-  - uid: 808
+  - uid: 804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 809
+  - uid: 805
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,1.5
       parent: 1
-  - uid: 810
+  - uid: 806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-1.5
       parent: 1
-  - uid: 811
+  - uid: 807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 812
+  - uid: 808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6606,23 +6712,23 @@ entities:
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 813
+  - uid: 809
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        133:
+        127:
         - - Pressed
           - Toggle
-        134:
+        128:
         - - Pressed
           - Toggle
-        135:
+        129:
         - - Pressed
           - Toggle
-  - uid: 814
+  - uid: 810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6630,19 +6736,19 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        137:
+        131:
         - - Pressed
           - Toggle
-        136:
+        130:
         - - Pressed
           - Toggle
-        138:
+        132:
         - - Pressed
           - Toggle
-        139:
+        133:
         - - Pressed
           - Toggle
-  - uid: 815
+  - uid: 811
     components:
     - type: Transform
       pos: -11.5,3.5
@@ -6651,22 +6757,22 @@ entities:
       state: True
     - type: DeviceLinkSource
       linkedPorts:
-        803:
-        - - Pressed
-          - Toggle
-        802:
-        - - Pressed
-          - Toggle
         799:
         - - Pressed
           - Toggle
-        801:
+        798:
         - - Pressed
           - Toggle
-        800:
+        795:
         - - Pressed
           - Toggle
-  - uid: 816
+        797:
+        - - Pressed
+          - Toggle
+        796:
+        - - Pressed
+          - Toggle
+  - uid: 812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6674,10 +6780,10 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        126:
+        120:
         - - Pressed
           - Toggle
-  - uid: 817
+  - uid: 813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6685,10 +6791,10 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        132:
+        126:
         - - Pressed
           - Toggle
-  - uid: 818
+  - uid: 814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6696,16 +6802,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        798:
+        794:
         - - Pressed
           - Toggle
-        797:
+        793:
         - - Pressed
           - Toggle
-        796:
+        792:
         - - Pressed
           - Toggle
-  - uid: 819
+  - uid: 815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6713,16 +6819,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        798:
+        794:
         - - Pressed
           - Toggle
-        797:
+        793:
         - - Pressed
           - Toggle
-        796:
+        792:
         - - Pressed
           - Toggle
-  - uid: 820
+  - uid: 816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6730,16 +6836,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        129:
+        123:
         - - Pressed
           - Toggle
-        128:
+        122:
         - - Pressed
           - Toggle
-        127:
+        121:
         - - Pressed
           - Toggle
-  - uid: 821
+  - uid: 817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6747,39 +6853,39 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        140:
+        134:
         - - Pressed
           - Toggle
-        141:
+        135:
         - - Pressed
           - Toggle
 - proto: SignalButtonDirectional
   entities:
-  - uid: 822
+  - uid: 818
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        119:
+        - - Pressed
+          - Toggle
         125:
         - - Pressed
           - Toggle
-        131:
-        - - Pressed
-          - Toggle
-        130:
+        124:
         - - Pressed
           - Toggle
 - proto: SignBridge
   entities:
-  - uid: 823
+  - uid: 819
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,26.5
       parent: 1
-  - uid: 824
+  - uid: 820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6787,7 +6893,7 @@ entities:
       parent: 1
 - proto: SignCargo
   entities:
-  - uid: 825
+  - uid: 821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6795,14 +6901,14 @@ entities:
       parent: 1
 - proto: SignCryogenicsMed
   entities:
-  - uid: 826
+  - uid: 822
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
 - proto: SignDirectionalBridge
   entities:
-  - uid: 827
+  - uid: 823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6810,7 +6916,7 @@ entities:
       parent: 1
 - proto: SignDirectionalCB1
   entities:
-  - uid: 828
+  - uid: 824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6818,7 +6924,7 @@ entities:
       parent: 1
 - proto: SignDirectionalDorms
   entities:
-  - uid: 829
+  - uid: 825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6826,7 +6932,7 @@ entities:
       parent: 1
 - proto: SignDirectionalMed
   entities:
-  - uid: 830
+  - uid: 826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6834,7 +6940,7 @@ entities:
       parent: 1
 - proto: SignDirectionalSci
   entities:
-  - uid: 831
+  - uid: 827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6842,7 +6948,7 @@ entities:
       parent: 1
 - proto: SignMedical
   entities:
-  - uid: 832
+  - uid: 828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6850,13 +6956,13 @@ entities:
       parent: 1
 - proto: SignScience
   entities:
-  - uid: 833
+  - uid: 829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 1
-  - uid: 834
+  - uid: 830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6864,7 +6970,7 @@ entities:
       parent: 1
 - proto: SignToolStorage
   entities:
-  - uid: 835
+  - uid: 831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6872,47 +6978,47 @@ entities:
       parent: 1
 - proto: SmartFridge
   entities:
-  - uid: 836
+  - uid: 832
     components:
     - type: Transform
       pos: -1.5,19.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 837
+  - uid: 833
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
 - proto: SpawnPointScribe
   entities:
-  - uid: 838
+  - uid: 834
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
 - proto: SpawnPointSurgeon
   entities:
-  - uid: 839
+  - uid: 835
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
 - proto: StairDark
   entities:
-  - uid: 840
+  - uid: 836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,28.5
       parent: 1
-  - uid: 841
+  - uid: 837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,28.5
       parent: 1
-  - uid: 842
+  - uid: 838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6920,44 +7026,44 @@ entities:
       parent: 1
 - proto: StairStageDark
   entities:
-  - uid: 843
+  - uid: 839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 844
+  - uid: 840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 1
-  - uid: 845
+  - uid: 841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,15.5
       parent: 1
-  - uid: 846
+  - uid: 842
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 847
+  - uid: 843
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 848
+  - uid: 844
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 849
+  - uid: 845
     components:
     - type: Transform
       pos: 13.5,2.5
@@ -6999,44 +7105,9 @@ entities:
           - 27
           - 23
           - 24
-  - uid: 29
-    components:
-    - type: Transform
-      pos: 3.5,16.5
-      parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14923
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 30
-          - 34
-          - 32
-          - 31
-          - 35
-          - 33
 - proto: SyringeInaprovaline
   entities:
-  - uid: 850
+  - uid: 846
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7044,7 +7115,7 @@ entities:
       parent: 1
 - proto: SyringeSaline
   entities:
-  - uid: 851
+  - uid: 847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7052,34 +7123,34 @@ entities:
       parent: 1
 - proto: Table
   entities:
-  - uid: 852
+  - uid: 848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 1
-  - uid: 853
+  - uid: 849
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 1
-  - uid: 854
+  - uid: 850
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 1
-  - uid: 855
+  - uid: 851
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 1
-  - uid: 856
+  - uid: 852
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 1
-  - uid: 857
+  - uid: 853
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7087,40 +7158,40 @@ entities:
       parent: 1
 - proto: TableGlass
   entities:
-  - uid: 858
+  - uid: 854
     components:
     - type: Transform
       pos: -3.5,19.5
       parent: 1
-  - uid: 859
+  - uid: 855
     components:
     - type: Transform
       pos: -2.5,18.5
       parent: 1
-  - uid: 860
+  - uid: 856
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
-  - uid: 861
+  - uid: 857
     components:
     - type: Transform
       pos: -5.5,25.5
       parent: 1
-  - uid: 862
+  - uid: 858
     components:
     - type: Transform
       pos: -5.5,24.5
       parent: 1
 - proto: TablePlasmaGlass
   entities:
-  - uid: 863
+  - uid: 859
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,1.5
       parent: 1
-  - uid: 864
+  - uid: 860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7128,31 +7199,31 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 865
+  - uid: 861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,20.5
       parent: 1
-  - uid: 866
+  - uid: 862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,20.5
       parent: 1
-  - uid: 867
+  - uid: 863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,20.5
       parent: 1
-  - uid: 868
+  - uid: 864
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 869
+  - uid: 865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7160,147 +7231,147 @@ entities:
       parent: 1
 - proto: ThrusterDSMWarship
   entities:
-  - uid: 870
+  - uid: 866
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 871
+  - uid: 867
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-0.5
       parent: 1
-  - uid: 872
+  - uid: 868
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-0.5
       parent: 1
-  - uid: 873
+  - uid: 869
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 874
+  - uid: 870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 875
+  - uid: 871
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 1
-  - uid: 876
+  - uid: 872
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 877
+  - uid: 873
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 878
+  - uid: 874
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 879
+  - uid: 875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 1
-  - uid: 880
+  - uid: 876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,8.5
       parent: 1
-  - uid: 881
+  - uid: 877
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,7.5
       parent: 1
-  - uid: 882
+  - uid: 878
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 1
-  - uid: 883
+  - uid: 879
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,7.5
       parent: 1
-  - uid: 884
+  - uid: 880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,19.5
       parent: 1
-  - uid: 885
+  - uid: 881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,18.5
       parent: 1
-  - uid: 886
+  - uid: 882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,19.5
       parent: 1
-  - uid: 887
+  - uid: 883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,18.5
       parent: 1
-  - uid: 888
+  - uid: 884
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 889
+  - uid: 885
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 890
+  - uid: 886
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 891
+  - uid: 887
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 1
-  - uid: 892
+  - uid: 888
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 1
-  - uid: 893
+  - uid: 889
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
 - proto: TimerTrigger
   entities:
-  - uid: 894
+  - uid: 890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7308,1020 +7379,1013 @@ entities:
       parent: 1
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 895
+  - uid: 891
     components:
     - type: Transform
       pos: 3.7653158,0.499721
       parent: 1
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 896
+  - uid: 892
     components:
     - type: Transform
       pos: 3.6296988,20.752205
       parent: 1
 - proto: VendingMachineChemicals
   entities:
-  - uid: 897
+  - uid: 893
     components:
     - type: Transform
       pos: -4.5,22.5
       parent: 1
 - proto: VendingMachineCigs
   entities:
-  - uid: 898
+  - uid: 894
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 1
-- proto: VendingMachineClothing
-  entities:
-  - uid: 899
-    components:
-    - type: Transform
-      pos: -8.5,1.5
-      parent: 1
 - proto: VendingMachineCoffee
   entities:
-  - uid: 900
+  - uid: 896
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
 - proto: VendingMachineCrescentEngivend
   entities:
-  - uid: 901
+  - uid: 897
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
 - proto: VendingMachineMedical
   entities:
-  - uid: 902
+  - uid: 898
     components:
     - type: Transform
       pos: -5.5,22.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 903
+  - uid: 899
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 904
+  - uid: 900
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 905
+  - uid: 901
     components:
     - type: Transform
       pos: 3.5,27.5
       parent: 1
-  - uid: 906
+  - uid: 902
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 1
-  - uid: 907
+  - uid: 903
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 908
+  - uid: 904
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 909
+  - uid: 905
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 910
+  - uid: 906
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 911
+  - uid: 907
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 912
+  - uid: 908
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 913
+  - uid: 909
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 914
+  - uid: 910
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 915
+  - uid: 911
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 916
+  - uid: 912
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 917
+  - uid: 913
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 918
+  - uid: 914
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 919
+  - uid: 915
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 920
+  - uid: 916
     components:
     - type: Transform
       pos: -13.5,3.5
       parent: 1
-  - uid: 921
+  - uid: 917
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 922
+  - uid: 918
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 923
+  - uid: 919
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 924
+  - uid: 920
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 925
+  - uid: 921
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 926
+  - uid: 922
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 927
+  - uid: 923
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 928
+  - uid: 924
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 929
+  - uid: 925
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 930
+  - uid: 926
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 931
+  - uid: 927
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 932
+  - uid: 928
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 933
+  - uid: 929
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 934
+  - uid: 930
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 935
+  - uid: 931
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
-  - uid: 936
+  - uid: 932
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 937
+  - uid: 933
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
-  - uid: 938
+  - uid: 934
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 939
+  - uid: 935
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
-  - uid: 940
+  - uid: 936
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
-  - uid: 941
+  - uid: 937
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 942
+  - uid: 938
     components:
     - type: Transform
       pos: 14.5,0.5
       parent: 1
-  - uid: 943
+  - uid: 939
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 944
+  - uid: 940
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 945
+  - uid: 941
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 946
+  - uid: 942
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 1
-  - uid: 947
+  - uid: 943
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 1
-  - uid: 948
+  - uid: 944
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 949
+  - uid: 945
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 1
-  - uid: 950
+  - uid: 946
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 1
-  - uid: 951
+  - uid: 947
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 1
-  - uid: 952
+  - uid: 948
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 1
-  - uid: 953
+  - uid: 949
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 954
+  - uid: 950
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 955
+  - uid: 951
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 956
+  - uid: 952
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 957
+  - uid: 953
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 958
+  - uid: 954
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 959
+  - uid: 955
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 960
+  - uid: 956
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 961
+  - uid: 957
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 962
+  - uid: 958
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 963
+  - uid: 959
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 964
+  - uid: 960
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 965
+  - uid: 961
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 966
+  - uid: 962
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 967
+  - uid: 963
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 968
+  - uid: 964
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 1
-  - uid: 969
+  - uid: 965
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 970
+  - uid: 966
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 1
-  - uid: 971
+  - uid: 967
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 972
+  - uid: 968
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 1
-  - uid: 973
+  - uid: 969
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-  - uid: 974
+  - uid: 970
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 975
+  - uid: 971
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 976
+  - uid: 972
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 977
+  - uid: 973
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 978
+  - uid: 974
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 979
+  - uid: 975
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 980
+  - uid: 976
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 981
+  - uid: 977
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 982
+  - uid: 978
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 1
-  - uid: 983
+  - uid: 979
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 1
-  - uid: 984
+  - uid: 980
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 985
+  - uid: 981
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 1
-  - uid: 986
+  - uid: 982
     components:
     - type: Transform
       pos: 8.5,10.5
       parent: 1
-  - uid: 987
+  - uid: 983
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 988
+  - uid: 984
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 989
+  - uid: 985
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 990
+  - uid: 986
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 991
+  - uid: 987
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 992
+  - uid: 988
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 1
-  - uid: 993
+  - uid: 989
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 1
-  - uid: 994
+  - uid: 990
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-  - uid: 995
+  - uid: 991
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 1
-  - uid: 996
+  - uid: 992
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 1
-  - uid: 997
+  - uid: 993
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 1
-  - uid: 998
+  - uid: 994
     components:
     - type: Transform
       pos: -8.5,12.5
       parent: 1
-  - uid: 999
+  - uid: 995
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 1000
+  - uid: 996
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 1
-  - uid: 1001
+  - uid: 997
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 1002
+  - uid: 998
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 1003
+  - uid: 999
     components:
     - type: Transform
       pos: -7.5,16.5
       parent: 1
-  - uid: 1004
+  - uid: 1000
     components:
     - type: Transform
       pos: -5.5,16.5
       parent: 1
-  - uid: 1005
+  - uid: 1001
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 1
-  - uid: 1006
+  - uid: 1002
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 1007
+  - uid: 1003
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 1008
+  - uid: 1004
     components:
     - type: Transform
       pos: -6.5,16.5
       parent: 1
-  - uid: 1009
+  - uid: 1005
     components:
     - type: Transform
       pos: -5.5,21.5
       parent: 1
-  - uid: 1010
+  - uid: 1006
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 1
-  - uid: 1011
+  - uid: 1007
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
-  - uid: 1012
+  - uid: 1008
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 1013
+  - uid: 1009
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 1
-  - uid: 1014
+  - uid: 1010
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 1
-  - uid: 1015
+  - uid: 1011
     components:
     - type: Transform
       pos: 9.5,15.5
       parent: 1
-  - uid: 1016
+  - uid: 1012
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 1017
+  - uid: 1013
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 1018
+  - uid: 1014
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 1
-  - uid: 1019
+  - uid: 1015
     components:
     - type: Transform
       pos: 5.5,17.5
       parent: 1
-  - uid: 1020
+  - uid: 1016
     components:
     - type: Transform
       pos: -5.5,17.5
       parent: 1
-  - uid: 1021
+  - uid: 1017
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 1022
+  - uid: 1018
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 1023
+  - uid: 1019
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 1024
+  - uid: 1020
     components:
     - type: Transform
       pos: -4.5,20.5
       parent: 1
-  - uid: 1025
+  - uid: 1021
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 1
-  - uid: 1026
+  - uid: 1022
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 1027
+  - uid: 1023
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 1028
+  - uid: 1024
     components:
     - type: Transform
       pos: -4.5,16.5
       parent: 1
-  - uid: 1029
+  - uid: 1025
     components:
     - type: Transform
       pos: -5.5,20.5
       parent: 1
-  - uid: 1030
+  - uid: 1026
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 1
-  - uid: 1031
+  - uid: 1027
     components:
     - type: Transform
       pos: -4.5,21.5
       parent: 1
-  - uid: 1032
+  - uid: 1028
     components:
     - type: Transform
       pos: -2.5,21.5
       parent: 1
-  - uid: 1033
+  - uid: 1029
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 1
-  - uid: 1034
+  - uid: 1030
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 1
-  - uid: 1035
+  - uid: 1031
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
-  - uid: 1036
+  - uid: 1032
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 1037
+  - uid: 1033
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 1
-  - uid: 1038
+  - uid: 1034
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 1
-  - uid: 1039
+  - uid: 1035
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
-  - uid: 1040
+  - uid: 1036
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 1
-  - uid: 1041
+  - uid: 1037
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 1
-  - uid: 1042
+  - uid: 1038
     components:
     - type: Transform
       pos: 6.5,21.5
       parent: 1
-  - uid: 1043
+  - uid: 1039
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 1
-  - uid: 1044
+  - uid: 1040
     components:
     - type: Transform
       pos: 5.5,20.5
       parent: 1
-  - uid: 1045
+  - uid: 1041
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 1
-  - uid: 1046
+  - uid: 1042
     components:
     - type: Transform
       pos: 7.5,21.5
       parent: 1
-  - uid: 1047
+  - uid: 1043
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
-  - uid: 1048
+  - uid: 1044
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
-  - uid: 1049
+  - uid: 1045
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 1
-  - uid: 1050
+  - uid: 1046
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 1
-  - uid: 1051
+  - uid: 1047
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 1
-  - uid: 1052
+  - uid: 1048
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 1053
+  - uid: 1049
     components:
     - type: Transform
       pos: -4.5,26.5
       parent: 1
-  - uid: 1054
+  - uid: 1050
     components:
     - type: Transform
       pos: -5.5,26.5
       parent: 1
-  - uid: 1055
+  - uid: 1051
     components:
     - type: Transform
       pos: -6.5,25.5
       parent: 1
-  - uid: 1056
+  - uid: 1052
     components:
     - type: Transform
       pos: -6.5,22.5
       parent: 1
-  - uid: 1057
+  - uid: 1053
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
-  - uid: 1058
+  - uid: 1054
     components:
     - type: Transform
       pos: 7.5,25.5
       parent: 1
-  - uid: 1059
+  - uid: 1055
     components:
     - type: Transform
       pos: 7.5,24.5
       parent: 1
-  - uid: 1060
+  - uid: 1056
     components:
     - type: Transform
       pos: 7.5,23.5
       parent: 1
-  - uid: 1061
+  - uid: 1057
     components:
     - type: Transform
       pos: 7.5,22.5
       parent: 1
-  - uid: 1062
+  - uid: 1058
     components:
     - type: Transform
       pos: 2.5,25.5
       parent: 1
-  - uid: 1063
+  - uid: 1059
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 1
-  - uid: 1064
+  - uid: 1060
     components:
     - type: Transform
       pos: -2.5,29.5
       parent: 1
-  - uid: 1065
+  - uid: 1061
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 1066
+  - uid: 1062
     components:
     - type: Transform
       pos: -2.5,28.5
       parent: 1
-  - uid: 1067
+  - uid: 1063
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 1
-  - uid: 1068
+  - uid: 1064
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 1
-  - uid: 1069
+  - uid: 1065
     components:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
-  - uid: 1070
+  - uid: 1066
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 1071
+  - uid: 1067
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 1072
+  - uid: 1068
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
-  - uid: 1073
+  - uid: 1069
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 1074
+  - uid: 1070
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 1
-  - uid: 1075
+  - uid: 1071
     components:
     - type: Transform
       pos: -4.5,18.5
       parent: 1
-  - uid: 1076
+  - uid: 1072
     components:
     - type: Transform
       pos: -4.5,19.5
       parent: 1
-  - uid: 1077
+  - uid: 1073
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 1078
+  - uid: 1074
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 1
-  - uid: 1079
+  - uid: 1075
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 1080
+  - uid: 1076
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 1081
+  - uid: 1077
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 1082
+  - uid: 1078
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 1083
+  - uid: 1079
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 1084
+  - uid: 1080
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 1
-  - uid: 1085
+  - uid: 1081
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 1
 - proto: WallShuttleDiagonalNortheastCurved
   entities:
-  - uid: 1086
+  - uid: 1082
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,27.5
       parent: 1
-  - uid: 1087
+  - uid: 1083
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 1
-  - uid: 1088
+  - uid: 1084
     components:
     - type: Transform
       pos: -6.5,26.5
       parent: 1
-  - uid: 1089
+  - uid: 1085
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
-  - uid: 1090
+  - uid: 1086
     components:
     - type: Transform
       pos: -5.5,29.5
       parent: 1
-  - uid: 1091
+  - uid: 1087
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
-  - uid: 1092
+  - uid: 1088
     components:
     - type: Transform
       pos: -8.5,16.5
       parent: 1
-  - uid: 1093
+  - uid: 1089
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8329,145 +8393,145 @@ entities:
       parent: 1
 - proto: WallShuttleDiagonalNortheastHollow
   entities:
-  - uid: 1094
+  - uid: 1090
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 1095
+  - uid: 1091
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 1
-  - uid: 1096
+  - uid: 1092
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 1
 - proto: WallShuttleDiagonalNorthwestCurved
   entities:
-  - uid: 1097
+  - uid: 1093
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 1
-  - uid: 1098
+  - uid: 1094
     components:
     - type: Transform
       pos: 3.5,30.5
       parent: 1
-  - uid: 1099
+  - uid: 1095
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 1
-  - uid: 1100
+  - uid: 1096
     components:
     - type: Transform
       pos: 9.5,16.5
       parent: 1
 - proto: WallShuttleDiagonalNorthwestHollow
   entities:
-  - uid: 1101
+  - uid: 1097
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-  - uid: 1102
+  - uid: 1098
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 1
-  - uid: 1103
+  - uid: 1099
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
 - proto: WallShuttleDiagonalSoutheastCurved
   entities:
-  - uid: 1104
+  - uid: 1100
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 1105
+  - uid: 1101
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 1106
+  - uid: 1102
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
 - proto: WallShuttleDiagonalSoutheastHollow
   entities:
-  - uid: 1107
+  - uid: 1103
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 1
-  - uid: 1108
+  - uid: 1104
     components:
     - type: Transform
       pos: -6.5,20.5
       parent: 1
 - proto: WallShuttleDiagonalSouthwestCurved
   entities:
-  - uid: 1109
+  - uid: 1105
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 1
-  - uid: 1110
+  - uid: 1106
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 1111
+  - uid: 1107
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 1112
+  - uid: 1108
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
 - proto: WallShuttleDiagonalSouthwestHollow
   entities:
-  - uid: 1113
+  - uid: 1109
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 1114
+  - uid: 1110
     components:
     - type: Transform
       pos: 7.5,20.5
       parent: 1
 - proto: WarpPointShip
   entities:
-  - uid: 1115
+  - uid: 1111
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
 - proto: WeaponCrusherGlaive
   entities:
-  - uid: 1116
+  - uid: 1112
     components:
     - type: Transform
       pos: 4.5218215,16.539116
       parent: 1
-  - uid: 1117
+  - uid: 1113
     components:
     - type: Transform
       pos: 4.5686965,10.468803
       parent: 1
 - proto: WeaponPistolNeoVolker
   entities:
-  - uid: 1118
+  - uid: 1114
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8475,7 +8539,7 @@ entities:
       parent: 1
 - proto: WeaponTurretLargeArtillery
   entities:
-  - uid: 1119
+  - uid: 1115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8484,48 +8548,82 @@ entities:
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: PointCannon
-      linkedConsoleId: 525
+      linkedConsoleIds:
+      - 519
+      linkedConsoleId: 519
     - type: Battery
       startingCharge: 0
 - proto: WeaponTurretRetribution
   entities:
-  - uid: 1120
+  - uid: 1116
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 1
+    - type: PointCannon
+      linkedConsoleIds:
+      - 519
+      linkedConsoleId: 519
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1121
+  - uid: 1117
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
+    - type: PointCannon
+      linkedConsoleIds:
+      - 519
+      linkedConsoleId: 519
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
+  - uid: 1126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,17.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 1000
+    - type: Battery
+      startingCharge: 68.286415
+    - type: ApcPowerReceiverBattery
+      enabled: True
+  - uid: 1127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,17.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 1000
+    - type: Battery
+      startingCharge: 74.45299
+    - type: ApcPowerReceiverBattery
+      enabled: True
 - proto: WindoorSecure
   entities:
-  - uid: 1122
+  - uid: 1118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,20.5
       parent: 1
-  - uid: 1123
+  - uid: 1119
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
-  - uid: 1124
+  - uid: 1120
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 1
-  - uid: 1125
+  - uid: 1121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8533,12 +8631,12 @@ entities:
       parent: 1
 - proto: WindoorSecurePlasma
   entities:
-  - uid: 1126
+  - uid: 1122
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 1
-  - uid: 1127
+  - uid: 1123
     components:
     - type: Transform
       pos: -1.5,28.5

--- a/Resources/Maps/_Crescent/Shuttles/NCWL/Battlecruisers/lister.yml
+++ b/Resources/Maps/_Crescent/Shuttles/NCWL/Battlecruisers/lister.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 268.1.0
   forkId: ""
   forkVersion: ""
-  time: 05/01/2026 12:51:36
-  entityCount: 1213
+  time: 05/03/2026 12:02:38
+  entityCount: 1215
 maps: []
 grids:
 - 1
@@ -509,6 +509,16 @@ entities:
             2431: -10,-11
             2452: 4,-16
             2458: 7,-3
+            2489: 0,11
+            2498: 1,10
+            2535: -6,8
+            2540: -6,11
+            2545: -5,13
+            2550: -5,14
+            2555: -1,10
+            2566: -10,-11
+            2587: 4,-16
+            2593: 7,-3
         - node:
             zIndex: 1
             id: LatticeCornerNW
@@ -652,6 +662,16 @@ entities:
             2441: -7,-3
             2447: -4,-16
             2465: 10,-11
+            2492: 0,11
+            2501: 1,10
+            2511: 5,13
+            2516: 5,14
+            2522: 6,8
+            2527: 6,11
+            2558: -1,10
+            2576: -7,-3
+            2582: -4,-16
+            2600: 10,-11
         - node:
             zIndex: 1
             id: LatticeCornerSE
@@ -858,6 +878,20 @@ entities:
             2444: -6,-5
             2478: -4,16
             2481: -3,18
+            2487: 0,11
+            2496: 1,10
+            2504: 1,11
+            2532: -6,5
+            2538: -6,11
+            2543: -5,13
+            2548: -5,14
+            2553: -1,10
+            2561: -1,11
+            2569: -10,-7
+            2573: -8,-6
+            2579: -6,-5
+            2613: -4,16
+            2616: -3,18
         - node:
             zIndex: 1
             id: LatticeCornerSW
@@ -1064,6 +1098,20 @@ entities:
             2468: 10,-7
             2472: 3,18
             2475: 4,16
+            2491: 0,11
+            2500: 1,10
+            2506: 1,11
+            2510: 5,13
+            2515: 5,14
+            2519: 6,5
+            2526: 6,11
+            2557: -1,10
+            2563: -1,11
+            2590: 6,-5
+            2596: 8,-6
+            2603: 10,-7
+            2607: 3,18
+            2610: 4,16
         - node:
             id: LatticeEdgeE
           decals:
@@ -1333,6 +1381,24 @@ entities:
             2456: 7,-3
             2477: -4,16
             2480: -3,18
+            2486: 0,11
+            2495: 1,10
+            2503: 1,11
+            2531: -6,5
+            2533: -6,8
+            2537: -6,11
+            2542: -5,13
+            2547: -5,14
+            2552: -1,10
+            2560: -1,11
+            2564: -10,-11
+            2568: -10,-7
+            2572: -8,-6
+            2578: -6,-5
+            2585: 4,-16
+            2591: 7,-3
+            2612: -4,16
+            2615: -3,18
         - node:
             id: LatticeEdgeN
           decals:
@@ -1697,6 +1763,29 @@ entities:
             2463: 10,-11
             2483: -5,-18
             2484: 5,-18
+            2488: 0,11
+            2497: 1,10
+            2508: 5,13
+            2513: 5,14
+            2520: 6,8
+            2524: 6,11
+            2534: -6,8
+            2539: -6,11
+            2544: -5,13
+            2549: -5,14
+            2554: -1,10
+            2565: -10,-11
+            2570: -9,-16
+            2574: -7,-3
+            2580: -4,-16
+            2583: -2,-16
+            2584: 2,-16
+            2586: 4,-16
+            2592: 7,-3
+            2597: 9,-16
+            2598: 10,-11
+            2618: -5,-18
+            2619: 5,-18
         - node:
             id: LatticeEdgeS
           decals:
@@ -2140,6 +2229,34 @@ entities:
             2476: -4,16
             2479: -3,18
             2482: -2,20
+            2485: 0,11
+            2493: 0,12
+            2494: 1,10
+            2502: 1,11
+            2507: 5,13
+            2512: 5,14
+            2517: 6,5
+            2523: 6,11
+            2528: 9,5
+            2529: -9,5
+            2530: -6,5
+            2536: -6,11
+            2541: -5,13
+            2546: -5,14
+            2551: -1,10
+            2559: -1,11
+            2567: -10,-7
+            2571: -8,-6
+            2577: -6,-5
+            2588: 6,-5
+            2594: 8,-6
+            2601: 10,-7
+            2604: 2,20
+            2605: 3,18
+            2608: 4,16
+            2611: -4,16
+            2614: -3,18
+            2617: -2,20
         - node:
             id: LatticeEdgeW
           decals:
@@ -2409,6 +2526,24 @@ entities:
             2467: 10,-7
             2471: 3,18
             2474: 4,16
+            2490: 0,11
+            2499: 1,10
+            2505: 1,11
+            2509: 5,13
+            2514: 5,14
+            2518: 6,5
+            2521: 6,8
+            2525: 6,11
+            2556: -1,10
+            2562: -1,11
+            2575: -7,-3
+            2581: -4,-16
+            2589: 6,-5
+            2595: 8,-6
+            2599: 10,-11
+            2602: 10,-7
+            2606: 3,18
+            2609: 4,16
         - node:
             color: '#FFFFFFFF'
             id: TechE
@@ -2907,15 +3042,31 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,12.5
+      pos: 5.5,15.5
       parent: 1
     - type: Physics
       canCollide: False
-  - uid: 3
+  - uid: 5
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,12.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,15.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,12.5
       parent: 1
     - type: Physics
       canCollide: False
@@ -2930,24 +3081,6 @@ entities:
     - type: DeviceLinkSink
       links:
       - 159
-    - type: Physics
-      canCollide: False
-- proto: AAAHardpointMediumBallistic
-  entities:
-  - uid: 5
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,15.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-  - uid: 6
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,15.5
-      parent: 1
     - type: Physics
       canCollide: False
 - proto: AirCanister
@@ -3005,7 +3138,7 @@ entities:
       pos: 3.5,8.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -5998.3975
+      secondsUntilStateChange: -6294.79
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -3028,7 +3161,7 @@ entities:
       pos: 3.5,-8.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -6866.33
+      secondsUntilStateChange: -7162.7227
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -3044,7 +3177,7 @@ entities:
       pos: 6.5,-8.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -6861.13
+      secondsUntilStateChange: -7157.5225
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -3595,32 +3728,24 @@ entities:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-- proto: BaseWeaponTurretShortbow
+- proto: BaseWeaponTurretAzimuth
   entities:
-  - uid: 124
+  - uid: 3
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,15.5
+      pos: -5.5,12.5
       parent: 1
-    - type: PointCannon
-      linkedConsoleIds:
-      - 612
-      linkedConsoleId: 612
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 125
+  - uid: 6
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,12.5
+      pos: -4.5,15.5
       parent: 1
-    - type: PointCannon
-      linkedConsoleIds:
-      - 612
-      linkedConsoleId: 612
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -3629,12 +3754,8 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,12.5
+      pos: 6.5,12.5
       parent: 1
-    - type: PointCannon
-      linkedConsoleIds:
-      - 612
-      linkedConsoleId: 612
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -3643,12 +3764,8 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,15.5
+      pos: 5.5,15.5
       parent: 1
-    - type: PointCannon
-      linkedConsoleIds:
-      - 612
-      linkedConsoleId: 612
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -3670,7 +3787,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 914
+      - 919
   - uid: 130
     components:
     - type: Transform
@@ -3679,7 +3796,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 913
+      - 918
   - uid: 131
     components:
     - type: Transform
@@ -3688,7 +3805,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 917
+      - 922
   - uid: 132
     components:
     - type: Transform
@@ -3697,7 +3814,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 918
+      - 923
   - uid: 133
     components:
     - type: Transform
@@ -3706,7 +3823,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 919
+      - 924
   - uid: 134
     components:
     - type: Transform
@@ -3715,7 +3832,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 920
+      - 925
   - uid: 135
     components:
     - type: Transform
@@ -3724,7 +3841,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 915
+      - 920
   - uid: 136
     components:
     - type: Transform
@@ -3733,7 +3850,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 916
+      - 921
 - proto: BlastDoorOpen
   entities:
   - uid: 137
@@ -6193,18 +6310,6 @@ entities:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-    - type: TargetingConsole
-      cannonGroups:
-        all:
-        - 124
-        - 125
-        - 126
-        - 127
-        48mm 'Shortbow' SRM:
-        - 124
-        - 125
-        - 126
-        - 127
 - proto: ConveyorBelt
   entities:
   - uid: 613
@@ -6215,7 +6320,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 961
+      - 966
   - uid: 614
     components:
     - type: Transform
@@ -6224,7 +6329,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 961
+      - 966
   - uid: 615
     components:
     - type: Transform
@@ -6233,7 +6338,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 960
+      - 965
   - uid: 616
     components:
     - type: Transform
@@ -6242,7 +6347,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       links:
-      - 960
+      - 965
 - proto: CrateFreezer2
   entities:
   - uid: 146
@@ -7527,6 +7632,18 @@ entities:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
+  - uid: 1214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 1215
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-9.5
+      parent: 1
 - proto: HandheldGPSBasic
   entities:
   - uid: 601
@@ -7964,13 +8081,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 1210
+  - uid: 854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
-  - uid: 1211
+  - uid: 855
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7978,159 +8095,159 @@ entities:
       parent: 1
 - proto: Rack
   entities:
-  - uid: 854
+  - uid: 856
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 855
+  - uid: 857
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 856
+  - uid: 858
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 857
+  - uid: 859
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 1212
+  - uid: 860
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 1213
+  - uid: 861
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
 - proto: Railing
   entities:
-  - uid: 858
+  - uid: 862
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 859
+  - uid: 863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 860
+  - uid: 864
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 861
+  - uid: 865
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 862
+  - uid: 866
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 863
+  - uid: 867
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 864
+  - uid: 868
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 1
-  - uid: 865
+  - uid: 869
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-12.5
       parent: 1
-  - uid: 866
+  - uid: 870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-11.5
       parent: 1
-  - uid: 867
+  - uid: 871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 1
-  - uid: 868
+  - uid: 872
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 869
+  - uid: 873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 870
+  - uid: 874
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 871
+  - uid: 875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 872
+  - uid: 876
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 873
+  - uid: 877
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 874
+  - uid: 878
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 875
+  - uid: 879
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 876
+  - uid: 880
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 877
+  - uid: 881
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 878
+  - uid: 882
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 879
+  - uid: 883
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8138,48 +8255,48 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 880
+  - uid: 884
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 881
+  - uid: 885
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 882
+  - uid: 886
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
-  - uid: 883
+  - uid: 887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 884
+  - uid: 888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-8.5
       parent: 1
-  - uid: 885
+  - uid: 889
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-8.5
       parent: 1
-  - uid: 886
+  - uid: 890
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-8.5
       parent: 1
-  - uid: 887
+  - uid: 891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8187,36 +8304,36 @@ entities:
       parent: 1
 - proto: RCDAmmo
   entities:
-  - uid: 888
+  - uid: 892
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 889
+  - uid: 893
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
 - proto: ReinforcedGirder
   entities:
-  - uid: 890
+  - uid: 894
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 891
+  - uid: 895
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 892
+  - uid: 896
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
 - proto: ShuttleLightRed
   entities:
-  - uid: 893
+  - uid: 897
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8224,112 +8341,112 @@ entities:
       parent: 1
 - proto: ShuttleLightSodium
   entities:
-  - uid: 894
+  - uid: 898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,9.5
       parent: 1
-  - uid: 895
+  - uid: 899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 896
+  - uid: 900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 897
+  - uid: 901
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 898
+  - uid: 902
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 1
-  - uid: 899
+  - uid: 903
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 900
+  - uid: 904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-  - uid: 901
+  - uid: 905
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 1
-  - uid: 902
+  - uid: 906
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 903
+  - uid: 907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 904
+  - uid: 908
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 905
+  - uid: 909
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 906
+  - uid: 910
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 907
+  - uid: 911
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 908
+  - uid: 912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 909
+  - uid: 913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 910
+  - uid: 914
     components:
     - type: Transform
       pos: -2.5,15.5
       parent: 1
-  - uid: 911
+  - uid: 915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 912
+  - uid: 916
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 1209
+  - uid: 917
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8337,7 +8454,7 @@ entities:
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 913
+  - uid: 918
     components:
     - type: Transform
       pos: 8.5,-6.5
@@ -8347,7 +8464,7 @@ entities:
         130:
         - - Pressed
           - Toggle
-  - uid: 914
+  - uid: 919
     components:
     - type: Transform
       pos: -7.5,-6.5
@@ -8359,7 +8476,7 @@ entities:
           - Toggle
 - proto: SignalButtonDirectional
   entities:
-  - uid: 915
+  - uid: 920
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8370,7 +8487,7 @@ entities:
         135:
         - - Pressed
           - Toggle
-  - uid: 916
+  - uid: 921
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8381,7 +8498,7 @@ entities:
         136:
         - - Pressed
           - Toggle
-  - uid: 917
+  - uid: 922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8392,7 +8509,7 @@ entities:
         131:
         - - Pressed
           - Toggle
-  - uid: 918
+  - uid: 923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8403,7 +8520,7 @@ entities:
         132:
         - - Pressed
           - Toggle
-  - uid: 919
+  - uid: 924
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8414,7 +8531,7 @@ entities:
         133:
         - - Pressed
           - Toggle
-  - uid: 920
+  - uid: 925
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8427,7 +8544,7 @@ entities:
           - Toggle
 - proto: SignDirectionalBrig
   entities:
-  - uid: 921
+  - uid: 926
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8435,25 +8552,25 @@ entities:
       parent: 1
 - proto: SignDirectionalEng
   entities:
-  - uid: 922
+  - uid: 927
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 923
+  - uid: 928
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
 - proto: SignDirectionalGravity
   entities:
-  - uid: 924
+  - uid: 929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 1
-  - uid: 925
+  - uid: 930
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8461,7 +8578,7 @@ entities:
       parent: 1
 - proto: SignDirectionalMed
   entities:
-  - uid: 926
+  - uid: 931
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8469,43 +8586,43 @@ entities:
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 927
+  - uid: 932
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 1
-  - uid: 928
+  - uid: 933
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 929
+  - uid: 934
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 930
+  - uid: 935
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 931
+  - uid: 936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 932
+  - uid: 937
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 1
-  - uid: 933
+  - uid: 938
     components:
     - type: Transform
       pos: -1.5,5.5
@@ -8548,30 +8665,30 @@ entities:
           - 607
 - proto: TableReinforced
   entities:
-  - uid: 934
+  - uid: 939
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 935
+  - uid: 940
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 936
+  - uid: 941
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
 - proto: TeslaCoil
   entities:
-  - uid: 937
+  - uid: 942
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-12.5
       parent: 1
-  - uid: 938
+  - uid: 943
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8579,111 +8696,111 @@ entities:
       parent: 1
 - proto: ThrusterNCWLWarship
   entities:
-  - uid: 939
+  - uid: 944
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-14.5
       parent: 1
-  - uid: 940
+  - uid: 945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-14.5
       parent: 1
-  - uid: 941
+  - uid: 946
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 942
+  - uid: 947
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-14.5
       parent: 1
-  - uid: 943
+  - uid: 948
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-12.5
       parent: 1
-  - uid: 944
+  - uid: 949
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
-  - uid: 945
-    components:
-    - type: Transform
-      pos: 7.5,4.5
-      parent: 1
-  - uid: 946
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-11.5
-      parent: 1
-  - uid: 947
-    components:
-    - type: Transform
-      pos: 8.5,4.5
-      parent: 1
-  - uid: 948
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-12.5
-      parent: 1
-  - uid: 949
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-11.5
-      parent: 1
   - uid: 950
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,6.5
+      pos: 7.5,4.5
       parent: 1
   - uid: 951
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,7.5
+      pos: -8.5,-11.5
       parent: 1
   - uid: 952
     components:
     - type: Transform
-      pos: -6.5,4.5
+      pos: 8.5,4.5
       parent: 1
   - uid: 953
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 1
+  - uid: 954
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-11.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-14.5
       parent: 1
-  - uid: 954
+  - uid: 959
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-14.5
       parent: 1
-  - uid: 955
+  - uid: 960
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 956
+  - uid: 961
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-14.5
       parent: 1
-  - uid: 957
+  - uid: 962
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8691,21 +8808,21 @@ entities:
       parent: 1
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 958
+  - uid: 963
     components:
     - type: Transform
       pos: -3.5365715,-11.993194
       parent: 1
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 959
+  - uid: 964
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
 - proto: TwoWayLever
   entities:
-  - uid: 960
+  - uid: 965
     components:
     - type: Transform
       pos: -7.5,-8.5
@@ -8726,7 +8843,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-  - uid: 961
+  - uid: 966
     components:
     - type: Transform
       pos: 8.5,-8.5
@@ -8749,1263 +8866,1263 @@ entities:
           - Off
 - proto: VendingMachineChemicals
   entities:
-  - uid: 962
+  - uid: 967
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 963
+  - uid: 968
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 964
+  - uid: 969
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
 - proto: WallPlastitaniumDiagonalCurved
   entities:
-  - uid: 965
+  - uid: 970
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 1
-  - uid: 966
+  - uid: 971
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
 - proto: WallPlastitaniumNCWL
   entities:
-  - uid: 967
+  - uid: 972
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 968
+  - uid: 973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,1.5
       parent: 1
-  - uid: 969
+  - uid: 974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,1.5
       parent: 1
-  - uid: 970
+  - uid: 975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
       parent: 1
-  - uid: 971
+  - uid: 976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,8.5
       parent: 1
-  - uid: 972
+  - uid: 977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,7.5
       parent: 1
-  - uid: 973
+  - uid: 978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,1.5
       parent: 1
-  - uid: 974
+  - uid: 979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 975
+  - uid: 980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 976
+  - uid: 981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 977
+  - uid: 982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 978
+  - uid: 983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 979
+  - uid: 984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 1
-  - uid: 980
+  - uid: 985
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,3.5
       parent: 1
-  - uid: 981
+  - uid: 986
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,9.5
       parent: 1
-  - uid: 982
+  - uid: 987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 983
+  - uid: 988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 984
+  - uid: 989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 1
-  - uid: 985
+  - uid: 990
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 986
+  - uid: 991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 987
+  - uid: 992
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 988
+  - uid: 993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 989
+  - uid: 994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 990
+  - uid: 995
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 991
+  - uid: 996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 992
+  - uid: 997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
-  - uid: 993
+  - uid: 998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 994
+  - uid: 999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-14.5
       parent: 1
-  - uid: 995
+  - uid: 1000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 996
+  - uid: 1001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,3.5
       parent: 1
-  - uid: 997
+  - uid: 1002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-1.5
       parent: 1
-  - uid: 998
+  - uid: 1003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
       parent: 1
-  - uid: 999
+  - uid: 1004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 1000
+  - uid: 1005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,3.5
       parent: 1
-  - uid: 1001
+  - uid: 1006
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-14.5
       parent: 1
-  - uid: 1002
+  - uid: 1007
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-14.5
       parent: 1
-  - uid: 1003
+  - uid: 1008
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-12.5
       parent: 1
-  - uid: 1004
+  - uid: 1009
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-0.5
       parent: 1
-  - uid: 1005
+  - uid: 1010
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 1
-  - uid: 1006
+  - uid: 1011
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-1.5
       parent: 1
-  - uid: 1007
+  - uid: 1012
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-10.5
       parent: 1
-  - uid: 1008
+  - uid: 1013
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-13.5
       parent: 1
-  - uid: 1009
+  - uid: 1014
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 1010
+  - uid: 1015
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-13.5
       parent: 1
-  - uid: 1011
+  - uid: 1016
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,3.5
       parent: 1
-  - uid: 1012
+  - uid: 1017
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 1013
+  - uid: 1018
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-16.5
       parent: 1
-  - uid: 1014
+  - uid: 1019
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 1015
+  - uid: 1020
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-10.5
       parent: 1
-  - uid: 1016
+  - uid: 1021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 1017
+  - uid: 1022
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-13.5
       parent: 1
-  - uid: 1018
+  - uid: 1023
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 1019
+  - uid: 1024
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-13.5
       parent: 1
-  - uid: 1020
+  - uid: 1025
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,3.5
       parent: 1
-  - uid: 1021
+  - uid: 1026
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 1022
+  - uid: 1027
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 1023
+  - uid: 1028
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,3.5
       parent: 1
-  - uid: 1024
+  - uid: 1029
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 1025
+  - uid: 1030
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,6.5
       parent: 1
-  - uid: 1026
+  - uid: 1031
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,7.5
       parent: 1
-  - uid: 1027
+  - uid: 1032
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,8.5
       parent: 1
-  - uid: 1028
+  - uid: 1033
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,8.5
       parent: 1
-  - uid: 1029
+  - uid: 1034
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,10.5
       parent: 1
-  - uid: 1030
+  - uid: 1035
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,11.5
       parent: 1
-  - uid: 1031
+  - uid: 1036
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,13.5
       parent: 1
-  - uid: 1032
+  - uid: 1037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,14.5
       parent: 1
-  - uid: 1033
+  - uid: 1038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,16.5
       parent: 1
-  - uid: 1034
+  - uid: 1039
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,17.5
       parent: 1
-  - uid: 1035
+  - uid: 1040
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,17.5
       parent: 1
-  - uid: 1036
+  - uid: 1041
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,17.5
       parent: 1
-  - uid: 1037
+  - uid: 1042
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,18.5
       parent: 1
-  - uid: 1038
+  - uid: 1043
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,18.5
       parent: 1
-  - uid: 1039
+  - uid: 1044
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,16.5
       parent: 1
-  - uid: 1040
+  - uid: 1045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,14.5
       parent: 1
-  - uid: 1041
+  - uid: 1046
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,13.5
       parent: 1
-  - uid: 1042
+  - uid: 1047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 1
-  - uid: 1043
+  - uid: 1048
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,10.5
       parent: 1
-  - uid: 1044
+  - uid: 1049
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,10.5
       parent: 1
-  - uid: 1045
+  - uid: 1050
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,9.5
       parent: 1
-  - uid: 1046
+  - uid: 1051
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 1047
+  - uid: 1052
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,8.5
       parent: 1
-  - uid: 1048
+  - uid: 1053
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,7.5
       parent: 1
-  - uid: 1049
+  - uid: 1054
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,6.5
       parent: 1
-  - uid: 1050
+  - uid: 1055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 1051
+  - uid: 1056
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 1052
+  - uid: 1057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 1053
+  - uid: 1058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,16.5
       parent: 1
-  - uid: 1054
+  - uid: 1059
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,17.5
       parent: 1
-  - uid: 1055
+  - uid: 1060
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,15.5
       parent: 1
-  - uid: 1056
+  - uid: 1061
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,14.5
       parent: 1
-  - uid: 1057
+  - uid: 1062
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,10.5
       parent: 1
-  - uid: 1058
+  - uid: 1063
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 1059
+  - uid: 1064
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,16.5
       parent: 1
-  - uid: 1060
+  - uid: 1065
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,15.5
       parent: 1
-  - uid: 1061
+  - uid: 1066
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,14.5
       parent: 1
-  - uid: 1062
+  - uid: 1067
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 1063
+  - uid: 1068
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 1064
+  - uid: 1069
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 1065
+  - uid: 1070
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 1066
+  - uid: 1071
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 1067
+  - uid: 1072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 1068
+  - uid: 1073
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,8.5
       parent: 1
-  - uid: 1069
+  - uid: 1074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 1070
+  - uid: 1075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,19.5
       parent: 1
-  - uid: 1071
+  - uid: 1076
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,19.5
       parent: 1
-  - uid: 1072
+  - uid: 1077
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 1073
+  - uid: 1078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 1074
+  - uid: 1079
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
-  - uid: 1075
+  - uid: 1080
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-12.5
       parent: 1
-  - uid: 1076
+  - uid: 1081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 1077
+  - uid: 1082
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-13.5
       parent: 1
-  - uid: 1078
+  - uid: 1083
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-13.5
       parent: 1
-  - uid: 1079
+  - uid: 1084
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-14.5
       parent: 1
-  - uid: 1080
+  - uid: 1085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-15.5
       parent: 1
-  - uid: 1081
+  - uid: 1086
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-15.5
       parent: 1
-  - uid: 1082
+  - uid: 1087
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-14.5
       parent: 1
-  - uid: 1083
+  - uid: 1088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-13.5
       parent: 1
-  - uid: 1084
+  - uid: 1089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-13.5
       parent: 1
-  - uid: 1085
+  - uid: 1090
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-12.5
       parent: 1
-  - uid: 1086
+  - uid: 1091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 1087
+  - uid: 1092
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 1088
+  - uid: 1093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-6.5
       parent: 1
-  - uid: 1089
+  - uid: 1094
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 1090
+  - uid: 1095
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-13.5
       parent: 1
-  - uid: 1091
+  - uid: 1096
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-13.5
       parent: 1
-  - uid: 1092
+  - uid: 1097
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-14.5
       parent: 1
-  - uid: 1093
+  - uid: 1098
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-15.5
       parent: 1
-  - uid: 1094
+  - uid: 1099
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-15.5
       parent: 1
-  - uid: 1095
+  - uid: 1100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-14.5
       parent: 1
-  - uid: 1096
+  - uid: 1101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-13.5
       parent: 1
-  - uid: 1097
+  - uid: 1102
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 1
-  - uid: 1098
+  - uid: 1103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-10.5
       parent: 1
-  - uid: 1099
+  - uid: 1104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-6.5
       parent: 1
-  - uid: 1100
+  - uid: 1105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 1101
+  - uid: 1106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-10.5
       parent: 1
-  - uid: 1102
+  - uid: 1107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-5.5
       parent: 1
-  - uid: 1103
+  - uid: 1108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 1104
+  - uid: 1109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-4.5
       parent: 1
-  - uid: 1105
+  - uid: 1110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-3.5
       parent: 1
-  - uid: 1106
+  - uid: 1111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-11.5
       parent: 1
-  - uid: 1107
+  - uid: 1112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-10.5
       parent: 1
-  - uid: 1108
+  - uid: 1113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-9.5
       parent: 1
-  - uid: 1109
+  - uid: 1114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-11.5
       parent: 1
-  - uid: 1110
+  - uid: 1115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 1
-  - uid: 1111
+  - uid: 1116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 1112
+  - uid: 1117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 1113
+  - uid: 1118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-7.5
       parent: 1
-  - uid: 1114
+  - uid: 1119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 1115
+  - uid: 1120
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 1
-  - uid: 1116
+  - uid: 1121
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 1117
+  - uid: 1122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 1118
+  - uid: 1123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-6.5
       parent: 1
-  - uid: 1119
+  - uid: 1124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,5.5
       parent: 1
-  - uid: 1120
+  - uid: 1125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 1121
+  - uid: 1126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-6.5
       parent: 1
-  - uid: 1122
+  - uid: 1127
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 1123
+  - uid: 1128
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 1124
+  - uid: 1129
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 1125
+  - uid: 1130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,4.5
       parent: 1
-  - uid: 1126
+  - uid: 1131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-6.5
       parent: 1
-  - uid: 1127
+  - uid: 1132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 1128
+  - uid: 1133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-10.5
       parent: 1
-  - uid: 1129
+  - uid: 1134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,5.5
       parent: 1
-  - uid: 1130
+  - uid: 1135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-11.5
       parent: 1
-  - uid: 1131
+  - uid: 1136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-0.5
       parent: 1
-  - uid: 1132
+  - uid: 1137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,0.5
       parent: 1
-  - uid: 1133
+  - uid: 1138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,4.5
       parent: 1
-  - uid: 1134
+  - uid: 1139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-2.5
       parent: 1
-  - uid: 1135
+  - uid: 1140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,0.5
       parent: 1
-  - uid: 1136
+  - uid: 1141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,2.5
       parent: 1
-  - uid: 1137
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-5.5
       parent: 1
-  - uid: 1138
+  - uid: 1143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-13.5
       parent: 1
-  - uid: 1139
+  - uid: 1144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,2.5
       parent: 1
-  - uid: 1140
+  - uid: 1145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 1141
+  - uid: 1146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-14.5
       parent: 1
-  - uid: 1142
+  - uid: 1147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-13.5
       parent: 1
-  - uid: 1143
+  - uid: 1148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-10.5
       parent: 1
-  - uid: 1144
+  - uid: 1149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-10.5
       parent: 1
-  - uid: 1145
+  - uid: 1150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-13.5
       parent: 1
-  - uid: 1146
+  - uid: 1151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-6.5
       parent: 1
-  - uid: 1147
+  - uid: 1152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 1148
+  - uid: 1153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 1149
+  - uid: 1154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-1.5
       parent: 1
-  - uid: 1150
+  - uid: 1155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-1.5
       parent: 1
-  - uid: 1151
+  - uid: 1156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 1152
+  - uid: 1157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,4.5
       parent: 1
-  - uid: 1153
+  - uid: 1158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-1.5
       parent: 1
-  - uid: 1154
+  - uid: 1159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 1155
+  - uid: 1160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 1156
+  - uid: 1161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 1157
+  - uid: 1162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-1.5
       parent: 1
-  - uid: 1158
+  - uid: 1163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-1.5
       parent: 1
-  - uid: 1159
+  - uid: 1164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 1
-  - uid: 1160
+  - uid: 1165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 1161
+  - uid: 1166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 1162
+  - uid: 1167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 1163
+  - uid: 1168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 1164
+  - uid: 1169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 1165
+  - uid: 1170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 1166
+  - uid: 1171
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 1167
+  - uid: 1172
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,10.5
       parent: 1
-  - uid: 1168
+  - uid: 1173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,10.5
       parent: 1
-  - uid: 1169
+  - uid: 1174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,10.5
       parent: 1
-  - uid: 1170
+  - uid: 1175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 1171
+  - uid: 1176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10013,186 +10130,186 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonalCurved
   entities:
-  - uid: 1172
+  - uid: 1177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 1
-  - uid: 1173
+  - uid: 1178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-15.5
       parent: 1
-  - uid: 1174
+  - uid: 1179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-10.5
       parent: 1
-  - uid: 1175
-    components:
-    - type: Transform
-      pos: -7.5,-5.5
-      parent: 1
-  - uid: 1176
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-2.5
-      parent: 1
-  - uid: 1177
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-15.5
-      parent: 1
-  - uid: 1178
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-17.5
-      parent: 1
-  - uid: 1179
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,0.5
-      parent: 1
   - uid: 1180
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-2.5
+      pos: -7.5,-5.5
       parent: 1
   - uid: 1181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,-2.5
+      pos: -6.5,-2.5
       parent: 1
   - uid: 1182
     components:
     - type: Transform
-      pos: -5.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-15.5
       parent: 1
   - uid: 1183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-2.5
+      parent: 1
+  - uid: 1186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 1188
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
-  - uid: 1184
+  - uid: 1189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-17.5
       parent: 1
-  - uid: 1185
+  - uid: 1190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,16.5
       parent: 1
-  - uid: 1186
+  - uid: 1191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,13.5
       parent: 1
-  - uid: 1187
+  - uid: 1192
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 1
-  - uid: 1188
+  - uid: 1193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,8.5
       parent: 1
-  - uid: 1189
+  - uid: 1194
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
-  - uid: 1190
+  - uid: 1195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,20.5
       parent: 1
-  - uid: 1191
+  - uid: 1196
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-15.5
       parent: 1
-  - uid: 1192
+  - uid: 1197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-15.5
       parent: 1
-  - uid: 1193
+  - uid: 1198
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
-  - uid: 1194
+  - uid: 1199
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 1
-  - uid: 1195
+  - uid: 1200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-10.5
       parent: 1
-  - uid: 1196
+  - uid: 1201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-6.5
       parent: 1
-  - uid: 1197
+  - uid: 1202
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1198
+  - uid: 1203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 1
-  - uid: 1199
+  - uid: 1204
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 1
-  - uid: 1200
+  - uid: 1205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 1
-  - uid: 1201
+  - uid: 1206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 1
-  - uid: 1202
+  - uid: 1207
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,8.5
       parent: 1
-  - uid: 1203
+  - uid: 1208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10200,12 +10317,12 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonalHollow
   entities:
-  - uid: 1204
+  - uid: 1209
     components:
     - type: Transform
       pos: -2.5,18.5
       parent: 1
-  - uid: 1205
+  - uid: 1210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10213,21 +10330,21 @@ entities:
       parent: 1
 - proto: WarpPointShip
   entities:
-  - uid: 1206
+  - uid: 1211
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: WaterCooler
   entities:
-  - uid: 1207
+  - uid: 1212
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
 - proto: WeaponTurretLargeMachinegun
   entities:
-  - uid: 1208
+  - uid: 1213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10248,9 +10365,7 @@ entities:
           occludes: True
           ent: null
     - type: ApcPowerReceiver
-      powerLoad: 1000
+      powerLoad: 5
     - type: Battery
-      startingCharge: 416.94626
-    - type: ApcPowerReceiverBattery
-      enabled: True
+      startingCharge: 0
 ...


### PR DESCRIPTION
i swapped the Lister from 4x 48mm to 4x 60mm, I gave it 2x more gyroscopes to help it better define itself as a mobile cruiser variant

I gave the sunesis the same gyroscope buff and 2x 200cc turrets, for a matching guncount to the Lister. I took its "Combat Phase" in mind and intentionally gave it weaker turrets than the Lister, this ship needs a pretty major remap but this works for today.