### PR TITLE
Researchable & craftable patreon weapons

### DIFF
--- a/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
+++ b/Resources/Locale/en-US/_Crescent/research/researchNEW.ftl
@@ -188,3 +188,4 @@ research-technology-shinohara-oldntballistics = Old NT Gun Schematics
 research-technology-shinohara-ntartillery = NT Artillery Patent
 research-technology-shinohara-weaponcase = Shinohara Storage Standards
 research-technology-shinohara-grenades = Shinohara Grenade Patterns
+research-technology-shinohara-pulseguns = Shinohara Pulse Weaponry

--- a/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/SHI/armor.yml
@@ -1,10 +1,10 @@
 #hardsuits
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, StreeCredRedeemable]
+  parent: [ClothingOuterHardsuitBase, StreeCredRedeemable, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitMetrocop
   name: SHI-WTI CMP-1 "Metropolis" security softsuit
-  description: A softsuit padded with durathread soft plates. very effective against low-power rounds and buckshot but weak against rifle rounds. Commony used by peace enforcers in mega cities.
+  description: A softsuit padded with durathread soft plates. More mobile then standard combat hardsuits, but offers very little protection outside of the carrier plate. Commonly used by the Patent Protection Force. #changed desc to memory hole mega gliess
   components:
   - type: Sprite
     sprite: _Crescent/Clothing/SHI/OuterClothing/metrocop.rsi
@@ -12,25 +12,27 @@
     equipSound: /Audio/_Crescent/Items/Clothing/CombineSuit/puton.ogg
     unequipSound: /Audio/_Crescent/Items/Clothing/CombineSuit/takeoff.ogg
     sprite: _Crescent/Clothing/SHI/OuterClothing/metrocop.rsi
+  - type: ExtendDescription #having a carrier plate makes the CMP-1 a viable choice even with the RAIKU suit in play.
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.8
-  - type: DegradeableArmor
-    armorMaxHealth: 2000 # this is its gimick that its got high health but shit protection
-    armorType: Metallic
-    armorRepair: PlasteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 15
-        Slash: 15
-        Piercing: 35
-        Heat: 15
-        Caustic: 15
+  - type: Armor #changed it from degradeable armor to work with the armor insert system, check to make sure the values fit your balance.
+    modifiers:
+      coefficients:
+        Blunt: 0.95 #personally stats should be lower to match description but tweak it as you wish.
+        Slash: 0.95
+        Heat: 0.9
+        Cold: 0.9
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.95
+    walkModifier: 0.97
+    sprintModifier: 0.97
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMetrocop
   - type: ClothingAddFaction
@@ -46,10 +48,10 @@
         volume: -7 # dawg this shit loud and i cant be bothered to make it quieter
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, StreeCredRedeemable]
+  parent: [ClothingOuterHardsuitBase, StreeCredRedeemable, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitCombine
   name: SHI-WTI OTA-3 "Combine" combat hardsuit
-  description: A nearly fully durathread combat hardsuit developed by Wu-Tan Industries, lacks protection but makes it up in its durability. Has glow up strips on the shoulders to prevent frendly fire in dark enviroments.
+  description: A nearly fully durathread combat hardsuit developed by Wu-Tan Industries, trading some of the mobility for extra protection alongside the carrier plate. Has glow up strips on the shoulders to prevent frendly fire in dark enviroments.
   components:
   - type: Sprite
     sprite: _Crescent/Clothing/SHI/OuterClothing/combine.rsi
@@ -57,24 +59,27 @@
     equipSound: /Audio/_Crescent/Items/Clothing/CombineSuit/puton.ogg
     unequipSound: /Audio/_Crescent/Items/Clothing/CombineSuit/takeoff.ogg
     sprite: _Crescent/Clothing/SHI/OuterClothing/combine.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 1000 # armor stats same as CMM patrol suit
-    armorType: Metallic
-    armorRepair: PlasteelPlate
-    initialModifiers:
-      flatReductions:
-        Blunt: 20
-        Slash: 20
-        Piercing: 60
-        Heat: 15
-        Caustic: 15
+  - type: Armor #again, changed from degradeable armor to fit with the armor instert system, just make sure to take a look at the values to make sure they seem balanced.
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Heat: 0.6
+        Cold: 0.6
+        Caustic: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
+    walkModifier: 0.85 #speed should be changed, this should be either on the same level as SBVT-2 or slower.
     sprintModifier: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombine

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -340,6 +340,15 @@
     BallisticCycler: 1000
 
 - type: latheRecipe
+  Id: PorodschokDonator
+  Result: PorodschokDonator
+  Completetime: 2
+  Materials:
+    Steel: 1500
+    Plasteel: 500
+    BallisticCycler: 1000
+
+- type: latheRecipe
   id: WeaponSniperNCWLNovomosin
   result: WeaponSniperNCWLNovomosin
   completetime: 2

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -423,6 +423,15 @@
     BasicMechatronics: 500
 
 - type: latheRecipe
+  id: WeaponDonorRevolverMadrugad
+  result: WeaponDonorRevolverMadrugad
+  completetime: 2
+  materials:
+    Steel: 1000
+    Silver: 300
+    BasicMechatronics: 500 #placeholder, if you are going to use something sepcific, I would recommend gold and wood as it contains both in the sprite.
+
+- type: latheRecipe
   id: WeaponSubMachineGunBeetle
   result: WeaponSubMachineGunBeetle
   completetime: 2

--- a/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/shinohara.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Recipes/Lathes/shinohara.yml
@@ -148,7 +148,7 @@
   materials:
     Durathread: 2000
     Steel: 500
-    HardsuitElectronics: 500
+    HardsuitElectronics: 500 #recipe is probably going to need a change
 
 - type: latheRecipe
   id: ClothingOuterHardsuitCombine
@@ -157,7 +157,7 @@
   materials:
     Durathread: 4000
     Steel: 1000
-    HardsuitElectronics: 500
+    HardsuitElectronics: 500 #both this and the one above were the base crafting prices, tweak it as you see fit.
 
 - type: latheRecipe
   id: ClothingOuterHardsuitHighsec
@@ -506,6 +506,25 @@
     Silver: 500
     BallisticCycler: 500
 
+- type: latheRecipe
+  id: WeaponSpecialPulseRifle
+  result: WeaponSpecialPulseRifle
+  completetime: 2
+  materials:
+    Steel: 1500
+    Plastic: 500
+    Silver: 500
+    BallisticCycler: 500 #this is just a placeholder recpipe, I would recommend using advanced electronics for both this and the AMR
+
+- type: latheRecipe
+  id: WeaponSpecialPulseAMR
+  result: WeaponSpecialPulseAMR
+  completetime: 2
+  materials:
+    Steel: 1500
+    Plastic: 500
+    Silver: 500
+    BallisticCycler: 500
 # MARK: Mech Weapons
 
 # - type: latheRecipe

--- a/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Structures/lathe.yml
@@ -797,6 +797,7 @@
       - WeaponPlasmaRifleSeethe
       - WeaponSubMachineGunC20rImperial
       - WeaponPistolNeoVolker
+      - WeaponDonorRevolverMadrugad
       - ClothingBeltSheathKhopesh
       - SRMKhopesh
       - WeaponSubMachineGunBeetle
@@ -860,6 +861,7 @@
       - PsoglavLPC
       - ZorniyLPC
       - StraznikLPC
+      - PorodschokDonator
       - WeaponSubMachineGunBloodhound
       - WeaponSubMachineGunMilitant
       - WeaponRifleNCWLBatanya
@@ -911,8 +913,8 @@
       - ClothingOuterHardsuitHighsec
       - ClothingOuterHardsuitHighsecUA
       - ClothingOuterHardsuitHighsecIndependent
-      #- ClothingOuterHardsuitMetrocop
-      #- ClothingOuterHardsuitCombine
+      - ClothingOuterHardsuitMetrocop
+      - ClothingOuterHardsuitCombine
       - WeaponPistolBlastpopRed
       - WeaponPistolBlastpopPurple
       - WeaponPistolBlastpopGray
@@ -923,6 +925,7 @@
       - WeaponRifleHoundMarksman
       - WeaponShotgunBlaster
       - WeaponShotgunSHIDoubleBarreled4g
+      - WeaponPistolZodum
       - WeaponPistolMk58SHI
       - WeaponSubMachineGunMP49
       - WeaponSubMachineGunWt550Hullrot
@@ -956,6 +959,8 @@
       - WeaponSubMachineGunSabre
       - WeaponLightMachineGunL6
       - WeaponLauncherMilkor
+      - WeaponSpecialPulseAMR
+      - WeaponSpecialPulseRifle
       - GrenadeSHIHG17Smart
       - HG13M2MiniHandgrenade
       - SHIHG19SmartHandgrenadeEMP

--- a/Resources/Prototypes/_Crescent/Research/communard.yml
+++ b/Resources/Prototypes/_Crescent/Research/communard.yml
@@ -163,6 +163,7 @@
   - WeaponSniperMolot
   - WeaponLightMachineGunConscript
   - WeaponShotgunProletar
+  - PorodschokDonator
 
 # - type: technology
 #   id: CommunardLancer

--- a/Resources/Prototypes/_Crescent/Research/imperial.yml
+++ b/Resources/Prototypes/_Crescent/Research/imperial.yml
@@ -164,6 +164,7 @@
   - WeaponSubMachineGunBeetle
   - WeaponRifleHunter
   - WeaponShotgunDSMMatusa
+  - WeaponDonorRevolverMadrugad
 
 - type: technology
   id: ImperialCarrion

--- a/Resources/Prototypes/_Crescent/Research/shinohara.yml
+++ b/Resources/Prototypes/_Crescent/Research/shinohara.yml
@@ -118,6 +118,8 @@
   - ClothingOuterHardsuitHighsec
   - ClothingOuterHardsuitHighsecUA
   - ClothingOuterHardsuitHighsecIndependent
+  - ClothingOuterHardsuitMetrocop
+  - ClothingOuterHardsuitCombine
 
 - type: technology
   id: ShinoharaDisposableGuns
@@ -278,6 +280,7 @@
   recipeUnlocks:
   - WeaponPistolSmartpistolSHI
   - WeaponShotgunEnforcer
+  - WeaponPistolZodum
   - WeaponRifleLecterSHI
   - WeaponLightMachineGunL6
   - WeaponSniperHristov
@@ -477,6 +480,19 @@
   - WeaponShotgunSpas
   - WeaponRifleM90GrenadeLauncher
   - WeaponSubMachineGunWt550Hullrot
+
+- type: technology
+  id: ShinoharaNTPulseguns
+  name: research-technology-shinohara-pulseguns
+  icon:
+    sprite: _Crescent/Objects/Weapons/Guns/sr3.rsi
+    state: icon
+  discipline: Corporate
+  tier: 3
+  cost: 6000
+  recipeUnlocks:
+  - WeaponSpecialPulseRifle
+  - WeaponSpecialPulseAMR
 
 - type: technology
   id: ShinoharaWeaponCase


### PR DESCRIPTION
# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Some of the patreon weapons were kinda just left in the code, so I decided to move some into the research tree, and to be made craftable. Do note that this only includes the SHI combine stuff (both armor and guns), the NCWL Porodschok, and the DSM Madrugad (it's technically an SRM weapon, but it still makes sense that DSM can have it given their R&D tree).

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Add the SHI, NCWL and DSM patreon weapons to their respective R&Ds and lathe.
- [x] Updated the SHI patreon armor to match current balancing.
- [] add the other patreon weapons (like the CD and PTA ones).

# Changelog

:cl:
- tweak: SHI combine equipment is now researchable and craftable.
- tweak:  NCWL Porodschok is researchable and craftable.
- tweak: DSM Madrugad is now researchable and craftable.