### PR TITLE
Reduces wirecutter and screwdriver sizes in-inventory

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Tools/tools.yml
@@ -52,9 +52,7 @@
       path: /Audio/Items/wirecutter.ogg
   - type: Item
     sprite: _Crescent/Objects/Tools/New_Tools/wirecutter.rsi
-    size: Normal
-    shape:
-      - 0,0,1,2
+    size: Small
   - type: ToolTileCompatible
   - type: PhysicalComposition
     materialComposition:
@@ -105,6 +103,7 @@
     storedSprite:
       sprite: _Crescent/Objects/Tools/New_Tools/screwdriver.rsi
       state: icon
+    size: Tiny
   - type: MeleeWeapon
     wideAnimationRotation: -135
     range: 1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

wirecutter reduced back to 1x2, screwdriver reduced to 1x1 (SCREWDRIVER BUFF??? WHAT MADNESS DO WE HAVE IN STORE NEXT???)

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
