### PR TITLE
Makes stamped papers not get covered in an error sprite

### DIFF
--- a/Resources/Locale/en-US/_Crescent/paper/stamp-component.ftl
+++ b/Resources/Locale/en-US/_Crescent/paper/stamp-component.ftl
@@ -1,4 +1,4 @@
 stamp-component-stamped-name-ncwl = Union Command
 stamp-component-stamped-name-empire = House Olywir
 stamp-component-stamped-name-hunters = St. Romaine's Church
-stamp-component-stamped-name-shi = Shinohara Heavy Industries
+stamp-component-stamped-name-shinohara = Shinohara Heavy Industries

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Misc/stamps.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Misc/stamps.yml
@@ -7,7 +7,7 @@
   - type: Stamp
     stampedName: stamp-component-stamped-name-ncwl
     stampedColor: "#ffd580"
-    stampState: "paper_stamp-ncwl"
+    stampState: "paper_stamp-qm"
   - type: Sprite
     sprite: _Crescent/Objects/Misc/stamps.rsi
     state: stampncwl
@@ -21,7 +21,7 @@
   - type: Stamp
     stampedName: stamp-component-stamped-name-empire
     stampedColor: "#432d51"
-    stampState: "paper_stamp-empire"
+    stampState: "paper_stamp-chaplain"
   - type: Sprite
     sprite: _Crescent/Objects/Misc/stamps.rsi
     state: empire
@@ -35,7 +35,7 @@
   - type: Stamp
     stampedName: stamp-component-stamped-name-hunters
     stampedColor: "#4a6741"
-    stampState: "paper_stamp-hunter"
+    stampState: "paper_stamp-generic"
   - type: Sprite
     sprite: _Crescent/Objects/Misc/stamps.rsi
     state: empire
@@ -49,7 +49,7 @@
   - type: Stamp
     stampedName: stamp-component-stamped-name-shinohara
     stampedColor: "#bb9042"
-    stampState: "paper_stamp-shi"
+    stampState: "paper_stamp-trader"
   - type: Sprite
     sprite: _Crescent/Objects/Misc/stamps.rsi
     state: stamp-shi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixes stamps so they aren't referencing sprites that no longer exist. Used existing vanilla sprites because I couldn't find the ones we used to use either because I'm incompetent or they were turned to dust in the great upstream incident of 2025.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
