### PR TITLE
Quick Psionics Rework

### DIFF
--- a/Content.Shared/Voidborn/EtherealComponent.cs
+++ b/Content.Shared/Voidborn/EtherealComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class EtherealComponent : Component
     ///     How much stamina damage does the user take each second they are in the dark realm?
     /// </summary>
     [DataField]
-    public float StaminaPerSecond = 1;
+    public float StaminaPerSecond = 10;
 
     [DataField]
     public float StaminaDamageOnFlash = 200f;

--- a/Resources/Locale/en-US/traits/psionics.ftl
+++ b/Resources/Locale/en-US/traits/psionics.ftl
@@ -19,26 +19,15 @@ trait-name-Elementalist = Elementalist
 trait-description-Elementalist =
     'Elementalists' are a rare and modern form of Psion, noted for their potential for bombastic feats of "Kinesis".
     So rare were these individuals, that at one point in time they were known by titles such as Sorcerer, or Magician, if they weren't a charlatan that is.
-    As an Elementalist, your talent for developing new powers is severely limited.
-    Yet despite this tradeoff, your powers are more exclusively the realm of flashy and dangerous. You will never generate any powers known as "Mentalics".
+    Yet despite this tradeoff, your powers are more exclusively the realm of flashy and dangerous.
     You are almost certainly going to be hunted. Let others know what you can do at the peril of your very soul.
-
-    - You can never "roll" new powers. The powers you buy at character creation are all you will ever have.
-    - Your available powers are strictly limited to "Kinetics".
-    - You will never be Telepathic.
 
 trait-name-PsychoHistorian = Psycho-Historian
 trait-description-PsychoHistorian =
     Psycho-Historians are a fairly common and well-studied branch of psionic users, whose powers are documented in the public domain
     as far back as the 1970s on Earth. Mythological accounts of such individuals can also be traced back thousands of years. Today,
     Psycho-Historians make up the overwhelming bulk of the Epistemics Cult's awakened members. Your powers are generally regarded as "Safe", as they
-    exclusively interact from one mind to another without need of interacting with extra-planar forces. However, you will never be able
-    to learn any powers known as "Kinesis".
-
-    - Your powers are developed at a significantly faster rate than other psychics.
-    - Your available powers are strictly limited to "Mentalics"
-    - You are automatically considered Telepathic.
-
+    exclusively interact from one mind to another without need of interacting with extra-planar forces.
 
 trait-name-Biomancer = Biomancer
 trait-description-Biomancer =
@@ -53,10 +42,13 @@ trait-description-Pyromancer =
     The cold worsened until my only option was to step into the fire. It did not burn me, but instead surrounded me like it was clothing, protecting me from the relentless cold.
     The flame was my shield.
 
+    - You are immune to welding and flashes.
+
 trait-name-PsionicHunter = Psion Hunter
-trait-description-PsionHunter =
-    Test
+trait-description-PsionicHunter =
+    I thought I was crazy. I've been hearing voices, day or night, they never stop. My sleep is troubled, my focus eroded. I must silence them.
 
 trait-name-AstralThief = Astral Thief
 trait-description-AstralThief =
-    Test
+    I've always been good at blending in, standing in the back of a crowd unnoticed, getting into places I don't belong. But recently, something has felt off,
+    they look straight at me and walk past. I am no longer there.

--- a/Resources/Locale/en-US/traits/psionics.ftl
+++ b/Resources/Locale/en-US/traits/psionics.ftl
@@ -44,11 +44,19 @@ trait-name-Biomancer = Biomancer
 trait-description-Biomancer =
     Every night, I have a strange but specific dream. I see myself in an operating room, one me standing over another, in a coma.
     This version of me that is awake whispers unintelligable words that refuse to leave my brain, like it was something I've said all my life.
-    The comatose version of me wakes up. (you are not telepathic, nor can you obtain most powers, but you are able to learn healing word, psionic regeneration, and revivify)
+    The comatose version of me wakes up.
 
 trait-name-Pyromancer = Pyromancer
 trait-description-Pyromancer =
     For years, my sleep had been restless. every time I tried to sleep, it was always too hot, and it felt like something was trying to shine a light in my closed eyes.
     Then, I had a strange dream. an unrelenting flame in the middle of a frozen forest, refusing to give out and die. I get closer to the fire as the cold got more and more intense.
     The cold worsened until my only option was to step into the fire. It did not burn me, but instead surrounded me like it was clothing, protecting me from the relentless cold.
-    The flame was my shield. (you are not telepathic, nor can you obtain most powers, but you can learn flame flare and can unlock other pyrokinetic abilities)
+    The flame was my shield.
+
+trait-name-PsionicHunter = Psion Hunter
+trait-description-PsionHunter =
+    Test
+
+trait-name-AstralThief = Astral Thief
+trait-description-AstralThief =
+    Test

--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -301,7 +301,7 @@
   components:
     - type: InstantAction
       icon: { sprite: Interface/Actions/voidborn_icons.rsi, state: darkswap }
-      useDelay: 10
+      useDelay: 8
       checkCanInteract: false
       event: !type:DarkSwapActionEvent
 

--- a/Resources/Prototypes/CharacterItemGroups/Psionics/castingTypes.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Psionics/castingTypes.yml
@@ -12,3 +12,9 @@
       id: Biomancer
     - type: trait
       id: Pyromancer
+    - type: trait
+      id: Elementalist
+    - type: trait
+      id: PsionicHunter
+    - type: trait
+      id: AstralThief

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -288,12 +288,12 @@
         type: Add
         time: 5
         refresh: false
-      - !type:ChemRerollPsionic #Nyano - Summary: lets the imbiber become psionic.
-        bonusMultiplier: 2
-        conditions:
-        - !type:ReagentThreshold
-          reagent: SpaceDrugs
-          min: 15
+#      - !type:ChemRerollPsionic #Nyano - Summary: lets the imbiber become psionic.
+#        bonusMultiplier: 2
+#        conditions:
+#        - !type:ReagentThreshold
+#          reagent: SpaceDrugs
+#          min: 15
       - !type:ChemAddMoodlet
         moodPrototype: SpaceDrugsBenefit
 

--- a/Resources/Prototypes/Reagents/psionic.yml
+++ b/Resources/Prototypes/Reagents/psionic.yml
@@ -19,10 +19,10 @@
       #     "psionic-regeneration-essence-breath"
       #   ]
       #   probability: 0.15
-      - !type:SatiateThirst
-        factor: -3
-      - !type:SatiateHunger
-        factor: -3
+#      - !type:SatiateThirst
+#        factor: -3
+#      - !type:SatiateHunger
+#        factor: -3
       - !type:ModifyBleedAmount
         amount: -1
       - !type:ModifyBloodLevel
@@ -80,12 +80,12 @@
         type: Add
         time: 5
         refresh: false
-      - !type:ChemRerollPsionic
-        bonusMultiplier: 4
-        conditions:
-        - !type:ReagentThreshold
-          reagent: LotophagoiOil
-          min: 20
+#      - !type:ChemRerollPsionic
+#        bonusMultiplier: 4
+#        conditions:
+#        - !type:ReagentThreshold
+#          reagent: LotophagoiOil
+#          min: 20
       - !type:GenericStatusEffect
         key: Stutter
         component: ScrambledAccent

--- a/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
@@ -1,0 +1,210 @@
+- type: trait
+  id: PsionicHunter
+  category: Psionics
+  points: -4
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          baselinePowerCost: 2000
+          nextPowerCost: 2000
+        - type: Eye
+          visMask:
+            - PsionicInvisibility
+            - Normal
+            - Ethereal
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - PsychognomyPower
+        - MetapsionicPower
+        - AssayPower
+        - DispelPower
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+            - Oni
+
+- type: trait
+  id: Pyromancer
+  category: Psionics
+  points: -8
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          baselinePowerCost: 2000
+          nextPowerCost: 2000
+        - type: EyeProtection
+        - type: FlashImmunity
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - TelepathyPower
+        - PyrokineticFlare
+        - SummonImpPower
+        - PyrokinesisPower
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+            - Oni
+
+- type: trait
+  id: AstralThief
+  category: Psionics
+  points: -8
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          roller: false
+          baselinePowerCost: 2000
+          nextPowerCost: 2000
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - TelepathyPower
+        - ShadeskipPower
+        - DarkSwapPower
+        - AnoigoPower
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+            - Oni
+
+- type: trait
+  id: Biomancer
+  category: Psionics
+  points: -8
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          baselinePowerCost: 2000
+          nextPowerCost: 2000
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - TelepathyPower
+        - PsionicRegenerationPower
+        - HealingWordPower
+        - RevivifyPower
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+            - Oni
+
+- type: trait
+  id: Elementalist
+  category: Psionics
+  points: -6
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          baselinePowerCost: 2000
+          nextPowerCost: 2000
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - TelepathyPower
+        - NoosphericZapPower
+        - TelekineticPulsePower
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+            - Oni
+
+- type: trait
+  id: PsychoHistorian
+  category: Psionics
+  points: -8
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Psionic
+          baselinePowerCost: 2000
+          nextPowerCost: 2000
+    - !type:TraitAddPsionics
+      psionicPowers:
+        - TelepathyPower
+        - XenoglossyPower
+        - PsychognomyPower
+        - TelegnosisPower
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsCasterType
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg
+        - MedicalBorg
+        - Chaplain
+        - Prisoner
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
+            - Oni

--- a/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
@@ -11,6 +11,7 @@
           nextPowerCost: 2000
     - !type:TraitAddPsionics
       psionicPowers:
+        - TelepathyPower
         - PsychognomyPower
         - MetapsionicPower
         - AssayPower

--- a/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
@@ -40,7 +40,7 @@
 - type: trait
   id: Pyromancer
   category: Psionics
-  points: -8
+  points: -10
   functions:
     - !type:TraitAddComponent
       components:
@@ -72,11 +72,15 @@
           species:
             - IPC
             - Oni
+        - !type:CharacterTraitRequirement
+          inverted: true
+          traits:
+            - Photophobia
 
 - type: trait
   id: AstralThief
   category: Psionics
-  points: -8
+  points: -10
   functions:
     - !type:TraitAddComponent
       components:
@@ -111,7 +115,7 @@
 - type: trait
   id: Biomancer
   category: Psionics
-  points: -8
+  points: -10
   functions:
     - !type:TraitAddComponent
       components:
@@ -145,7 +149,7 @@
 - type: trait
   id: Elementalist
   category: Psionics
-  points: -6
+  points: -10
   functions:
     - !type:TraitAddComponent
       components:
@@ -178,7 +182,7 @@
 - type: trait
   id: PsychoHistorian
   category: Psionics
-  points: -8
+  points: -10
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterArchetypes.yml
@@ -6,13 +6,9 @@
     - !type:TraitAddComponent
       components:
         - type: Psionic
+          roller: false
           baselinePowerCost: 2000
           nextPowerCost: 2000
-        - type: Eye
-          visMask:
-            - PsionicInvisibility
-            - Normal
-            - Ethereal
     - !type:TraitAddPsionics
       psionicPowers:
         - PsychognomyPower
@@ -45,6 +41,7 @@
     - !type:TraitAddComponent
       components:
         - type: Psionic
+          roller: false
           baselinePowerCost: 2000
           nextPowerCost: 2000
         - type: EyeProtection
@@ -120,6 +117,7 @@
     - !type:TraitAddComponent
       components:
         - type: Psionic
+          roller: false
           baselinePowerCost: 2000
           nextPowerCost: 2000
     - !type:TraitAddPsionics
@@ -154,6 +152,7 @@
     - !type:TraitAddComponent
       components:
         - type: Psionic
+          roller: false
           baselinePowerCost: 2000
           nextPowerCost: 2000
     - !type:TraitAddPsionics
@@ -187,6 +186,7 @@
     - !type:TraitAddComponent
       components:
         - type: Psionic
+          roller: false
           baselinePowerCost: 2000
           nextPowerCost: 2000
     - !type:TraitAddPsionics

--- a/Resources/Prototypes/Traits/Psionics/casterTypes.yml
+++ b/Resources/Prototypes/Traits/Psionics/casterTypes.yml
@@ -1,26 +1,26 @@
-- type: trait
-  id: LatentPsychic
-  category: Psionics
-  points: -4
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Psionic
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: TraitsCasterType
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Borg
-        - MedicalBorg
-        - Chaplain
-        - Prisoner
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterSpeciesRequirement
-          species:
-            - Moth
+#- type: trait
+#  id: LatentPsychic
+#  category: Psionics
+#  points: -4
+#  functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: Psionic
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: TraitsCasterType
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#        - Borg
+#        - MedicalBorg
+#        - Chaplain
+#        - Prisoner
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterSpeciesRequirement
+#          species:
+#            - Moth
 
 - type: trait
   id: PsionicInsulation
@@ -48,86 +48,86 @@
             - IPC
             - Oni
 
-- type: trait
-  id: PsychoHistorian
-  category: Psionics
-  points: -4
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Psionic
-          baselinePowerCost: 75
-          nextPowerCost: 75
-          removable: false
-          powerPool: PsychoHistorianPowerPool
-    - !type:TraitAddPsionics
-      psionicPowers:
-        - TelepathyPower
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: TraitsCasterType
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Borg
-        - MedicalBorg
-        - Chaplain
-        - Prisoner
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterSpeciesRequirement
-          species:
-            - Moth
+#- type: trait
+#  id: PsychoHistorian
+#  category: Psionics
+#  points: -4
+#  functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: Psionic
+#          baselinePowerCost: 75
+#          nextPowerCost: 75
+#          removable: false
+#          powerPool: PsychoHistorianPowerPool
+#    - !type:TraitAddPsionics
+#      psionicPowers:
+#        - TelepathyPower
+#  requirements:
+#   - !type:CharacterItemGroupRequirement
+#      group: TraitsCasterType
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#        - Borg
+#        - MedicalBorg
+#        - Chaplain
+#        - Prisoner
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterSpeciesRequirement
+#          species:
+#            - Moth
 
 
-- type: trait
-  id: Biomancer
-  category: Psionics
-  points: -4
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Psionic
-          powerPool: BiomancerPowerPool
-    - !type:TraitAddPsionics
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: TraitsCasterType
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Borg
-        - MedicalBorg
-        - Chaplain
-        - Prisoner
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterSpeciesRequirement
-          species:
-            - Moth
+#- type: trait
+#  id: Biomancer
+#  category: Psionics
+#  points: -4
+#  functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: Psionic
+#          powerPool: BiomancerPowerPool
+#    - !type:TraitAddPsionics
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#     group: TraitsCasterType
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#        - Borg
+#        - MedicalBorg
+#        - Chaplain
+#        - Prisoner
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterSpeciesRequirement
+#          species:
+#            - Moth
 
-- type: trait
-  id: Pyromancer
-  category: Psionics
-  points: -4
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Psionic
-          powerPool: PyromancerPowerPool
-    - !type:TraitAddPsionics
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: TraitsCasterType
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Borg
-        - MedicalBorg
-        - Chaplain
-        - Prisoner
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterSpeciesRequirement
-          species:
-            - Moth
+#- type: trait
+#  id: Pyromancer
+#  category: Psionics
+#  points: -4
+# functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: Psionic
+#          powerPool: PyromancerPowerPool
+#    - !type:TraitAddPsionics
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: TraitsCasterType
+#   - !type:CharacterJobRequirement
+#      inverted: true
+#     jobs:
+#        - Borg
+#        - MedicalBorg
+#        - Chaplain
+#        - Prisoner
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterSpeciesRequirement
+#          species:
+#            - Moth

--- a/Resources/Prototypes/Traits/Psionics/feats.yml
+++ b/Resources/Prototypes/Traits/Psionics/feats.yml
@@ -1,37 +1,37 @@
-- type: trait
-  id: HighPotential
-  category: Psionics
-  points: -10
-  requirements:
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterTraitRequirement
-          traits:
-            - LatentPsychic
-            - PsychoHistorian
-            - Biomancer
-            - Pyromancer
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterSpeciesRequirement
-          inverted: true
-          species:
-            - IPC
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Oni
-        - Voidborn
-  functions:
-    - !type:TraitReplaceComponent
-      components:
-        - type: PotentiaModifier
-          potentiaMultiplier: 1.5
+#- type: trait
+#  id: HighPotential
+#  category: Psionics
+#  points: -4
+#  requirements:
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterTraitRequirement
+#          traits:
+#            - LatentPsychic
+#            - PsychoHistorian
+#            - Biomancer
+#            - Pyromancer
+#    - !type:CharacterLogicOrRequirement
+#      requirements:
+#        - !type:CharacterSpeciesRequirement
+#          inverted: true
+#          species:
+#            - IPC
+#    - !type:CharacterSpeciesRequirement
+#      inverted: true
+#      species:
+#        - Oni
+#        - Voidborn
+#  functions:
+#    - !type:TraitReplaceComponent
+#      components:
+#        - type: PotentiaModifier
+#          potentiaMultiplier: 1.5
 
 - type: trait
   id: PowerOverwhelming
   category: Psionics
-  points: -10
+  points: -4
   requirements:
     - !type:CharacterLogicOrRequirement
       requirements:
@@ -41,6 +41,8 @@
             - PsychoHistorian
             - Biomancer
             - Pyromancer
+            - Elementalist
+            - AstralThief
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Traits/Psionics/feats.yml
+++ b/Resources/Prototypes/Traits/Psionics/feats.yml
@@ -37,7 +37,7 @@
       requirements:
         - !type:CharacterTraitRequirement
           traits:
-            - LatentPsychic
+#            - LatentPsychic
             - PsychoHistorian
             - Biomancer
             - Pyromancer

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -302,6 +302,7 @@
       inverted: true
       traits:
         - Blindness
+        - Pyromancer
   functions:
     - !type:TraitReplaceComponent
       components:


### PR DESCRIPTION
A rework meant to pull psionics out of the limbo they have been in since they were added and remove the RNG element that crippled them. Adds several psicaster archetypes with unique power pools, they now start with innate telepathy and a few powers. As a tradeoff, they no longer gain potentia from drugs and are limited to their starting abilities. The most unbalanced abilities are either removed or rebalanced.
This is meant to give every archetype its specialty, by avoiding any power overlaps, we can make classes that will have different strengths and counters.

Psicaster Archetypes:
- Psionic Hunter: The weakest class, it trades combat abilities for the capability to sense and identify psions around them.
- Pyromancer: Limited to a few offensive powers, they gain innate flash and welder protection.
- Elementalist: Only has Noospheric Zap and Telekinetic Pulse for now. Meant to be a more offensive caste similar to Pyromancer.
- Astral Thief: With a limited invisibility that drains their stamina quickly, a jump and the power to open doors, the Astral thief is built for quick stealth strikes and evasion.
- Biomancer: A psychic healer. They can regenerate themselves, heal small amounts of damage with their palm, or raise their comrades out of crit.
- Psycho-Historian: Devoid of combat abilities, they instead have innate understanding of all languages. They can also scry around with Telegnosis, allowing them to leave their bodies to scan their surroundings as an ethereal ghost. Their connection to the noosphere allows them to glean some information from the voices in their head such as age, gender or skin color.

My concerns:
With psionics finally being useful without farming or getting a lucky roll, they might become *too* common. The balance is probably not quite right as they are mostly not meant to be roundstart abilities. I'm hoping this will be counterbalanced by other game systems but we can always come back and fiddle with it again.

Leaving this as a draft for now for testing and feedback.

---

# TODO

- [x] Add and change descriptions for the new caster types
- [ ] Give Psionic hunters innate psionic invisibility vision, similar to psionic immune mobs
- [ ] Give Psionic hunters the ability to hear and identify people using telepathy without allowing them to speak in it themselves
- [ ] Implement more Elementalist abilities

---
