### PR TITLE
NCWL Grenades + Factions OWN their Grenades

### DIFF
--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
@@ -12,11 +12,9 @@
     - 0,0,7,1
   - type: StorageFill
     contents:
-      - id: ExGrenade
-        amount: 4
-      - id: SyndieMiniBomb
-        amount: 2
-      - id: EmpGrenade
+      - id: RGD55M13Handgrenade
+        amount: 6
+      - id: ZaryiaFlashangHandgrenade
         amount: 2
   - type: StaticPrice
     price: 250

--- a/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
+++ b/Resources/Prototypes/_Crescent/Catalog/Fills/Belt/belt.yml
@@ -14,7 +14,7 @@
     contents:
       - id: RGD55M13Handgrenade
         amount: 6
-      - id: ZaryiaFlashangHandgrenade
+      - id: ZaryiaFlashbangHandgrenade
         amount: 2
   - type: StaticPrice
     price: 250

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -602,11 +602,19 @@
     Plasma: 250
     NanotrasenElectronics: 1500
 
-#- type: latheRecipe
-#  id: NCWLRGD55M13
-#  result: RGD55M13Hendgrenade
-#  completetime: 2
-# materials:
-#   Plasma: 500
-#    Steel: 100
+- type: latheRecipe
+  id: RGD55M13Handgrenade
+  result: RGD55M13Handgrenade
+  completetime: 2
+  materials:
+   Plasma: 400
+   Steel: 100
 
+- type: latheRecipe
+  id: ZaryiaFlashbangHandgrenade
+  result: ZaryiaFlashbangHandgrenade
+  completetime: 2
+  materials:
+   Plastic: 100
+   Plasma: 50
+   Steel: 150

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -603,7 +603,7 @@
     NanotrasenElectronics: 1500
 
 - type: latheRecipe
-  id: NCWLRGD55M13
+  id: RGD55M13Handgrenade
   result: RGD55M13Handgrenade
   completetime: 2
   materials:

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -612,7 +612,7 @@
 
 - type: latheRecipe
   id: ZaryiaFlashbangHandgrenade
-  result: NCWL Zaryia-4M Flashbang
+  result: ZaryiaFlashbangHandgrenade
   completetime: 2
   materials:
    Plastic: 100

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -612,7 +612,7 @@
 
 - type: latheRecipe
   id: ZaryiaFlashbangHandgrenade
-  result: ZaryiaFlashbangHandgrenade
+  result: NCWL Zaryia-4M Flashbang
   completetime: 2
   materials:
    Plastic: 100

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -603,7 +603,7 @@
     NanotrasenElectronics: 1500
 
 - type: latheRecipe
-  id: RGD55M13Handgrenade
+  id: NCWLRGD55M13
   result: RGD55M13Handgrenade
   completetime: 2
   materials:

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -269,7 +269,7 @@
       - TimerTrigger
       - EMPGrenadeElectronics
       - GrenadeDSMG4Twistcap
-      - GrenadeNCWLRGD55M13
+      - RGD55M13Handgrenade
       - ZaryiaFlashbangHandgrenade
       - DrumMagazineShotgunSlug
       - DrumMagazineShotgunEmpty

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -269,6 +269,8 @@
       - TimerTrigger
       - EMPGrenadeElectronics
       - GrenadeDSMG4Twistcap
+      - GrenadeNCWLRGD55M13
+      - ZaryiaFlashbangHandgrenade
       - DrumMagazineShotgunSlug
       - DrumMagazineShotgunEmpty
       - DrumMagazineShotgunBuck

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -267,10 +267,6 @@
       - VoiceTrigger
       - SignalTrigger
       - TimerTrigger
-      - EMPGrenadeElectronics
-      - GrenadeDSMG4Twistcap
-      - RGD55M13Handgrenade
-      - ZaryiaFlashbangHandgrenade
       - DrumMagazineShotgunSlug
       - DrumMagazineShotgunEmpty
       - DrumMagazineShotgunBuck
@@ -819,6 +815,7 @@
       - KhanLPC
       - PerigaleLPC
       - RaiderLPC
+      - GrenadeDSMG4Twistcap
       # DSM end
       # NCWL start
       - ClothingHeadHelmetNCWLEVA
@@ -886,6 +883,8 @@
       - ClothingOuterHardsuitNCWLJuggernaut
       - NCWLKukri
       - ClothingBeltSheathNCWLKukri
+      - RGD55M13Handgrenade
+      - ZaryiaFlashbangHandgrenade
       # NCWL end
       - ClothingUniformJumpsuitExecutiveShinoharaSuit
       - ClothingUniformJumpsuitShinoharaLogistics
@@ -999,6 +998,7 @@
       - MetempsychoticMachineCircuitboard
       - HardlinerFlatpack
       - PowerCageHardliner
+      - EMPGrenadeElectronics
       #fabdisk recipies
       - WeaponRifleM90GrenadeLauncherNT
       - WeaponSubMachineGunMP5NT

--- a/Resources/Prototypes/_Crescent/Research/communard.yml
+++ b/Resources/Prototypes/_Crescent/Research/communard.yml
@@ -103,6 +103,8 @@
   - WeaponSubMachineGunNCWLWatchdog
   - ClothingOuterHardsuitNCWLInfantry
   - WeaponShotgunDoubleBarreledNCWL
+  - RGD55M13Handgrenade
+  - ZaryiaFlashbangHandgrenade
 
 # - type: technology
 #   id: CommunardKrechet

--- a/Resources/Prototypes/_Crescent/Research/imperial.yml
+++ b/Resources/Prototypes/_Crescent/Research/imperial.yml
@@ -33,7 +33,7 @@
   - ClothingOuterHardsuitImperialSoldier
   - WeaponRifleMiller
   - WeaponSubMachineGunC20rImperial
-  - DSMG4TwistcapHandgrenade
+  - GrenadeDSMG4Twistcap
 #putarmorplate
 
 

--- a/Resources/Prototypes/_Crescent/Research/imperial.yml
+++ b/Resources/Prototypes/_Crescent/Research/imperial.yml
@@ -33,6 +33,7 @@
   - ClothingOuterHardsuitImperialSoldier
   - WeaponRifleMiller
   - WeaponSubMachineGunC20rImperial
+  - DSMG4TwistcapHandgrenade
 #putarmorplate
 
 


### PR DESCRIPTION


# Description

This PR makes the NCWL RGD-55M13 Grenade and the NCWL Zaryia-4M Flashbang accessible to NCWL through their standard gear research.

it also replaces the grenades that was in their armory at first (three vests, 4 SHI smart grenades, 2 IRM twist cap grenades, 2 SHI EMP grenades) with three vests with 6 RGD-55M13 Grenades and 2 Zaryia-4M Flashbang each.

Additionally, No longer does every lathe under the sun have SHI and DSM Grenades accessible to all; SHI and DSM now are the only ones who can research and produce their own grenades.
That means no Vagrants on a backwater producing high tech SHI products, that means no NCWL Partisans throwing Mandate weapons back towards the imperials.

If you want SHI Grenades, Buy them today!

The RGD-55M13 Grenade has a 4 second fuze and does around 180~ Damage to a Mk1 +Steel Insert Humanoid compared to the 200 Damage of other grenades, however the 20% faster fuze and slightly 20% cheaper plasma cost makes up for this damage lapse.

The Zaryia-4M Flashbang has a 2 second fuze, and if you recall; gas masks have widely had their flash protection removed.  A new way to clear the way for your pointman in a Boarding Action..?


---

# TODO

- [ ] Brewing my Coffee
- [x] Test of the Vest changes
- [x] Test of the RnD changes
- [x] Sending confused screenshots to EB of a Simple Change that I messed up

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>
<img width="390" height="311" alt="Screenshot 2026-05-06 094737" src="https://github.com/user-attachments/assets/1865be6b-e8a1-4a7f-9c63-117da0facae7" />
</h1></summary>
<p>
<details><summary><h1>
<img width="390" height="311" alt="
<img width="867" height="353" alt="Screenshot 2026-05-06 094817" src="https://github.com/user-attachments/assets/513e0d5c-428d-4dc8-8f3d-8cd886bb2daf" />
<img width="489" height="287" alt="Screenshot 2026-05-06 100411" src="https://github.com/user-attachments/assets/42c332c4-1e2c-4b39-b463-bd8f7d5c366c" />
<img width="492" height="318" alt="Screenshot 2026-05-06 102933" src="https://github.com/user-attachments/assets/ebc8d1b6-7bf1-46b2-8169-452fa74aa11c" />

https://github.com/user-attachments/assets/3e3a6d96-364c-448c-8d28-1b01e9d3d25d


</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

:cl:
- add: IRM Twist Cap to DSM Research
- tweak: Changed Grenade vests on Balreska to NCWL Grenades
- remove: Faction grenades where they don't belong
