### PR TITLE
no more 90% explosion resistance for you

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -111,7 +111,7 @@
     damageCoefficient: 0.1
 
 - type: entity
-  parent: ClothingBeltSecurityWebbing
+  parent: [ClothingBeltSecurityWebbing, ContentsExplosionResistanceBase]
   id: ClothingBeltNfsdWebbing
   name: nfsd webbing
   description: A tactical assault webbing.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Multiple in-game belts had faulty yaml parenting that resulted in what was meant to be a 90% explosion resistance for their contents applying to the _entire wearer_

this uhh... this should now be fixed

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
