### PR TITLE
remove phase prevent comp from basebullet

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -55,10 +55,6 @@
   description: If you can see this you're probably dead!
   abstract: true
   components:
-  - type: ProjectilePhasePrevent
-    mask:
-    - Impassable
-    - BulletImpassable
   - type: Reflective
   - type: Clickable
   - type: Sprite


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

A quick (and admittedly lazy) catch-all I put into the yaml when popping in phase prevent on our projectiles has had an inadvertent effect of making Exhumer cannon projectiles not check their code properly and become much weaker, this removes the catch-all and thus makes mining gooderer again.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
