### PR TITLE
Converts NCWL's Lancer to a utility mech + some misc mech tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -182,7 +182,7 @@
         Blunt: 14 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 5
+    baseSprintSpeed: 4.5
 
 - type: entity
   id: MechRipleyBattery

--- a/Resources/Prototypes/_Crescent/Entities/Objects/Specific/mechs.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Objects/Specific/mechs.yml
@@ -20,7 +20,7 @@
     footstepSoundCollection:
       path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
   - type: Mech
-    maxIntegrity: 225
+    maxIntegrity: 275
     baseState: carrion
     openState: carrion-open
     brokenState: carrion-broken
@@ -37,7 +37,7 @@
         Blunt: 40
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 2.5
+    baseSprintSpeed: 4.5
     weightlessFriction: 0.4
     weightlessAcceleration: 0.1
     weightlessModifier: 8 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
@@ -141,9 +141,9 @@
 
 - type: entity
   id: MechNCWLLancer
-  parent: [ BaseMech, HybridScoutMech ]
+  parent: [ BaseMech, IndustrialMech ]
   name: HNF mk.I Lancer hybrid mechsuit
-  description: A light biped exosuit that can take both light weapon and some industrial modules. Developed by Pang Tai Arms under the codename Project Goldenstar, and adapted for the uses of the State by the Union Homeguard Naval Foundries some time after. The workhorse of the Homeguard Navy.
+  description: A light biped exosuit that can take industrial modules. Developed by Pang Tai Arms under the codename Project Goldenstar, and adapted for the uses of the State by the Union Homeguard Naval Foundries some time after. The workhorse of the Homeguard Navy.
   components:
   - type: Sprite
     drawdepth: Mobs
@@ -159,11 +159,11 @@
     footstepSoundCollection:
       path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
   - type: Mech
-    maxIntegrity: 220
+    maxIntegrity: 275
     baseState: lancer
     openState: lancer-open
     brokenState: lancer-broken
-    mechToPilotDamageMultiplier: 0.25
+    mechToPilotDamageMultiplier: 0.5
     airtight: true
     pilotWhitelist:
       components:
@@ -173,13 +173,13 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 25
+        Blunt: 40
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2.7
-    baseSprintSpeed: 2.7
+    baseWalkSpeed: 2.5
+    baseSprintSpeed: 4.5
     weightlessFriction: 0.4
-    weightlessAcceleration: 0.2
-    weightlessModifier: 7.5 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
+    weightlessAcceleration: 0.1
+    weightlessModifier: 8 # 20ish ship speed - weightless speed is influenced by weightlessModifier and base(Walk/Sprint)Speed
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: ProjectileIFF

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -133,7 +133,7 @@
         Blunt: 26
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 5
+    baseSprintSpeed: 4.5
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: StaticPrice


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Changes up the Mk1 Lancer's parenting so that it is now purely a utility platform capable of carrying drills/clamps/pKAs etc. Also replaces Ripley spawns on Balreska with this 'updated' Lancer platform.

Reels back the speed that Ripley/Clarke have over other mechs and buffs the DSM Carrion and NCWL Lancer to share in this new baseline speed. Carrion/Lancer are still strictly 'better' than their independent counterpoints by having slightly more durability and a stronger ability to maneuver in vacuums.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
