### PR TITLE
Mapped Hardpoints an Shields unwrenchable

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Structures/Machines/Computers/hardpoints.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/Machines/Computers/hardpoints.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseHardpoint
-  parent: BaseMachinePowered
+  parent: BaseMachineUnwrenchable
   name: Hardpoint
   abstract: true
   components:
@@ -22,8 +22,6 @@
           collection: MetalGlassBreak
   - type: Repairable
     doAfterDelay: 8
-  - type: Anchorable
-    delay: 10
   - type: PointLight
     enabled: false
     castShadows: false

--- a/Resources/Prototypes/_Crescent/Entities/Structures/Machines/unwrenchabletech.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/Machines/unwrenchabletech.yml
@@ -1,0 +1,49 @@
+- type: entity
+  abstract: true
+  parent: BaseStructure
+  id: BaseMachineUnwrenchable
+  components:
+  - type: InteractionOutline
+  - type: Physics
+    bodyType: Static
+  - type: Transform
+    noRot: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: InteractionVerbs
+    allowedVerbs:
+    - KnockOn
+  - type: ApcPowerReceiver
+    powerLoad: 1000
+  - type: ExtensionCableReceiver
+  - type: LightningTarget
+    priority: 1

--- a/Resources/Prototypes/_Crescent/Entities/Structures/shield_emitter.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/shield_emitter.yml
@@ -14,7 +14,7 @@
 
 - type: entity
   id: ShieldEmitter
-  parent: BaseMachinePowered
+  parent: BaseMachineUnwrenchable
   name: NT-910 'Goliath' deflector emitter
   description: A complicated array of machinery - guzzles power and maintains a bubble deflector shield around the mother vessel. Overheats with too much use.
   components:


### PR DESCRIPTION
All mapped hardpoints and shields are now unwrenchable, this should have happened a year ago. Hardpoints are deeply set gun mounts to disperse recoil/electronics stuff with the rest of your shuttle. 

Yeah this is a balance thing, the gameplay of roundstart ship modding is something I've grown very bored with, this is shared with several of our more jaded/experienced players. The Meta of breaking down several ships to dominate someone who didn't do the same thing is never fun.

I will be allowing moveable hardpoints to be craftable, currently small hardpoints and medium fixed points are greenlighted for this. I will start with it only being a SAW thing as I try to refine this. Perhaps we may do craftable movable shields at some point.


as an ideasguy note, I want to experiment with an different system to this to be more friendly with field-repairs