### PR TITLE
Misc Bugfixes/Tweaks Quatro [Draugr Suit, CDT StealthSuit, Courtier, NemesisWreck

### DIFF
--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -103,8 +103,8 @@ ent-ClothingOuterHardsuitJuggernautReverseEngineered = CSA-80UA - "Guan Yu" tacs
     .desc = The pride and joy of the Cybersun-Armaments Corporation, named after an ancient Sol' War God. Commonly known throughout the galaxy as a "Juggernaut".
         Matching its bulky appearance, it protects against all forms of damage. It feels VERY heavy.
 ent-ClothingOuterHardsuitCybersunStealth = CDT mk.I "Èguǐ" tacsuit
-    .desc = A rare prototype tacsuit produced by the Cyberdawn-Technologies Corporation that features metamaterial plating which warps light around it to produce an "Invisibility cloak" effect.
-    Unfortunately, it accomplishes this by trading a lot of protections that one would normally expect from a typical tacsuit.
+    .desc = A rare prototype tacsuit produced by the Cyberdawn-Technologies Corporation that seeks to improve upon stolen designs of the SVBT-2XB "RAIKU" suit from their competitors at Shinohara.
+    Accomplishes this by using advanced meta-materials to strengthen the light armor plating sewn into the suit's core with only a minimal loss in agility.
 ent-ClothingOuterHardsuitWizard = WZD-84 - "Mana" tacsuit
     .desc = A bizarre gem-encrusted hardsuit. Famously used by members of the Wizard Federation in their operations.
     Contrary to it's appearance, it can protect its wearer from space and considerable amounts of physical trauma, it feels somewhat light.

--- a/Resources/Maps/_Crescent/Derelicts/NemWreck1.yml
+++ b/Resources/Maps/_Crescent/Derelicts/NemWreck1.yml
@@ -11511,13 +11511,6 @@ entities:
       isPlaceable: True
     - type: Physics
       bodyType: Static
-- proto: WarpPointShip
-  entities:
-  - uid: 1458
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1
 - proto: WindowTintedDirectional
   entities:
   - uid: 1459

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/FourFamilies/OuterClothing/armor.yml
@@ -1,7 +1,7 @@
 #hardsuits
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitDraugr
   name: DRAUGR mk.I pressurized combat exosuit
   description: A combat hardsuit of antiquated make. Tribal fetishes adorn the dented breastplate. Used by many Pacters belonging to the Al'Seik family.
@@ -15,15 +15,14 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor # I am completely winging this. This is complete dogshit. Thankfully, 'abysmal dogshit' is all that's being asked of me.
-    armorMaxHealth: 100
-    armorType: Plastic
-    armorRepair: SteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 36
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Heat: 0.9
+        Cold: 0.9
+        Caustic: 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -39,7 +38,7 @@
       - ClothingOuterHardsuitThukker
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitArabet
   name: prophet's pressurized hardsuit
   description: An unusual hardsuit constructed of sleek plasteel, gilded with tribal patterns. The shoulderplates bear the mark of the Arabet family of the Pact.
@@ -53,15 +52,14 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 100
-    armorType: Plastic
-    armorRepair: SteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 36
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Heat: 0.9
+        Cold: 0.9
+        Caustic: 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -71,7 +69,7 @@
     price: 1000
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitIzdari
   name: izdari beltrunner's armored hardsuit
   description: A modified version of an antiquated atmospheric techinican's hardsuit. Around three generations out of date. Attributed commonly to the Izdari family.
@@ -85,15 +83,14 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 100
-    armorType: Plastic
-    armorRepair: SteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 36
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Heat: 0.9
+        Cold: 0.9
+        Caustic: 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -109,7 +106,7 @@
       - ClothingOuterHardsuitDraugr
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitThukker
   name: thukker combat engineer's hardsuit
   description: A modified mining hardsuit adorned with the livery of the Thukker family of the Pact. Features bulky lead shielding against radiation.
@@ -123,15 +120,14 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 100
-    armorType: Plastic
-    armorRepair: SteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 36
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Heat: 0.9
+        Cold: 0.9
+        Caustic: 0.9
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
@@ -267,12 +267,6 @@
     sprite: _Crescent/Clothing/SHI/OuterClothing/speedsuit.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/SHI/OuterClothing/speedsuit.rsi
-  - type: ExtendDescription
-    descriptionList:
-      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
-        fontSize: 15
-        color: "#ff2106"
-        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/courtier.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/courtier.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-imperial
   canBeAntag: false
   requirements:
-    - !type:CharacterWhitelistRequirement
+    #- !type:CharacterWhitelistRequirement
     - !type:FactionRequirement
       factionID: "DSM"
     - !type:CharacterOverallTimeRequirement

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -70,8 +70,8 @@
     - type: StealthOnMove
       passiveVisibilityRate: -0.75
       movementVisibilityRate: 0.375
-  - type: FlashImmunity
-  - type: FlashSoundSuppression
+  - type: NightVision
+    isEquipment: true
 
 
 # cybersun dreadnought suit.

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -64,22 +64,19 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.65
-  - type: DegradeableArmor
-    armorMaxHealth: 600
-    armorType: Metallic
-    armorRepair: SteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 10
-        Slash: 25
-        Piercing: 45
-        Heat: 15
-        Caustic: 15
-        Radiation: 25
+    damageCoefficient: 0.9
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.65
+        Heat: 0.9
+        Cold: 0.9
+        Caustic: 0.9
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.85
+    walkModifier: 1.2
+    sprintModifier: 1.2
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersunStealth


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

- Draugr suit changed to use our current percentage resistances instead of old flat damage nullification
- CDT Egui Stealth Suit changed to use percentage resistances, now acts a a very slightly slower but more durable SHI Raiku suit. Night-Vision added and FlashProtection removed, description clarified to no longer mention the defunct stealth field.
- Courtier whitelist requirement commented out, making the role playable again
- Nemesis wrecks will no longer have erroneous ghost warp points

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
