### PR TITLE
Gives the export/independent SVBT-2 suit coefficients and plate slots

### DIFF
--- a/Resources/Prototypes/_Crescent/Entities/Clothing/corporate.yml
+++ b/Resources/Prototypes/_Crescent/Entities/Clothing/corporate.yml
@@ -237,7 +237,7 @@
   - type: GroupExamine
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, StreeCredRedeemableHigh]
+  parent: [ClothingOuterHardsuitBase, StreeCredRedeemableHigh, ClothingArmorInsertHardsuit]
   id: ClothingOuterHardsuitHighsecIndependent
   name: freelance SVBT-2 combat hardsuit
   description: A modular combat hardsuit developed by Shinohara Heavy Industries. Sold to elite mercs and corporate deathsquads everywhere. The internal IFF has been swapped from SHI standards, for safety reasons.
@@ -246,25 +246,29 @@
     sprite: _Crescent/Clothing/SHI/OuterClothing/corpsecinde.rsi
   - type: Clothing
     sprite: _Crescent/Clothing/SHI/OuterClothing/corpsecinde.rsi
+  - type: ExtendDescription
+    descriptionList:
+      - description: This is a carrier vest, it will only provide mediocre protection on its own. Put an armor insert into it to fully utilize it.
+        fontSize: 15
+        color: "#ff2106"
+        requireDetailRange: true
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: DegradeableArmor
-    armorMaxHealth: 900
-    armorType: Ceramic
-    armorRepair: NTCeramic
-    initialModifiers:
-      flatReductions:
-        Blunt: 25
-        Slash: 35
-        Piercing: 70
-        Heat: 15
-        Caustic: 15
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.75
+        Slash: 0.75
+        Heat: 0.7
+        Cold: 0.7
+        Caustic: 0.7
+        Radiation: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.85
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCorpsec
   - type: ReverseEngineering # SectorCrescent


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Suit has been practically unobtainium for a long while so this oversight wasn't really a problem, but now SHI will be able to produce its signature hardsuit for export so its about time this bad boy got set up properly (and by that I mean making it basically 1:1 with the SHI in-house version).

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added fun :D
- tweak: Tweaked fun
- fix: Fixed fun!
- remove: Removed fun :(
