### PR TITLE
Well

### DIFF
--- a/Resources/Prototypes/World/worldgen_default.yml
+++ b/Resources/Prototypes/World/worldgen_default.yml
@@ -5,10 +5,10 @@
   - type: BiomeSelection
     biomes:
     - Failsafe
-    - GraveyardWrecks
+    # - GraveyardWrecks
     - AbyssWrecks
     #- AncientBattlefieldWrecks
-    - HeartlandsWrecks
+    # - HeartlandsWrecks
     - AsteroidCentralBeltRing
     - NewAsteroidsStandardTaypanOne
     - NewAsteroidsStandardTaypanTwo

--- a/Resources/Prototypes/_Crescent/GameRules/hullrotGamemodes.yml
+++ b/Resources/Prototypes/_Crescent/GameRules/hullrotGamemodes.yml
@@ -141,10 +141,10 @@
         posY: 120
         IFFColor: IndianRed
         IFFFaction: TFSC
-      AncientBattlefield:
-        gameMapID: AncientBattlefield
-        posX: 3920
-        posY: -5550
+      # AncientBattlefield:
+      #   gameMapID: AncientBattlefield
+      #   posX: 3920
+      #   posY: -5550
       IronRing:
         gameMapID: IronRing
         posX: -3000

--- a/Resources/Prototypes/_Crescent/World/basic.yml
+++ b/Resources/Prototypes/_Crescent/World/basic.yml
@@ -255,6 +255,9 @@
   chunkComponents:
   - type: DebrisFeaturePlacerController
     densityNoiseChannel: DensityGraveyard
+    densityMultiplier: 18
+    maxDebrisPerChunk: 1
+    randomCancelChance: 0.8
   - type: NoiseDrivenDebrisSelector
     noiseChannel: WreckGraveyard
     debrisTable:


### PR DESCRIPTION
Prevents the two primary salvage fields from spawning, primarily for testing purposes for tomorrows host. Also sets the two debris fields to only spawn wrecks 20% of the time, for when and if this gets reverted. 